### PR TITLE
Update installation of internet identity

### DIFF
--- a/dfx.json
+++ b/dfx.json
@@ -48,9 +48,9 @@
     },
     "internet_identity": {
       "type": "custom",
-      "candid": "internet_identity.did",
-      "wasm": "internet_identity.wasm",
-      "build": "./scripts/canisters/local_deploy/internet_identity.sh"
+      "candid": "https://github.com/dfinity/internet-identity/releases/latest/download/internet_identity.did",
+      "wasm": "https://github.com/dfinity/internet-identity/releases/latest/download/internet_identity_dev.wasm.gz",
+      "shrink": false
     }
   }
 }

--- a/scripts/canisters/local_deploy/internet_identity.sh
+++ b/scripts/canisters/local_deploy/internet_identity.sh
@@ -1,6 +1,0 @@
-#!/usr/bin/env bash
-set -euo pipefail
-
-# Download the Internet Identity canister's development wasm as well as its candid interface file. See dfx.json for details.
-curl -sSL https://github.com/dfinity/internet-identity/releases/latest/download/internet_identity_dev.wasm -o internet_identity.wasm
-curl -sSL https://github.com/dfinity/internet-identity/releases/latest/download/internet_identity.did -o internet_identity.did


### PR DESCRIPTION
Fixes internet identity installation. The installation script is not necessary now.