### PR TITLE
Drop stable memory from individual user canisters

### DIFF
--- a/src/canister/individual_user_template/src/api/canister_lifecycle/pre_upgrade.rs
+++ b/src/canister/individual_user_template/src/api/canister_lifecycle/pre_upgrade.rs
@@ -1,4 +1,5 @@
 use ciborium::ser;
+use ic_stable_structures::Memory;
 use ic_stable_structures::writer::Writer;
 
 use crate::data_model::memory;
@@ -15,6 +16,9 @@ fn pre_upgrade() {
 
     let len = state_bytes.len() as u32;
     let mut memory = memory::get_upgrades_memory();
+    if memory.size() == 0 {
+        memory::init_memory_manager()
+    }
     let mut writer = Writer::new(&mut memory, 0);
     writer.write(&len.to_le_bytes()).unwrap();
     writer.write(&state_bytes).unwrap();

--- a/src/canister/individual_user_template/src/api/canister_lifecycle/pre_upgrade.rs
+++ b/src/canister/individual_user_template/src/api/canister_lifecycle/pre_upgrade.rs
@@ -1,5 +1,5 @@
 use ciborium::ser;
-use ic_stable_structures::Memory;
+use ic_cdk::api::stable;
 use ic_stable_structures::writer::Writer;
 
 use crate::data_model::memory;
@@ -15,11 +15,12 @@ fn pre_upgrade() {
     .expect("failed to encode state");
 
     let len = state_bytes.len() as u32;
-    let mut memory = memory::get_upgrades_memory();
-    if memory.size() == 0 {
-        memory::init_memory_manager()
+    
+    if stable::stable_size() == 0 {
+        memory::init_memory_manager();
     }
-    let mut writer = Writer::new(&mut memory, 0);
+    let mut upgrade_memory = memory::get_upgrades_memory();
+    let mut writer = Writer::new(&mut upgrade_memory, 0);
     writer.write(&len.to_le_bytes()).unwrap();
     writer.write(&state_bytes).unwrap();
 }

--- a/src/canister/individual_user_template/src/data_model/memory.rs
+++ b/src/canister/individual_user_template/src/data_model/memory.rs
@@ -18,5 +18,12 @@ thread_local! {
 }
 
 pub fn get_upgrades_memory() -> Memory {
+    init_memory_manager();
     MEMORY_MANAGER.with(|m| m.borrow_mut().get(UPGRADES))
+}
+
+fn init_memory_manager() {
+    MEMORY_MANAGER.with(|m| {
+        *m.borrow_mut() = MemoryManager::init_with_bucket_size(DefaultMemoryImpl::default(), 1);
+    })
 }

--- a/src/canister/individual_user_template/src/data_model/memory.rs
+++ b/src/canister/individual_user_template/src/data_model/memory.rs
@@ -18,11 +18,10 @@ thread_local! {
 }
 
 pub fn get_upgrades_memory() -> Memory {
-    init_memory_manager();
     MEMORY_MANAGER.with(|m| m.borrow_mut().get(UPGRADES))
 }
 
-fn init_memory_manager() {
+pub fn init_memory_manager() {
     MEMORY_MANAGER.with(|m| {
         *m.borrow_mut() = MemoryManager::init_with_bucket_size(DefaultMemoryImpl::default(), 1);
     })

--- a/src/canister/user_index/can.did
+++ b/src/canister/user_index/can.did
@@ -65,5 +65,6 @@ service : (UserIndexInitArgs) -> {
       principal,
       principal,
       opt CanisterInstallMode,
+      bool,
     ) -> (text);
 }

--- a/src/canister/user_index/src/api/upgrade_individual_user_template/update_user_index_upgrade_user_canisters_with_latest_wasm.rs
+++ b/src/canister/user_index/src/api/upgrade_individual_user_template/update_user_index_upgrade_user_canisters_with_latest_wasm.rs
@@ -149,7 +149,7 @@ async fn upgrade_user_canister(
                 configuration.url_to_send_canister_metrics_to.clone(),
             ),
         },
-        true
+        false
     )
     .await
     .map_err(|e| e.1)

--- a/src/canister/user_index/src/api/upgrade_individual_user_template/update_user_index_upgrade_user_canisters_with_latest_wasm.rs
+++ b/src/canister/user_index/src/api/upgrade_individual_user_template/update_user_index_upgrade_user_canisters_with_latest_wasm.rs
@@ -149,6 +149,7 @@ async fn upgrade_user_canister(
                 configuration.url_to_send_canister_metrics_to.clone(),
             ),
         },
+        true
     )
     .await
     .map_err(|e| e.1)

