### PR TITLE
add generic proposal to reset individual canisters

### DIFF
--- a/.github/workflows/create_release_on_tag_push.yml
+++ b/.github/workflows/create_release_on_tag_push.yml
@@ -106,7 +106,7 @@ jobs:
             --url 'https://hotornot.wtf' \
             --target-canister-id $CANISTER_ID \
             --wasm-path .dfx/ic/canisters/${CANISTER_NAME}/${CANISTER_NAME}.wasm.gz \
-            --canister-upgrade-arg '(record {})' \
+            --canister-upgrade-arg "(record {version=\"${{ github.ref_name }}\"})" \
             $NEURON_ID > "proposals/${CANISTER_NAME}/upgrade.json"
           ./quill send proposals/${CANISTER_NAME}/upgrade.json --yes
       - name: Submit upgrade proposal for post_cache canister

--- a/scripts/canisters/local_deploy/install_all_canisters.sh
+++ b/scripts/canisters/local_deploy/install_all_canisters.sh
@@ -154,4 +154,5 @@ dfx canister install user_index --argument "(record {
       vec { variant { CanisterAdmin }; variant { CanisterController }; }
     };
   };
+  version= \"v1.0.0\"
 })"

--- a/scripts/canisters/local_deploy/upgrade_all_canisters.sh
+++ b/scripts/canisters/local_deploy/upgrade_all_canisters.sh
@@ -34,4 +34,6 @@ fi
 dfx canister install configuration --mode upgrade --argument "(record {})"
 dfx canister install data_backup --mode upgrade --argument "(record {})"
 dfx canister install post_cache --mode upgrade --argument "(record {})"
-dfx canister install user_index --mode upgrade --argument "(record {})"
+dfx canister install user_index --mode upgrade --argument "(record {
+  version= \"v1.1.0\"
+})"

--- a/src/canister/configuration/can.did
+++ b/src/canister/configuration/can.did
@@ -11,6 +11,7 @@ type KnownPrincipalType = variant {
   CanisterIdDataBackup;
   CanisterIdPostCache;
   CanisterIdSNSController;
+  CanisterIdSnsGovernance;
   UserIdGlobalSuperAdmin;
 };
 type Result = variant { Ok; Err : text };

--- a/src/canister/configuration/src/api/canister_lifecycle/post_upgrade.rs
+++ b/src/canister/configuration/src/api/canister_lifecycle/post_upgrade.rs
@@ -1,4 +1,8 @@
+use std::str::FromStr;
+
+use candid::Principal;
 use ic_cdk::storage;
+use shared_utils::{common::types::known_principal::KnownPrincipalType, constant::GOVERNANCE_CANISTER_ID};
 
 use crate::CANISTER_DATA;
 
