### PR TITLE
Feat/upgrade fleet of canister using streaming futures

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -229,9 +229,9 @@ checksum = "88bffebc5d80432c9b140ee17875ff173a8ab62faad5b257da912bd2f6c1c0a1"
 
 [[package]]
 name = "futures"
-version = "0.3.28"
+version = "0.3.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23342abe12aba583913b2e62f22225ff9c950774065e4bfb61a19cd9770fec40"
+checksum = "da0290714b38af9b4a7b094b8a37086d1b4e61f2df9122c3cad2577669145335"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -244,9 +244,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.28"
+version = "0.3.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "955518d47e09b25bbebc7a18df10b81f0c766eaf4c4f1cccef2fca5f2a4fb5f2"
+checksum = "ff4dd66668b557604244583e3e1e1eada8c5c2e96a6d0d6653ede395b78bbacb"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -254,15 +254,15 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.28"
+version = "0.3.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4bca583b7e26f571124fe5b7561d49cb2868d79116cfa0eefce955557c6fee8c"
+checksum = "eb1d22c66e66d9d72e1758f0bd7d4fd0bee04cad842ee34587d68c07e45d088c"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.28"
+version = "0.3.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ccecee823288125bd88b4d7f565c9e58e41858e47ab72e8ea2d64e93624386e0"
+checksum = "0f4fb8693db0cf099eadcca0efe2a5a22e4550f98ed16aba6c48700da29597bc"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -271,15 +271,15 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.28"
+version = "0.3.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fff74096e71ed47f8e023204cfd0aa1289cd54ae5430a9523be060cdb849964"
+checksum = "8bf34a163b5c4c52d0478a4d757da8fb65cabef42ba90515efee0f6f9fa45aaa"
 
 [[package]]
 name = "futures-macro"
