### PR TITLE
Migrate individual template data stage 2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -424,8 +424,10 @@ name = "individual_user_template"
 version = "0.1.0"
 dependencies = [
  "candid",
+ "ciborium",
  "ic-cdk",
  "ic-cdk-timers",
+ "ic-stable-structures",
  "serde",
  "shared_utils",
  "test_utils",

--- a/default.nix
+++ b/default.nix
@@ -8,9 +8,4 @@ in
 dfx-env.overrideAttrs (old: {
   nativeBuildInputs = with pkgs; old.nativeBuildInputs ++
     [ rustup pkg-config openssl protobuf cmake cachix killall jq coreutils bc python3Full ];
-
-  # shellHook = ''
-  #   rustup toolchain install stable
-  #   rustup target add wasm32-unknown-unknown
-  # '';
 })

--- a/notes/hot_or_not.md
+++ b/notes/hot_or_not.md
@@ -43,3 +43,21 @@
       UserClient -- talk to own <br> and others' canisters --> IndividualUserCanister
     end
 ```
+
+# Proposed Changes
+
+- Have a configuration canister that pushes changes downstream on every subnet
+- Test serializing entire canister contents and then sending it elsewhere to be reinitialized on a different subnet or archived off chain
+- Embrace stable memory to eliminate the cost of upgrades
+- Embrace subnet ownership to eliminate the cost of new canister creation
+- Canister recycling
+  - Track user sessions
+  - Reclaim if beyond threshold
+  - Figure out what to do with the data.
+
+## Scaling
+
+- Subnet splitting
+- Manual sharding
+  - On chain
+  - Off chain

--- a/notes/notes.md
+++ b/notes/notes.md
@@ -1,1 +1,24 @@
 # Notes
+
+## Upgrade on
+
+### User Index
+
+- Starting at 9857
+- Ending at 9789
+
+### Difference
+
+68
+
+# Daily change since 2023-09-29
+
+- 29th to 30th - 18
+- 30th to 31st - 22
+- 31st to 1st - 28
+- 1st to 2nd - 27
+- 2nd to 3rd - 24
+- 3rd to 4th - 25
+- 4th to 5th - 275
+- 5th to 6th - 171
+- 6th to 7th - (91)

--- a/src/canister/individual_user_template/Cargo.toml
+++ b/src/canister/individual_user_template/Cargo.toml
@@ -10,6 +10,8 @@ crate-type = ["cdylib"]
 
 [dependencies]
 candid = { workspace = true }
+ciborium = { workspace = true }
+ic-stable-structures = {workspace = true }
 ic-cdk = { workspace = true }
 ic-cdk-timers = { workspace = true }
 serde = { workspace = true }

--- a/src/canister/individual_user_template/src/api/canister_lifecycle/post_upgrade.rs
+++ b/src/canister/individual_user_template/src/api/canister_lifecycle/post_upgrade.rs
@@ -1,20 +1,19 @@
 use std::time::Duration;
+use ciborium::de;
+use ic_stable_structures::Memory;
 
-use shared_utils::{
-    canister_specific::individual_user_template::types::arg::IndividualUserTemplateInitArgs,
-    common::utils::stable_memory_serializer_deserializer,
-};
+use crate::data_model::memory;
+
+use shared_utils::canister_specific::individual_user_template::types::arg::IndividualUserTemplateInitArgs;
 
 use crate::{
     api::{
         hot_or_not_bet::reenqueue_timers_for_pending_bet_outcomes::reenqueue_timers_for_pending_bet_outcomes,
         well_known_principal::update_locally_stored_well_known_principals,
     },
-    data_model::CanisterData,
     CANISTER_DATA,
 };
 
-use super::{init::send_canister_metrics, pre_upgrade::BUFFER_SIZE_BYTES};
 
 #[ic_cdk::post_upgrade]
 fn post_upgrade() {
@@ -22,22 +21,22 @@ fn post_upgrade() {
     save_upgrade_args_to_memory();
     refetch_well_known_principals();
     reenqueue_timers_for_pending_bet_outcomes();
-    send_canister_metrics();
 }
 
 fn restore_data_from_stable_memory() {
-    match stable_memory_serializer_deserializer::deserialize_from_stable_memory::<CanisterData>(
-        BUFFER_SIZE_BYTES,
-    ) {
-        Ok(canister_data) => {
-            CANISTER_DATA.with(|canister_data_ref_cell| {
-                *canister_data_ref_cell.borrow_mut() = canister_data;
-            });
-        }
-        Err(e) => {
-            panic!("Error: {:?}", e);
-        }
-    }
+    let heap_data = memory::get_upgrades_memory();
+    let mut heap_data_len_bytes = [0; 4];
+    heap_data.read(0, &mut heap_data_len_bytes);
+    let heap_data_len = u32::from_le_bytes(heap_data_len_bytes) as usize;
+
+    let mut canister_data_bytes = vec![0; heap_data_len];
+    heap_data.read(4, &mut canister_data_bytes);
+    
+
+    let canister_data = de::from_reader(&*canister_data_bytes).expect("Failed to deserialize heap data");
+    CANISTER_DATA.with(|canister_data_ref_cell| {
+        *canister_data_ref_cell.borrow_mut() = canister_data;
+    });
 }
 
 fn save_upgrade_args_to_memory() {

--- a/src/canister/individual_user_template/src/api/canister_lifecycle/pre_upgrade.rs
+++ b/src/canister/individual_user_template/src/api/canister_lifecycle/pre_upgrade.rs
@@ -1,17 +1,22 @@
-use shared_utils::common::utils::stable_memory_serializer_deserializer;
+use ciborium::ser;
+use ic_stable_structures::writer::Writer;
 
+use crate::data_model::memory;
 use crate::CANISTER_DATA;
 
 pub const BUFFER_SIZE_BYTES: usize = 2 * 1024 * 1024; // 2 MiB
 
 #[ic_cdk::pre_upgrade]
 fn pre_upgrade() {
+    let mut state_bytes = vec![];
     CANISTER_DATA.with(|canister_data_ref_cell| {
-        let canister_data = canister_data_ref_cell.take();
-        stable_memory_serializer_deserializer::serialize_to_stable_memory(
-            canister_data,
-            BUFFER_SIZE_BYTES,
-        )
-        .expect("Failed to serialize canister data");
-    });
+        ser::into_writer(&*canister_data_ref_cell.borrow(), &mut state_bytes)
+    })
+    .expect("failed to encode state");
+
+    let len = state_bytes.len() as u32;
+    let mut memory = memory::get_upgrades_memory();
+    let mut writer = Writer::new(&mut memory, 0);
+    writer.write(&len.to_le_bytes()).unwrap();
+    writer.write(&state_bytes).unwrap();
 }

--- a/src/canister/individual_user_template/src/api/canister_lifecycle/pre_upgrade.rs
+++ b/src/canister/individual_user_template/src/api/canister_lifecycle/pre_upgrade.rs
@@ -4,7 +4,6 @@ use ic_stable_structures::writer::Writer;
 use crate::data_model::memory;
 use crate::CANISTER_DATA;
 
-pub const BUFFER_SIZE_BYTES: usize = 2 * 1024 * 1024; // 2 MiB
 
 #[ic_cdk::pre_upgrade]
 fn pre_upgrade() {

--- a/src/canister/individual_user_template/src/data_model/memory.rs
+++ b/src/canister/individual_user_template/src/data_model/memory.rs
@@ -1,0 +1,22 @@
+use ic_stable_structures::{DefaultMemoryImpl, memory_manager::{MemoryId, VirtualMemory, MemoryManager}};
+use std::cell::RefCell;
+
+// A memory for upgrades, where data from the heap can be serialized/deserialized.
+const UPGRADES: MemoryId = MemoryId::new(0);
+
+// A memory for the StableBTreeMap we're using. A new memory should be created for
+// every additional stable structure.
+
+
+pub type Memory = VirtualMemory<DefaultMemoryImpl>;
+
+thread_local! {
+    // The memory manager is used for simulating multiple memories. Given a `MemoryId` it can
+    // return a memory that can be used by stable structures.
+    static MEMORY_MANAGER: RefCell<MemoryManager<DefaultMemoryImpl>> =
+        RefCell::new(MemoryManager::init(DefaultMemoryImpl::default()));
+}
+
+pub fn get_upgrades_memory() -> Memory {
+    MEMORY_MANAGER.with(|m| m.borrow_mut().get(UPGRADES))
+}

--- a/src/canister/individual_user_template/src/data_model/mod.rs
+++ b/src/canister/individual_user_template/src/data_model/mod.rs
@@ -17,6 +17,7 @@ use shared_utils::{
 use self::version_details::VersionDetails;
 
 pub mod version_details;
+pub mod memory;
 
 #[derive(Default, Deserialize, Serialize)]
 pub struct CanisterData {

--- a/src/canister/user_index/src/api/canister_lifecycle/post_upgrade.rs
+++ b/src/canister/user_index/src/api/canister_lifecycle/post_upgrade.rs
@@ -26,8 +26,9 @@ fn post_upgrade() {
             known_principal_ids: well_known_principals,
             signups_open_on_this_subnet: false,
             url_to_send_canister_metrics_to:
-                "https://receive-canister-metrics-and-push-to-timeseries-d-74gsa5ifla-uc.a.run.app/receive-metrics"
-                    .to_string(),
+                // "https://amused-welcome-anemone.ngrok-free.app/receive-metrics".to_string(),
+            "https://receive-canister-metrics-and-push-to-timeseries-d-74gsa5ifla-uc.a.run.app/receive-metrics"
+                .to_string(),
         };
     });
 }

--- a/src/lib/integration_tests/tests/cycle_management/when_canister_cycle_balance_is_below_the_configured_or_freezing_threshold_then_running_topup_function_in_user_index_canister_tops_up_the_canisters_that_need_it.rs
+++ b/src/lib/integration_tests/tests/cycle_management/when_canister_cycle_balance_is_below_the_configured_or_freezing_threshold_then_running_topup_function_in_user_index_canister_tops_up_the_canisters_that_need_it.rs
@@ -62,7 +62,7 @@ fn when_canister_cycle_balance_is_below_the_configured_or_freezing_threshold_the
             alice_canister_id,
             *user_index_canister_id,
             "return_cycles_to_user_index_canister",
-            candid::encode_one(Some(1_000_000_000_000_u128)).unwrap(),
+            candid::encode_one(Some(600_000_000_000_u128)).unwrap(),
         )
         .unwrap();
 
@@ -125,5 +125,5 @@ fn when_canister_cycle_balance_is_below_the_configured_or_freezing_threshold_the
         alice_cycle_balance_after_user_index_upgrade
     );
 
-    assert!(alice_cycle_balance_after_user_index_upgrade >= 1_000_000_000_000);
+    assert!(alice_cycle_balance_after_user_index_upgrade >= 600_000_000_000);
 }

--- a/src/lib/shared_utils/src/common/timer/send_metrics.rs
+++ b/src/lib/shared_utils/src/common/timer/send_metrics.rs
@@ -11,8 +11,9 @@ use serde::Serialize;
 
 use crate::common::utils::system_time;
 
-// Send metrics every hour
-const PING_INTERVAL_FOR_CALLING_METRICS_REST_API: Duration = Duration::from_secs(60 * 60);
+// Send metrics every 6 hours
+const PING_INTERVAL_FOR_CALLING_METRICS_REST_API: Duration = Duration::from_secs(60 * 60 * 6);
+// const PING_INTERVAL_FOR_CALLING_METRICS_REST_API: Duration = Duration::from_secs(60);
 const CYCLES_TO_SEND_ALONG_WITH_EVERY_REQUEST: u128 = 1_000_000_000;
 
 pub fn enqueue_timer_for_calling_metrics_rest_api(url_to_ping: String) {

--- a/src/lib/shared_utils/src/constant.rs
+++ b/src/lib/shared_utils/src/constant.rs
@@ -2,7 +2,7 @@ use candid::Principal;
 
 use crate::common::types::known_principal::{KnownPrincipalMap, KnownPrincipalType};
 
-pub const INDIVIDUAL_USER_CANISTER_RECHARGE_AMOUNT: u128 = 1_000_000_000_000; // 1T Cycles
+pub const INDIVIDUAL_USER_CANISTER_RECHARGE_AMOUNT: u128 = 600_000_000_000; // 0.6T Cycles
 pub const CYCLES_THRESHOLD_TO_INITIATE_RECHARGE: u128 = 500_000_000_000; // 0.5T Cycles
 
 pub const MAX_USERS_IN_FOLLOWER_FOLLOWING_LIST: u64 = 10000;


### PR DESCRIPTION
## Changes
- update `post_upgrade` hook to take use of memory manager.
- remove sending matrices in `post_upgrade`