@@ -8,6 +12,7 @@ fn post_upgrade() {
         Ok((canister_data,)) => {
             CANISTER_DATA.with(|canister_data_ref_cell| {
                 *canister_data_ref_cell.borrow_mut() = canister_data;
+                canister_data_ref_cell.borrow_mut().known_principal_ids.insert(KnownPrincipalType::CanisterIdSnsGovernance, Principal::from_str(GOVERNANCE_CANISTER_ID).unwrap());
             });
         }
         Err(_) => {

--- a/src/canister/data_backup/can.did
+++ b/src/canister/data_backup/can.did
@@ -63,6 +63,7 @@ type KnownPrincipalType = variant {
   CanisterIdDataBackup;
   CanisterIdPostCache;
   CanisterIdSNSController;
+  CanisterIdSnsGovernance;
   UserIdGlobalSuperAdmin;
 };
 type MintEvent = variant {

--- a/src/canister/individual_user_template/can.did
+++ b/src/canister/individual_user_template/can.did
@@ -102,6 +102,7 @@ type KnownPrincipalType = variant {
   CanisterIdDataBackup;
   CanisterIdPostCache;
   CanisterIdSNSController;
+  CanisterIdSnsGovernance;
   UserIdGlobalSuperAdmin;
 };
 type MintEvent = variant {

--- a/src/canister/individual_user_template/can.did
+++ b/src/canister/individual_user_template/can.did
@@ -89,6 +89,7 @@ type HotOrNotOutcomePayoutEvent = variant {
 };
 type IndividualUserTemplateInitArgs = record {
   known_principal_ids : opt vec record { KnownPrincipalType; principal };
+  version : text;
   url_to_send_canister_metrics_to : opt text;
   profile_owner : opt principal;
   upgrade_version_number : opt nat64;
@@ -305,6 +306,7 @@ service : (IndividualUserTemplateInitArgs) -> {
       nat64,
     ) -> (Result_5) query;
   get_utility_token_balance : () -> (nat64) query;
+  get_version : () -> (text) query;
   get_version_number : () -> (nat64) query;
   get_well_known_principal_value : (KnownPrincipalType) -> (
       opt principal,

--- a/src/canister/individual_user_template/src/api/canister_lifecycle/init.rs
+++ b/src/canister/individual_user_template/src/api/canister_lifecycle/init.rs
@@ -79,6 +79,7 @@ mod test {
             url_to_send_canister_metrics_to: Some(
                 "http://metrics-url.com/receive-metrics".to_string(),
             ),
+            version: String::from("v1.0.0")
         };
         let mut data = CanisterData::default();
 

--- a/src/canister/individual_user_template/src/api/canister_lifecycle/post_upgrade.rs
+++ b/src/canister/individual_user_template/src/api/canister_lifecycle/post_upgrade.rs
@@ -1,4 +1,4 @@
-use std::time::Duration;
+use std::{time::Duration, borrow::BorrowMut};
 use ciborium::de;
 use ic_stable_structures::Memory;
 
@@ -56,6 +56,8 @@ fn save_upgrade_args_to_memory() {
         if let Some(upgrade_version_number) = upgrade_args.upgrade_version_number {
             canister_data_ref_cell.version_details.version_number = upgrade_version_number;
         }
+
+        canister_data_ref_cell.borrow_mut().version_details.version = upgrade_args.version;
 
         if let Some(url_to_send_canister_metrics_to) = upgrade_args.url_to_send_canister_metrics_to
         {

--- a/src/canister/individual_user_template/src/api/canister_management/mod.rs
+++ b/src/canister/individual_user_template/src/api/canister_management/mod.rs
@@ -16,3 +16,12 @@ pub fn get_version_number() -> u64 {
         canister_data_ref.borrow().version_details.version_number
     })
 }
+
+#[candid::candid_method(query)]
+#[ic_cdk::query]
+pub fn get_version() -> String {
+    CANISTER_DATA.with(|canister_data_ref| {
+        canister_data_ref.borrow().version_details.version.clone()
+    })
+}
+

--- a/src/canister/individual_user_template/src/data_model/version_details.rs
+++ b/src/canister/individual_user_template/src/data_model/version_details.rs
@@ -4,4 +4,6 @@ use serde::Serialize;
 #[derive(Default, CandidType, Deserialize, Serialize)]
 pub struct VersionDetails {
     pub version_number: u64,
+    #[serde(default)]
+    pub version: String
 }

--- a/src/canister/post_cache/can.did
+++ b/src/canister/post_cache/can.did
@@ -7,6 +7,7 @@ type KnownPrincipalType = variant {
   CanisterIdDataBackup;
   CanisterIdPostCache;
   CanisterIdSNSController;
+  CanisterIdSnsGovernance;
   UserIdGlobalSuperAdmin;
 };
 type PostCacheInitArgs = record {

--- a/src/canister/user_index/can.did
+++ b/src/canister/user_index/can.did
@@ -23,6 +23,7 @@ type KnownPrincipalType = variant {
   CanisterIdDataBackup;
   CanisterIdPostCache;
   CanisterIdSNSController;
+  CanisterIdSnsGovernance;
   UserIdGlobalSuperAdmin;
 };
 type RejectionCode = variant {
@@ -38,7 +39,8 @@ type Result = variant {
   Ok : record { CanisterStatusResponse };
   Err : record { RejectionCode; text };
 };
-type Result_1 = variant { Ok; Err : SetUniqueUsernameError };
+type Result_1 = variant { Ok : text; Err : text };
+type Result_2 = variant { Ok; Err : SetUniqueUsernameError };
 type SetUniqueUsernameError = variant {
   UsernameAlreadyTaken;
   SendingCanisterDoesNotMatchUserCanisterId;
@@ -68,6 +70,7 @@ service : (UserIndexInitArgs) -> {
   backup_all_individual_user_canisters : () -> ();
   get_index_details_is_user_name_taken : (text) -> (bool) query;
   get_index_details_last_upgrade_status : () -> (UpgradeStatus) query;
+  get_list_of_available_canisters : () -> (vec principal) query;
   get_requester_principals_canister_id_create_if_not_exists_and_optionally_allow_referrer : (
       opt principal,
     ) -> (principal);
@@ -86,16 +89,20 @@ service : (UserIndexInitArgs) -> {
       principal,
       text,
     ) -> ();
+  reset_user_individual_canisters : (vec principal) -> (Result_1);
   set_permission_to_upgrade_individual_canisters : (bool) -> (text);
   start_upgrades_for_individual_canisters : () -> (text);
   update_index_with_unique_user_name_corresponding_to_user_principal_id : (
       text,
       principal,
-    ) -> (Result_1);
+    ) -> (Result_2);
   upgrade_specific_individual_user_canister_with_latest_wasm : (
       principal,
       principal,
       opt CanisterInstallMode,
       bool,
     ) -> (text);
+  validate_reset_user_individual_canisters : (vec principal) -> (
+      Result_1,
+    ) query;
 }

--- a/src/canister/user_index/can.did
+++ b/src/canister/user_index/can.did
@@ -52,6 +52,7 @@ type SystemTime = record {
 };
 type UpgradeStatus = record {
   version_number : nat64;
+  version : text;
   last_run_on : SystemTime;
   failed_canister_ids : vec record { principal; principal; text };
   successful_upgrade_count : nat32;
@@ -64,6 +65,7 @@ type UserAccessRole = variant {
 };
 type UserIndexInitArgs = record {
   known_principal_ids : opt vec record { KnownPrincipalType; principal };
+  version : text;
   access_control_map : opt vec record { principal; vec UserAccessRole };
 };
 service : (UserIndexInitArgs) -> {

--- a/src/canister/user_index/src/api/canister_lifecycle/init.rs
+++ b/src/canister/user_index/src/api/canister_lifecycle/init.rs
@@ -20,6 +20,7 @@ fn init_impl(init_args: UserIndexInitArgs, data: &mut CanisterData) {
             data.known_principal_ids
                 .insert(*principal_belongs_to, *principal_id);
         });
+    data.allow_upgrades_for_individual_canisters = true;
 }
 
 #[cfg(test)]
@@ -72,6 +73,8 @@ mod test {
         let init_args = UserIndexInitArgs {
             known_principal_ids: Some(known_principal_ids),
             access_control_map: Some(access_control_map),
+            version: String::from("v1.0.0")
+
         };
         let mut data = CanisterData::default();
 

--- a/src/canister/user_index/src/api/canister_lifecycle/post_upgrade.rs
+++ b/src/canister/user_index/src/api/canister_lifecycle/post_upgrade.rs
@@ -1,13 +1,13 @@
 use std::time::Duration;
 
-use shared_utils::common::utils::stable_memory_serializer_deserializer;
+use shared_utils::{common::utils::{stable_memory_serializer_deserializer, system_time}, canister_specific::user_index::types::args::UserIndexInitArgs};
 
 use crate::{
     api::{
         upgrade_individual_user_template::update_user_index_upgrade_user_canisters_with_latest_wasm,
         well_known_principal::update_locally_stored_well_known_principals,
     },
-    data_model::{configuration::Configuration, CanisterData},
+    data_model::{configuration::Configuration, CanisterData, canister_upgrade::UpgradeStatus},
     CANISTER_DATA,
 };
 
@@ -16,6 +16,7 @@ use super::pre_upgrade::BUFFER_SIZE_BYTES;
 #[ic_cdk::post_upgrade]
 fn post_upgrade() {
     restore_data_from_stable_memory();
+    update_version_from_args();
     refetch_well_known_principals();
     upgrade_all_indexed_user_canisters();
 
@@ -31,6 +32,22 @@ fn post_upgrade() {
                 .to_string(),
         };
     });
+}
+
+fn update_version_from_args() {
+    let (upgrade_args, ) = ic_cdk::api::call::arg_data::<(UserIndexInitArgs,)>();
+    CANISTER_DATA.with(|canister_data_ref| {
+      let last_upgrade_status = canister_data_ref.borrow().last_run_upgrade_status.clone();
+       let upgrade_status = UpgradeStatus {
+        last_run_on: system_time::get_current_system_time_from_ic(),
+        failed_canister_ids: vec![],
+        version_number: last_upgrade_status.version_number,
+        successful_upgrade_count: 0,
+        version: upgrade_args.version
+       };
+       canister_data_ref.borrow_mut().last_run_upgrade_status = upgrade_status;
+    })
+
 }
 
 fn restore_data_from_stable_memory() {

--- a/src/canister/user_index/src/api/canister_management/mod.rs
+++ b/src/canister/user_index/src/api/canister_management/mod.rs
@@ -96,7 +96,8 @@ pub async fn reset_user_individual_canisters(canisters: Vec<Principal>) -> Resul
             known_principal_ids: Some(CANISTER_DATA.with(|canister_data_ref| {canister_data_ref.borrow().known_principal_ids.clone()})),
             profile_owner: None,
             upgrade_version_number: Some(CANISTER_DATA.with(|canister_data_ref| canister_data_ref.borrow().last_run_upgrade_status.version_number)),
-            url_to_send_canister_metrics_to: Some(CANISTER_DATA.with(|canister_data_ref| canister_data_ref.borrow().configuration.url_to_send_canister_metrics_to.clone()))
+            url_to_send_canister_metrics_to: Some(CANISTER_DATA.with(|canister_data_ref| canister_data_ref.borrow().configuration.url_to_send_canister_metrics_to.clone())),
+            version: CANISTER_DATA.with(|canister_data_ref_cell| canister_data_ref_cell.borrow().last_run_upgrade_status.version.clone())
         }, false).await?;
         Ok(canister.clone())
     });

--- a/src/canister/user_index/src/api/canister_management/mod.rs
+++ b/src/canister/user_index/src/api/canister_management/mod.rs
@@ -1,8 +1,9 @@
-use ic_cdk::api::{management_canister::{main::{canister_status, CanisterStatusResponse}, provisional::CanisterIdRecord}, call::CallResult};
-use candid::Principal;
-use shared_utils::common::types::known_principal::KnownPrincipalType;
 
-use crate::CANISTER_DATA;
+use ic_cdk::{api::{management_canister::{main::{canister_status, CanisterStatusResponse, CanisterInstallMode}, provisional::CanisterIdRecord}, call::CallResult}, caller};
+use candid::Principal;
+use shared_utils::{common::{types::known_principal::KnownPrincipalType, utils::task::run_task_concurrently}, canister_specific::individual_user_template::types::arg::IndividualUserTemplateInitArgs};
+
+use crate::{CANISTER_DATA, util::canister_management};
 
 use super::upgrade_individual_user_template::update_user_index_upgrade_user_canisters_with_latest_wasm;
 
@@ -52,4 +53,68 @@ pub async fn start_upgrades_for_individual_canisters() -> String {
     });
     ic_cdk::spawn(update_user_index_upgrade_user_canisters_with_latest_wasm::upgrade_user_canisters_with_latest_wasm());
     "Success".to_string()
+}
+
+#[ic_cdk::query]
+#[candid::candid_method(query)]
+pub fn get_list_of_available_canisters() -> Vec<Principal> {
+    CANISTER_DATA.with(|canister_data_ref|{
+        canister_data_ref.borrow().available_canisters.clone().into_iter().collect()
+    })
+}
+
+#[ic_cdk::query]
+#[candid::candid_method(query)]
+pub fn validate_reset_user_individual_canisters(_canisters: Vec<Principal>) -> Result<String, String> {
+    let caller_id = caller();
+    let governance_canister_id = CANISTER_DATA.with(|canister_data_ref| {
+        canister_data_ref.borrow().known_principal_ids.get(&KnownPrincipalType::CanisterIdSnsGovernance).cloned()
+    }).ok_or("Governance Canister Id not found")?;
+    
+    if caller_id !=  governance_canister_id {
+        return Err("This Proposal can only be executed through DAO".to_string())
+    };
+
+    Ok("Success".to_string())
+}
+
+
+#[ic_cdk::update]
+#[candid::candid_method(update)]
+pub async fn reset_user_individual_canisters(canisters: Vec<Principal>) -> Result<String, String> {
+    let caller_id = caller();
+    let governance_canister_id = CANISTER_DATA.with(|canister_data_ref| {
+        canister_data_ref.borrow().known_principal_ids.get(&KnownPrincipalType::CanisterIdSnsGovernance).cloned()
+    }).ok_or("Governance Canister Id not found")?;
+    
+    if caller_id !=  governance_canister_id {
+        return Err("This method can only be executed through DAO".to_string())
+    };
+    
+    let canister_reinstall_futures = canisters.iter().map(|canister| async {
+        canister_management::upgrade_individual_user_canister(canister.clone(), CanisterInstallMode::Reinstall, IndividualUserTemplateInitArgs {
+            known_principal_ids: Some(CANISTER_DATA.with(|canister_data_ref| {canister_data_ref.borrow().known_principal_ids.clone()})),
+            profile_owner: None,
+            upgrade_version_number: Some(CANISTER_DATA.with(|canister_data_ref| canister_data_ref.borrow().last_run_upgrade_status.version_number)),
+            url_to_send_canister_metrics_to: Some(CANISTER_DATA.with(|canister_data_ref| canister_data_ref.borrow().configuration.url_to_send_canister_metrics_to.clone()))
+        }, false).await?;
+        Ok(canister.clone())
+    });
+
+    let result_callback = |reinstall_res: CallResult<Principal>| { 
+        
+       match reinstall_res {
+        Ok(canister_id) => {
+            CANISTER_DATA.with(|canister_data_ref| {
+                canister_data_ref.borrow_mut().available_canisters.insert(canister_id);
+            })
+        },
+        Err(e) => ic_cdk::println!("Failed to reinstall canister {}", e.1)
+       }
+    };
+
+
+    run_task_concurrently(canister_reinstall_futures, 10, result_callback, || false).await;
+
+    Ok(format!("Sucess {}", canisters[0].to_string()))
 }

--- a/src/canister/user_index/src/api/upgrade_individual_user_template/upgrade_specific_individual_user_canister_with_latest_wasm.rs
+++ b/src/canister/user_index/src/api/upgrade_individual_user_template/upgrade_specific_individual_user_canister_with_latest_wasm.rs
@@ -50,6 +50,7 @@ async fn upgrade_specific_individual_user_canister_with_latest_wasm(
             profile_owner: Some(user_principal_id),
             upgrade_version_number: Some(saved_upgrade_status.version_number + 1),
             url_to_send_canister_metrics_to: Some(configuration.url_to_send_canister_metrics_to),
+            version: saved_upgrade_status.version
         },
         unsafe_drop_stable_memory
     )

--- a/src/canister/user_index/src/data_model/canister_upgrade/mod.rs
+++ b/src/canister/user_index/src/data_model/canister_upgrade/mod.rs
@@ -12,6 +12,8 @@ pub struct UpgradeStatus {
     pub last_run_on: SystemTime,
     pub successful_upgrade_count: u32,
     pub failed_canister_ids: Vec<(Principal, Principal, String)>,
+    #[serde(default)]
+    pub version: String,
 }
 
 impl Display for UpgradeStatus {
@@ -27,6 +29,7 @@ impl Default for UpgradeStatus {
             last_run_on: UNIX_EPOCH,
             successful_upgrade_count: 0,
             failed_canister_ids: Vec::new(),
+            version: String::from("v0.0.0")
         }
     }
 }