-version = "0.3.28"
+version = "0.3.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89ca545a94061b6365f2c7355b4b32bd20df3ff95f02da9329b34ccc3bd6ee72"
+checksum = "53b153fd91e4b0147f4aced87be237c98248656bb01050b96bf3ee89220a8ddb"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -288,21 +288,21 @@ dependencies = [
 
 [[package]]
 name = "futures-sink"
-version = "0.3.28"
+version = "0.3.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f43be4fe21a13b9781a69afa4985b0f6ee0e1afab2c6f454a8cf30e2b2237b6e"
+checksum = "e36d3378ee38c2a36ad710c5d30c2911d752cb941c00c72dbabfb786a7970817"
 
 [[package]]
 name = "futures-task"
-version = "0.3.28"
+version = "0.3.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76d3d132be6c0e6aa1534069c705a74a5997a356c0dc2f86a47765e5617c5b65"
+checksum = "efd193069b0ddadc69c46389b740bbccdd97203899b48d09c5f7969591d6bae2"
 
 [[package]]
 name = "futures-util"
-version = "0.3.28"
+version = "0.3.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26b01e40b772d54cf6c6d721c1d1abd0647a0106a12ecaa1c186273392a69533"
+checksum = "a19526d624e703a3179b3d322efec918b6246ea0fa51d41124525f00f1cc8104"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -458,9 +458,9 @@ checksum = "884e2677b40cc8c339eaefcb701c32ef1fd2493d71118dc0ca4b6a736c93bd67"
 
 [[package]]
 name = "libc"
-version = "0.2.147"
+version = "0.2.151"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4668fb0ea861c1df094127ac5f1da3409a82116a4ba74fca2e58ef927159bb3"
+checksum = "302d7ab3130588088d277783b1e2d2e10c9e9e4a16dd9050e6ec93fb3e7048f4"
 
 [[package]]
 name = "memchr"
@@ -534,9 +534,9 @@ checksum = "9f746c4065a8fa3fe23974dd82f15431cc8d40779821001404d10d2e79ca7d79"
 
 [[package]]
 name = "pin-project-lite"
-version = "0.2.9"
+version = "0.2.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0a7ae3ac2f1173085d398531c705756c94a4c56843785df85a60c1a0afac116"
+checksum = "8afb450f006bf6385ca15ef45d71d2288452bc3683ce2e2cacc0d18e4be60b58"
 
 [[package]]
 name = "pin-utils"
@@ -840,6 +840,7 @@ name = "user_index"
 version = "0.1.0"
 dependencies = [
  "candid",
+ "futures",
  "ic-cdk",
  "ic-cdk-timers",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,5 +21,6 @@ ic-stable-structures = "0.5.6"
 ic-test-state-machine-client = "3.0.0"
 rmp-serde = "1.1.2"
 serde = "1.0.186"
+futures = "0.3.29"
 shared_utils = { path = "./src/lib/shared_utils" }
 test_utils = { path = "./src/lib/test_utils" }

--- a/src/canister/user_index/Cargo.toml
+++ b/src/canister/user_index/Cargo.toml
@@ -14,6 +14,7 @@ ic-cdk = { workspace = true }
 ic-cdk-timers = { workspace = true }
 shared_utils = { workspace = true }
 serde = { workspace = true }
+futures = { workspace = true }
 
 [dev-dependencies]
 test_utils = { workspace = true }

--- a/src/canister/user_index/src/api/canister_lifecycle/post_upgrade.rs
+++ b/src/canister/user_index/src/api/canister_lifecycle/post_upgrade.rs
@@ -17,7 +17,7 @@ use super::pre_upgrade::BUFFER_SIZE_BYTES;
 fn post_upgrade() {
     restore_data_from_stable_memory();
     refetch_well_known_principals();
-    // upgrade_all_indexed_user_canisters();
+    upgrade_all_indexed_user_canisters();
 
     CANISTER_DATA.with(|canister_data_ref_cell| {
         let well_known_principals = canister_data_ref_cell.borrow().known_principal_ids.clone();

--- a/src/canister/user_index/src/api/upgrade_individual_user_template/update_user_index_upgrade_user_canisters_with_latest_wasm.rs
+++ b/src/canister/user_index/src/api/upgrade_individual_user_template/update_user_index_upgrade_user_canisters_with_latest_wasm.rs
@@ -182,7 +182,7 @@ async fn upgrade_user_canister(
                 configuration.url_to_send_canister_metrics_to.clone(),
             ),
         },
-        false
+        true
     )
     .await
     .map_err(|e| e.1)

--- a/src/canister/user_index/src/util/canister_management.rs
+++ b/src/canister/user_index/src/util/canister_management.rs
@@ -93,15 +93,6 @@ pub async fn upgrade_individual_user_canister(
     unsafe_drop_stable_memory: bool
 ) -> Result<(), (RejectionCode, String)> {
     stop_canister(CanisterIdRecord {canister_id: canister_id.clone()}).await?;
-    loop {
-        let (canister_status, ) = canister_status(CanisterIdRecord {canister_id: canister_id.clone()}).await.unwrap();
-        match canister_status.status {
-            CanisterStatusType::Stopped => break,
-            _ => ic_cdk::println!("Canister {:?} is stopping", &canister_id)
-        }
-    }        
-        
-
     let serialized_arg =
         candid::encode_args((arg,)).expect("Failed to serialize the install argument.");
 
@@ -115,6 +106,5 @@ pub async fn upgrade_individual_user_canister(
         };
 
     api::call::call(Principal::management_canister(), "install_code", (upgrade_args, )).await?;
-
     start_canister(CanisterIdRecord {canister_id}).await
 }

--- a/src/lib/integration_tests/tests/backup_and_restore/when_backups_are_run_on_all_the_individual_user_canisters_they_capture_all_relevant_data_and_when_restored_they_return_the_canisters_to_their_original_state.rs
+++ b/src/lib/integration_tests/tests/backup_and_restore/when_backups_are_run_on_all_the_individual_user_canisters_they_capture_all_relevant_data_and_when_restored_they_return_the_canisters_to_their_original_state.rs
@@ -258,8 +258,8 @@ fn when_backups_are_run_on_all_the_individual_user_canisters_they_capture_all_re
         )
         .unwrap();
 
-    state_machine.advance_time(Duration::from_secs(30));
-    state_machine.tick();
+    // state_machine.advance_time(Duration::from_secs(30));
+    // state_machine.tick();
 
     state_machine
         .update_call(

--- a/src/lib/integration_tests/tests/hot_or_not/when_bob_charlie_dan_place_bet_on_alice_created_post_then_expected_outcomes_occur.rs
+++ b/src/lib/integration_tests/tests/hot_or_not/when_bob_charlie_dan_place_bet_on_alice_created_post_then_expected_outcomes_occur.rs
@@ -280,8 +280,8 @@ fn when_bob_charlie_dan_place_bet_on_alice_created_post_then_expected_outcomes_o
         )
         .unwrap();
 
-    state_machine.advance_time(Duration::from_secs(30));
-    state_machine.tick();
+    // state_machine.advance_time(Duration::from_secs(30));
+    // state_machine.tick();
 
     // * advance time to the end of the first slot and then 5 minutes
     state_machine.advance_time(Duration::from_secs(60 * (60 + 5)));


### PR DESCRIPTION
## Changes
- use streaming futures to upgrade fleet of canisters
- stop the canisters before upgrading.

## Impact
- fixes #206 