### PR TITLE
Feat/add parameter to stop and resume upgrades

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -688,6 +688,7 @@ name = "shared_utils"
 version = "0.1.0"
 dependencies = [
  "candid",
+ "futures",
  "ic-cdk",
  "ic-cdk-timers",
  "ic-stable-structures",
@@ -840,7 +841,6 @@ name = "user_index"
 version = "0.1.0"
 dependencies = [
  "candid",
- "futures",
  "ic-cdk",
  "ic-cdk-timers",
  "serde",

--- a/src/canister/individual_user_template/can.did
+++ b/src/canister/individual_user_template/can.did
@@ -301,6 +301,7 @@ service : (IndividualUserTemplateInitArgs) -> {
       nat64,
     ) -> (Result_5) query;
   get_utility_token_balance : () -> (nat64) query;
+  get_version_number : () -> (nat64) query;
   get_well_known_principal_value : (KnownPrincipalType) -> (
       opt principal,
     ) query;

--- a/src/canister/individual_user_template/src/api/canister_management/mod.rs
+++ b/src/canister/individual_user_template/src/api/canister_management/mod.rs
@@ -1,7 +1,18 @@
 use ic_cdk::api::stable::stable_size;
 
+use crate::CANISTER_DATA;
+
 #[candid::candid_method(query)]
 #[ic_cdk::query]
 pub fn get_stable_memory_size() -> u32 {
     stable_size()
+}
+
+
+#[candid::candid_method(query)]
+#[ic_cdk::query]
+pub fn get_version_number() -> u64 {
+    CANISTER_DATA.with(|canister_data_ref| {
+        canister_data_ref.borrow().version_details.version_number
+    })
 }

--- a/src/canister/user_index/Cargo.toml
+++ b/src/canister/user_index/Cargo.toml
@@ -14,7 +14,6 @@ ic-cdk = { workspace = true }
 ic-cdk-timers = { workspace = true }
 shared_utils = { workspace = true }
 serde = { workspace = true }
-futures = { workspace = true }
 
 [dev-dependencies]
 test_utils = { workspace = true }

--- a/src/canister/user_index/can.did
+++ b/src/canister/user_index/can.did
@@ -86,6 +86,8 @@ service : (UserIndexInitArgs) -> {
       principal,
       text,
     ) -> ();
+  set_permission_to_upgrade_individual_canisters : (bool) -> (text);
+  start_upgrades_for_individual_canisters : () -> (text);
   update_index_with_unique_user_name_corresponding_to_user_principal_id : (
       text,
       principal,

--- a/src/canister/user_index/src/api/canister_management/mod.rs
+++ b/src/canister/user_index/src/api/canister_management/mod.rs
@@ -1,5 +1,10 @@
 use ic_cdk::api::{management_canister::{main::{canister_status, CanisterStatusResponse}, provisional::CanisterIdRecord}, call::CallResult};
 use candid::Principal;
+use shared_utils::common::types::known_principal::KnownPrincipalType;
+
+use crate::CANISTER_DATA;
+
+use super::upgrade_individual_user_template::update_user_index_upgrade_user_canisters_with_latest_wasm;
 
 
 
@@ -7,4 +12,44 @@ use candid::Principal;
 #[ic_cdk::update]
 pub async fn get_user_canister_status(canister_id: Principal) -> CallResult<(CanisterStatusResponse,)>{
     canister_status(CanisterIdRecord {canister_id}).await
+}
+
+
+#[candid::candid_method(update)]
+#[ic_cdk::update]
+pub async fn set_permission_to_upgrade_individual_canisters(flag: bool) -> String {
+    let api_caller = ic_cdk::caller();
+    let known_principal_ids = CANISTER_DATA.with(|canister_data_ref_cell| canister_data_ref_cell.borrow().known_principal_ids.clone());
+    if *known_principal_ids
+        .get(&KnownPrincipalType::UserIdGlobalSuperAdmin)
+        .unwrap()
+        != api_caller
+    {
+        return "Unauthorized caller".to_string();
+    };
+
+    CANISTER_DATA.with(|canister_data_ref| {
+       canister_data_ref.borrow_mut().allow_upgrades_for_individual_canisters = flag;
+    });
+    return "Success".to_string()
+}
+
+#[candid::candid_method(update)]
+#[ic_cdk::update]
+pub async fn start_upgrades_for_individual_canisters() -> String {
+    let api_caller = ic_cdk::caller();
+    let known_principal_ids = CANISTER_DATA.with(|canister_data_ref_cell| canister_data_ref_cell.borrow().known_principal_ids.clone());
+    if *known_principal_ids
+        .get(&KnownPrincipalType::UserIdGlobalSuperAdmin)
+        .unwrap()
+        != api_caller
+    {
+        return "Unauthorized caller".to_string();
+    };
+
+    CANISTER_DATA.with(|canister_data_ref| {
+        canister_data_ref.borrow_mut().allow_upgrades_for_individual_canisters = true;
+    });
+    ic_cdk::spawn(update_user_index_upgrade_user_canisters_with_latest_wasm::upgrade_user_canisters_with_latest_wasm());
+    "Success".to_string()
 }

--- a/src/canister/user_index/src/api/upgrade_individual_user_template/update_user_index_upgrade_user_canisters_with_latest_wasm.rs
+++ b/src/canister/user_index/src/api/upgrade_individual_user_template/update_user_index_upgrade_user_canisters_with_latest_wasm.rs
@@ -146,7 +146,7 @@ async fn upgrade_user_canister(
                 configuration.url_to_send_canister_metrics_to.clone(),
             ),
         },
-        true
+        false
     )
     .await
     .map_err(|e| e.1)

--- a/src/canister/user_index/src/api/upgrade_individual_user_template/update_user_index_upgrade_user_canisters_with_latest_wasm.rs
+++ b/src/canister/user_index/src/api/upgrade_individual_user_template/update_user_index_upgrade_user_canisters_with_latest_wasm.rs
@@ -18,7 +18,7 @@ use crate::{
     CANISTER_DATA,
 };
 
-const MAX_CONCURRENCY: usize = 15;
+const MAX_CONCURRENCY: usize = 11;
 
 pub async fn upgrade_user_canisters_with_latest_wasm() {
     let mut upgrade_count = 0;

--- a/src/canister/user_index/src/data_model/mod.rs
+++ b/src/canister/user_index/src/data_model/mod.rs
@@ -9,10 +9,17 @@ use self::{canister_upgrade::UpgradeStatus, configuration::Configuration};
 pub mod canister_upgrade;
 pub mod configuration;
 
+
+const fn _default_true() -> bool {
+    return true;
+}
+
 #[derive(Default, CandidType, Deserialize, Serialize)]
 pub struct CanisterData {
     pub configuration: Configuration,
     pub last_run_upgrade_status: UpgradeStatus,
+    #[serde(default = "_default_true")]
+    pub allow_upgrades_for_individual_canisters: bool,
     pub known_principal_ids: KnownPrincipalMap,
     pub user_principal_id_to_canister_id_map: BTreeMap<Principal, Principal>,
     pub unique_user_name_to_user_principal_id_map: BTreeMap<String, Principal>,

--- a/src/canister/user_index/src/util/canister_management.rs
+++ b/src/canister/user_index/src/util/canister_management.rs
@@ -3,7 +3,7 @@ use ic_cdk::api::{
     self,
     call::RejectionCode,
     management_canister::{
-        main::{self, CanisterInstallMode, CreateCanisterArgument, WasmModule, InstallCodeArgument, stop_canister, start_canister, canister_status, CanisterStatusType},
+        main::{self, CanisterInstallMode, CreateCanisterArgument, WasmModule, InstallCodeArgument, stop_canister, start_canister},
         provisional::{CanisterSettings, CanisterIdRecord},
     }, canister_version,
 };

--- a/src/lib/shared_utils/Cargo.toml
+++ b/src/lib/shared_utils/Cargo.toml
@@ -11,6 +11,7 @@ ic-cdk = { workspace = true }
 ic-cdk-timers = { workspace = true }
 ic-stable-structures = { workspace = true }
 rmp-serde = { workspace = true }
+futures = { workspace =true }
 serde = { workspace = true }
 
 [dev-dependencies]

--- a/src/lib/shared_utils/src/common/utils/mod.rs
+++ b/src/lib/shared_utils/src/common/utils/mod.rs
@@ -1,2 +1,3 @@
 pub mod stable_memory_serializer_deserializer;
+pub mod task;
 pub mod system_time;

--- a/src/lib/shared_utils/src/common/utils/task.rs
+++ b/src/lib/shared_utils/src/common/utils/task.rs
@@ -1,0 +1,40 @@
+use std::pin::Pin;
+use futures::{stream::FuturesUnordered, Future, StreamExt};
+
+pub async fn run_task_concurrently<T>(
+    mut futures: impl Iterator<Item = impl Future<Output = T>>, 
+    concurrency: usize,
+    mut result_callback: impl FnMut(T), 
+    breaking_condition: impl Fn() -> bool)   {
+
+
+        let mut in_progress_futures: FuturesUnordered<Pin<Box<dyn Future<Output = T>>>> = FuturesUnordered::new();
+
+        for _ in 0..concurrency {
+            let next_future = match futures.next() {
+                None => break,
+                Some(some)=> some,
+            };
+            if breaking_condition() {
+                break;
+            }
+            in_progress_futures.push(Box::pin(next_future));
+        }
+
+        for next_future in futures {
+            if breaking_condition() {
+                break;
+            }
+            let result = in_progress_futures.next().await.unwrap();
+            result_callback(result);
+            in_progress_futures.push(Box::pin(next_future));
+        }
+
+        loop {
+            match in_progress_futures.next().await {
+                None => break,
+                Some (result) => result_callback(result)
+            }
+        }
+
+}


### PR DESCRIPTION
## Changes
- added `allow_upgrades_for_individual_canisters` (default value: true) to user_index canister data which determines upgrades of individual canisters
- added `start_upgrades_for_individual_canisters` in user_index canister
- added `set_permission_to_upgrade_individual_canisters` in user_index canister
- added `get_version_number` in `individual_user_template`
- increase concurrency to 15 for running upgrades
- refactored running concurrent upgrades.

## Impact
- fixes #218 
- fixes #212 