--- a/src/canister/user_index/src/data_model/mod.rs
+++ b/src/canister/user_index/src/data_model/mod.rs
@@ -1,4 +1,4 @@
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, HashSet};
 
 use candid::{CandidType, Deserialize, Principal};
 use serde::Serialize;
@@ -14,12 +14,18 @@ const fn _default_true() -> bool {
     return true;
 }
 
+fn _default_vec_principal() -> HashSet<Principal> {
+    return HashSet::new()
+}
+
 #[derive(Default, CandidType, Deserialize, Serialize)]
 pub struct CanisterData {
     pub configuration: Configuration,
     pub last_run_upgrade_status: UpgradeStatus,
     #[serde(default = "_default_true")]
     pub allow_upgrades_for_individual_canisters: bool,
+    #[serde(default = "_default_vec_principal")]
+    pub available_canisters: HashSet<Principal>,
     pub known_principal_ids: KnownPrincipalMap,
     pub user_principal_id_to_canister_id_map: BTreeMap<Principal, Principal>,
     pub unique_user_name_to_user_principal_id_map: BTreeMap<String, Principal>,

--- a/src/canister/user_index/src/util/canister_management.rs
+++ b/src/canister/user_index/src/util/canister_management.rs
@@ -66,6 +66,7 @@ pub async fn create_users_canister(profile_owner: Principal) -> Principal {
             canister_data_ref_cell.borrow().known_principal_ids.clone()
         })),
         upgrade_version_number: Some(0),