--- a/src/canister/user_index/src/api/upgrade_individual_user_template/upgrade_specific_individual_user_canister_with_latest_wasm.rs
+++ b/src/canister/user_index/src/api/upgrade_individual_user_template/upgrade_specific_individual_user_canister_with_latest_wasm.rs
@@ -15,6 +15,7 @@ async fn upgrade_specific_individual_user_canister_with_latest_wasm(
     user_principal_id: Principal,
     user_canister_id: Principal,
     upgrade_mode: Option<CanisterInstallMode>,
+    unsafe_drop_stable_memory: bool
 ) -> String {
     let api_caller = ic_cdk::caller();
 
@@ -50,6 +51,7 @@ async fn upgrade_specific_individual_user_canister_with_latest_wasm(
             upgrade_version_number: Some(saved_upgrade_status.version_number + 1),
             url_to_send_canister_metrics_to: Some(configuration.url_to_send_canister_metrics_to),
         },
+        unsafe_drop_stable_memory
     )
     .await
     {

--- a/src/canister/user_index/src/util/canister_management.rs
+++ b/src/canister/user_index/src/util/canister_management.rs
@@ -1,12 +1,13 @@
-use candid::Principal;
+use candid::{Principal, CandidType};
 use ic_cdk::api::{
     self,
-    call::RejectionCode,
+    call::{RejectionCode, CallResult},
     management_canister::{
-        main::{self, CanisterInstallMode, CreateCanisterArgument, InstallCodeArgument},
+        main::{self, CanisterInstallMode, CreateCanisterArgument, WasmModule},
         provisional::CanisterSettings,
-    },
+    }, canister_version,
 };
+use serde::{Serialize, Deserialize};
 use shared_utils::{
     canister_specific::individual_user_template::types::arg::IndividualUserTemplateInitArgs,
     constant::INDIVIDUAL_USER_CANISTER_RECHARGE_AMOUNT,
@@ -17,6 +18,22 @@ use crate::CANISTER_DATA;
 const INDIVIDUAL_USER_TEMPLATE_CANISTER_WASM: &[u8] = include_bytes!(
     "../../../../../target/wasm32-unknown-unknown/release/individual_user_template.wasm.gz"
 );
+
+#[derive( CandidType, Serialize, Deserialize, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Clone)]
+struct InstallCodeArgument {
+    /// See [CanisterInstallMode].
+    pub mode: CanisterInstallMode,
+    /// Principle of the canister.
+    pub canister_id: Principal,
+    /// Code to be installed.
+    pub wasm_module: WasmModule,
+    /// The argument to be passed to `canister_init` or `canister_post_upgrade`.
+    pub arg: Vec<u8>,
+    /// sender_canister_version must be set to ic_cdk::api::canister_version()
+    pub sender_canister_version: Option<u64>,
+    /// drop stable memory after install/upgrade execution.
+    pub unsafe_drop_stable_memory: Option<bool>,
+}
 
 pub async fn create_users_canister(profile_owner: Principal) -> Principal {
     // * config for provisioning canister
@@ -57,14 +74,15 @@ pub async fn create_users_canister(profile_owner: Principal) -> Principal {
         .expect("Failed to serialize the install argument.");
 
     // * install wasm to provisioned canister
-    main::install_code(InstallCodeArgument {
+    let install_args = InstallCodeArgument {
         mode: CanisterInstallMode::Install,
         canister_id,
+        sender_canister_version: Some(canister_version()),
         wasm_module: INDIVIDUAL_USER_TEMPLATE_CANISTER_WASM.into(),
         arg,
-    })
-    .await
-    .unwrap();
+        unsafe_drop_stable_memory: Some(false),
+    };
+    let _result: CallResult<()>  = api::call::call(Principal::management_canister(), "install_code", (install_args,)).await;
 
     canister_id
 }
@@ -73,15 +91,19 @@ pub async fn upgrade_individual_user_canister(
     canister_id: Principal,
     install_mode: CanisterInstallMode,
     arg: IndividualUserTemplateInitArgs,
+    unsafe_drop_stable_memory: bool
 ) -> Result<(), (RejectionCode, String)> {
     let serialized_arg =
         candid::encode_args((arg,)).expect("Failed to serialize the install argument.");
 
-    main::install_code(InstallCodeArgument {
-        mode: install_mode,
-        canister_id,
-        wasm_module: INDIVIDUAL_USER_TEMPLATE_CANISTER_WASM.into(),
-        arg: serialized_arg,
-    })
-    .await
+        let upgrade_args = InstallCodeArgument {
+            mode: install_mode,
+            canister_id,
+            wasm_module: INDIVIDUAL_USER_TEMPLATE_CANISTER_WASM.into(),
+            sender_canister_version: Some(canister_version()),
+            arg: serialized_arg,
+            unsafe_drop_stable_memory: Some(unsafe_drop_stable_memory)
+        };
+
+    api::call::call(Principal::management_canister(), "install_code", (upgrade_args, )).await    
 }

--- a/src/lib/integration_tests/tests/backup_and_restore/when_restoring_all_data_to_an_individual_user_canister_after_backing_up_data_to_backup_canister_and_reinitializing_canister_then_data_restored_successfully_to_individual_user_canister.rs
+++ b/src/lib/integration_tests/tests/backup_and_restore/when_restoring_all_data_to_an_individual_user_canister_after_backing_up_data_to_backup_canister_and_reinitializing_canister_then_data_restored_successfully_to_individual_user_canister.rs
@@ -352,6 +352,7 @@ fn when_restoring_all_data_to_an_individual_user_canister_after_backing_up_data_
                 get_mock_user_alice_principal_id(),
                 alice_canister_id,
                 Some(CanisterInstallMode::Reinstall),
+                true,
             ))
             .unwrap(),
         )


### PR DESCRIPTION
## Changes
- add a flag to drop stable memory for the method `upgrade_sepecific_individual_user_canister_with_latest_wasm`

- While running upgrade for user_index set the `unsafe_drop_stable memory: true`. This will drop all the stable memory from individual canisters (This will not execute for now as we have commented out the code to upgrade all individual user_template canister)

- Update the tests accordingly.
