### PR TITLE
Feat/add user canister status apis

### DIFF
--- a/src/canister/individual_user_template/can.did
+++ b/src/canister/individual_user_template/can.did
@@ -294,6 +294,7 @@ service : (IndividualUserTemplateInitArgs) -> {
   get_profile_details : () -> (UserProfileDetailsForFrontend) query;
   get_rewarded_for_referral : (principal, principal) -> ();
   get_rewarded_for_signing_up : () -> ();
+  get_stable_memory_size : () -> (nat32) query;
   get_user_caniser_cycle_balance : () -> (nat) query;
   get_user_utility_token_transaction_history_with_pagination : (
       nat64,

--- a/src/canister/individual_user_template/src/api/canister_management/mod.rs
+++ b/src/canister/individual_user_template/src/api/canister_management/mod.rs
@@ -1,0 +1,7 @@
+use ic_cdk::api::stable::stable_size;
+
+#[candid::candid_method(query)]
+#[ic_cdk::query]
+pub fn get_stable_memory_size() -> u32 {
+    stable_size()
+}

--- a/src/canister/individual_user_template/src/api/mod.rs
+++ b/src/canister/individual_user_template/src/api/mod.rs
@@ -7,3 +7,4 @@ pub mod post;
 pub mod profile;
 pub mod token;
 pub mod well_known_principal;
+pub mod canister_management;

--- a/src/canister/user_index/can.did
+++ b/src/canister/user_index/can.did
@@ -1,4 +1,19 @@
 type CanisterInstallMode = variant { reinstall; upgrade; install };
+type CanisterStatusResponse = record {
+  status : CanisterStatusType;
+  memory_size : nat;
+  cycles : nat;
+  settings : DefiniteCanisterSettings;
+  idle_cycles_burned_per_day : nat;
+  module_hash : opt vec nat8;
+};
+type CanisterStatusType = variant { stopped; stopping; running };
+type DefiniteCanisterSettings = record {
+  freezing_threshold : nat;
+  controllers : vec principal;
+  memory_allocation : nat;
+  compute_allocation : nat;
+};
 type KnownPrincipalType = variant {
   CanisterIdUserIndex;
   CanisterIdConfiguration;
@@ -10,7 +25,20 @@ type KnownPrincipalType = variant {
   CanisterIdSNSController;
   UserIdGlobalSuperAdmin;
 };
-type Result = variant { Ok; Err : SetUniqueUsernameError };
+type RejectionCode = variant {
+  NoError;
+  CanisterError;
+  SysTransient;
+  DestinationInvalid;
+  Unknown;
+  SysFatal;
+  CanisterReject;
+};
+type Result = variant {
+  Ok : record { CanisterStatusResponse };
+  Err : record { RejectionCode; text };
+};
+type Result_1 = variant { Ok; Err : SetUniqueUsernameError };
 type SetUniqueUsernameError = variant {
   UsernameAlreadyTaken;
   SendingCanisterDoesNotMatchUserCanisterId;
@@ -47,6 +75,7 @@ service : (UserIndexInitArgs) -> {
   get_user_canister_id_from_user_principal_id : (principal) -> (
       opt principal,
     ) query;
+  get_user_canister_status : (principal) -> (Result);
   get_user_index_canister_count : () -> (nat64) query;
   get_user_index_canister_cycle_balance : () -> (nat) query;
   get_well_known_principal_value : (KnownPrincipalType) -> (
@@ -60,7 +89,7 @@ service : (UserIndexInitArgs) -> {
   update_index_with_unique_user_name_corresponding_to_user_principal_id : (
       text,
       principal,
-    ) -> (Result);
+    ) -> (Result_1);
   upgrade_specific_individual_user_canister_with_latest_wasm : (
       principal,
       principal,

--- a/src/canister/user_index/src/api/canister_management/mod.rs
+++ b/src/canister/user_index/src/api/canister_management/mod.rs
@@ -1,0 +1,10 @@
+use ic_cdk::api::{management_canister::{main::{canister_status, CanisterStatusResponse}, provisional::CanisterIdRecord}, call::CallResult};
+use candid::Principal;
+
+
+
+#[candid::candid_method(update)]
+#[ic_cdk::update]
+pub async fn get_user_canister_status(canister_id: Principal) -> CallResult<(CanisterStatusResponse,)>{
+    canister_status(CanisterIdRecord {canister_id}).await
+}

--- a/src/canister/user_index/src/api/mod.rs
+++ b/src/canister/user_index/src/api/mod.rs
@@ -4,3 +4,4 @@ pub mod cycle_management;
 pub mod upgrade_individual_user_template;
 pub mod user_record;
 pub mod well_known_principal;
+pub mod canister_management;

--- a/src/canister/user_index/src/lib.rs
+++ b/src/canister/user_index/src/lib.rs
@@ -2,7 +2,7 @@ use std::cell::RefCell;
 
 use candid::{export_service, Principal};
 use data_model::{canister_upgrade::UpgradeStatus, CanisterData};
-use ic_cdk::api::management_canister::main::CanisterInstallMode;
+use ic_cdk::api::{management_canister::main::{CanisterInstallMode, CanisterStatusResponse}, call::CallResult};
 use shared_utils::{
     canister_specific::user_index::types::args::UserIndexInitArgs,
     common::types::known_principal::KnownPrincipalType,


### PR DESCRIPTION
## Changes

- added `get_stable_memory_size` in `individual_user_template` canister
- added `get_user_canister_status` in `user_index` canister