+        version: CANISTER_DATA.with(|canister_data_ref_cell| canister_data_ref_cell.borrow().last_run_upgrade_status.version.clone()),
         url_to_send_canister_metrics_to: Some(configuration.url_to_send_canister_metrics_to),
     };
 

--- a/src/lib/integration_tests/tests/backup_and_restore/when_backups_are_run_on_all_the_individual_user_canisters_they_capture_all_relevant_data_and_when_restored_they_return_the_canisters_to_their_original_state.rs
+++ b/src/lib/integration_tests/tests/backup_and_restore/when_backups_are_run_on_all_the_individual_user_canisters_they_capture_all_relevant_data_and_when_restored_they_return_the_canisters_to_their_original_state.rs
@@ -189,11 +189,17 @@ fn when_backups_are_run_on_all_the_individual_user_canisters_they_capture_all_re
         )
         .unwrap();
 
+    let user_index_upgrade_arg = UserIndexInitArgs {
+        known_principal_ids: None,
+        access_control_map: None,
+        version: String::from("v1.0.0")
+    };
+
     state_machine
         .upgrade_canister(
             user_index_canister_id,
             get_canister_wasm(KnownPrincipalType::CanisterIdUserIndex),
-            candid::encode_one(()).unwrap(),
+            candid::encode_one(user_index_upgrade_arg).unwrap(),
             Some(get_global_super_admin_principal_id()),
         )
         .unwrap();

--- a/src/lib/integration_tests/tests/cycle_management/when_canister_cycle_balance_is_below_the_configured_or_freezing_threshold_then_running_topup_function_in_user_index_canister_tops_up_the_canisters_that_need_it.rs
+++ b/src/lib/integration_tests/tests/cycle_management/when_canister_cycle_balance_is_below_the_configured_or_freezing_threshold_then_running_topup_function_in_user_index_canister_tops_up_the_canisters_that_need_it.rs
@@ -13,7 +13,6 @@ use test_utils::setup::{
     },
 };
 
-#[ignore]
 #[test]
 fn when_canister_cycle_balance_is_below_the_configured_or_freezing_threshold_then_running_topup_function_in_user_index_canister_tops_up_the_canisters_that_need_it(
 ) {

--- a/src/lib/shared_utils/src/canister_specific/individual_user_template/types/arg.rs
+++ b/src/lib/shared_utils/src/canister_specific/individual_user_template/types/arg.rs
@@ -10,6 +10,7 @@ pub struct IndividualUserTemplateInitArgs {
     pub profile_owner: Option<Principal>,
     pub upgrade_version_number: Option<u64>,
     pub url_to_send_canister_metrics_to: Option<String>,
+    pub version: String,
 }
 
 #[derive(Deserialize, CandidType, Clone)]

--- a/src/lib/shared_utils/src/canister_specific/user_index/types/args.rs
+++ b/src/lib/shared_utils/src/canister_specific/user_index/types/args.rs
@@ -8,4 +8,5 @@ use crate::{access_control::UserAccessRole, common::types::known_principal::Know
 pub struct UserIndexInitArgs {
     pub known_principal_ids: Option<KnownPrincipalMap>,
     pub access_control_map: Option<HashMap<Principal, Vec<UserAccessRole>>>,
+    pub version: String
 }

--- a/src/lib/shared_utils/src/common/types/known_principal.rs
+++ b/src/lib/shared_utils/src/common/types/known_principal.rs
@@ -14,6 +14,7 @@ pub enum KnownPrincipalType {
     CanisterIdSNSController,
     CanisterIdTopicCacheIndex,
     CanisterIdUserIndex,
+    CanisterIdSnsGovernance,
 }
 
 pub type KnownPrincipalMap = HashMap<KnownPrincipalType, Principal>;

--- a/src/lib/shared_utils/src/constant.rs
+++ b/src/lib/shared_utils/src/constant.rs
@@ -2,7 +2,7 @@ use candid::Principal;
 
 use crate::common::types::known_principal::{KnownPrincipalMap, KnownPrincipalType};
 
-pub const INDIVIDUAL_USER_CANISTER_RECHARGE_AMOUNT: u128 = 600_000_000_000; // 0.6T Cycles
+pub const INDIVIDUAL_USER_CANISTER_RECHARGE_AMOUNT: u128 = 1_000_000_000_000; // 1T Cycles
 pub const CYCLES_THRESHOLD_TO_INITIATE_RECHARGE: u128 = 500_000_000_000; // 0.5T Cycles
 
 pub const MAX_USERS_IN_FOLLOWER_FOLLOWING_LIST: u64 = 10000;

--- a/src/lib/shared_utils/src/constant.rs
+++ b/src/lib/shared_utils/src/constant.rs
@@ -10,6 +10,7 @@ pub const MAX_POSTS_IN_ONE_REQUEST: u64 = 100;
 pub const HOME_FEED_DIFFERENCE_TO_INITIATE_SYNCHRONISATION: u64 = 100;
 pub const HOT_OR_NOT_FEED_DIFFERENCE_TO_INITIATE_SYNCHRONISATION: u64 = 100;
 // * Important Principal IDs
+pub const GOVERNANCE_CANISTER_ID: &str = "6wcax-haaaa-aaaaq-aaava-cai";
 
 pub fn get_global_super_admin_principal_id_v1(
     well_known_canisters: KnownPrincipalMap,

--- a/src/lib/test_utils/src/setup/env/v1.rs
+++ b/src/lib/test_utils/src/setup/env/v1.rs
@@ -146,6 +146,7 @@ pub fn get_initialized_env_with_provisioned_known_canisters(
         candid::encode_one(UserIndexInitArgs {
             known_principal_ids: Some(known_principal_map_with_all_canisters.clone()),
             access_control_map: Some(user_index_access_control_map),
+            version: String::from("v1.0.0")
         })
         .unwrap(),
     );


### PR DESCRIPTION
## Changes

- add generic proposal to reset canisters `reset_user_individual_canisters`.
- add sns governance canister id in configuration canister in well known principal ids.
- added changes for semver version in canisters
- Semver version is mandatory field of init and upgrading user_index canisters.
- update a test for recharging canisters.
- add a method in individual canister to get semver version.