### PR TITLE
228 post cache filters

### DIFF
--- a/.github/workflows/all_canisters_test_suite_on_any_push.yml
+++ b/.github/workflows/all_canisters_test_suite_on_any_push.yml
@@ -66,5 +66,8 @@ jobs:
       - name: Build post_cache canister
         run: |
           nix-shell --run "dfx build post_cache"
+          gzip -f -1 ./target/wasm32-unknown-unknown/release/post_cache.wasm
       - name: Run canister test suite
         run: nix-shell --run "cargo test"
+      - name: Run canister test suite - feature mockdata
+        run: nix-shell --run "cargo test --features mockdata --package post_cache"

--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ quill
 sns-testing/**
 msg.json
 candid/**
+ic-test-state-machine

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,30 @@
 version = 3
 
 [[package]]
+name = "addr2line"
+version = "0.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a30b2e23b9e17a9f90641c7ab1549cd9b44f296d3ccbf309d2863cfe398a0cb"
+dependencies = [
+ "gimli",
+]
+
+[[package]]
+name = "adler"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
+
+[[package]]
+name = "aho-corasick"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2969dcb958b36655471fc61f7e416fa76033bdd4bfed0678d8fee1e2d07a1f0"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "anyhow"
 version = "1.0.71"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -15,10 +39,63 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "23b62fc65de8e4e7f52534fb52b0f3ed04746ae267519eef2a83941e8085068b"
 
 [[package]]
+name = "ascii-canvas"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8824ecca2e851cec16968d54a01dd372ef8f95b244fb84b84e70128be347c3c6"
+dependencies = [
+ "term",
+]
+
+[[package]]
+name = "async-trait"
+version = "0.1.77"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c980ee35e870bd1a4d2c8294d4c04d0499e67bca1e4b5cefcc693c2fa00caea9"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.48",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
+
+[[package]]
+name = "backtrace"
+version = "0.3.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2089b7e3f35b9dd2d0ed921ead4f6d318c27680d4a5bd167b3ee120edb105837"
+dependencies = [
+ "addr2line",
+ "cc",
+ "cfg-if",
+ "libc",
+ "miniz_oxide",
+ "object",
+ "rustc-demangle",
+]
+
+[[package]]
+name = "base64"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
+
+[[package]]
+name = "base64"
+version = "0.21.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
+
+[[package]]
+name = "beef"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a8241f3ebb85c056b509d4327ad0358fbbba6ffb340bf388f26350aeda225b1"
 
 [[package]]
 name = "binread"
@@ -44,6 +121,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "bit-set"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0700ddab506f33b20a03b13996eccd309a48e5ff77d0d95926aa0210fb4e95f1"
+dependencies = [
+ "bit-vec",
+]
+
+[[package]]
+name = "bit-vec"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "349f9b6a179ed607305526ca489b34ad0a41aed5f7980fa90eb03160b69598fb"
+
+[[package]]
+name = "bitflags"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+
+[[package]]
+name = "bitflags"
+version = "2.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed570934406eb16438a4e976b1b4500774099c13b8cb96eec99f620f05090ddf"
+
+[[package]]
 name = "block-buffer"
 version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -53,26 +157,42 @@ dependencies = [
 ]
 
 [[package]]
+name = "bumpalo"
+version = "3.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f30e7476521f6f8af1a1c4c0b8cc94f0bee37d91763d0ca2665f299b6cd8aec"
+
+[[package]]
 name = "byteorder"
 version = "1.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
 
 [[package]]
-name = "candid"
-version = "0.9.3"
+name = "bytes"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a31e5ab22cdcd093b93b02bdff4ba18ffee324b05e669b25cdd93fdb8402d207"
+checksum = "a2bd12c1caf447e69cd4528f47f94d203fd2582878ecb9e9465484c4148a8223"
+
+[[package]]
+name = "candid"
+version = "0.9.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "465c1ce01d8089ee5b49ba20d3a9da15a28bba64c35cdff2aa256d37e319625d"
 dependencies = [
  "anyhow",
  "binread",
  "byteorder",
  "candid_derive",
  "codespan-reporting",
+ "convert_case",
  "crc32fast",
  "data-encoding",
  "hex",
+ "lalrpop",
+ "lalrpop-util",
  "leb128",
+ "logos",
  "num-bigint",
  "num-traits",
  "num_enum",
@@ -87,21 +207,24 @@ dependencies = [
 
 [[package]]
 name = "candid_derive"
-version = "0.6.2"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "810b3bd60244f282090652ffc7c30a9d23892e72dfe443e46ee55569044f7dd5"
+checksum = "201ea498d901add0822653ac94cb0f8a92f9b1758a5273f4dafbb6673c9a5020"
 dependencies = [
  "lazy_static",
  "proc-macro2",
  "quote",
- "syn 2.0.29",
+ "syn 2.0.48",
 ]
 
 [[package]]
 name = "cc"
-version = "1.0.79"
+version = "1.0.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50d30906286121d95be3d479533b458f87493b30a4b5f79a607db8f5d11aa91f"
+checksum = "f1174fb0b6ec23863f8b971027804a42614e347eafb0a95bf0b12cdae21fc4d0"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "cfg-if"
@@ -158,6 +281,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "convert_case"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec182b0ca2f35d8fc196cf3404988fd8b8c739a4d270ff118a398feb0cbec1ca"
+dependencies = [
+ "unicode-segmentation",
+]
+
+[[package]]
+name = "core-foundation"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
+name = "core-foundation-sys"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06ea2b9bc92be3c2baa9334a323ebca2d6f074ff852cd1d7b11064035cd3868f"
+
+[[package]]
 name = "cpufeatures"
 version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -174,6 +322,27 @@ checksum = "b540bd8bc810d3885c6ea91e2018302f68baba2129ab3e88f32389ee9370880d"
 dependencies = [
  "cfg-if",
 ]
+
+[[package]]
+name = "crossbeam-channel"
+version = "0.5.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "176dc175b78f56c0f321911d9c8eb2b77a78a4860b9c19db83835fea1a46649b"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "248e3bacc7dc6baa3b21e405ee045c3047101a49145e7e9eca583ab4c2ca5345"
+
+[[package]]
+name = "crunchy"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7"
 
 [[package]]
 name = "crypto-common"
@@ -206,6 +375,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "deranged"
+version = "0.3.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b42b6fa04a440b495c8b04d0e71b707c585f83cb9cb28cf8cd0d976c315e31b4"
+dependencies = [
+ "powerfmt",
+]
+
+[[package]]
+name = "diff"
+version = "0.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56254986775e3233ffa9c4d7d3faaf6d36a2c09d30b20687e9f88bc8bafc16c8"
+
+[[package]]
 name = "digest"
 version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -216,16 +400,86 @@ dependencies = [
 ]
 
 [[package]]
+name = "dirs-next"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b98cf8ebf19c3d1b223e151f99a4f9f0690dca41414773390fc824184ac833e1"
+dependencies = [
+ "cfg-if",
+ "dirs-sys-next",
+]
+
+[[package]]
+name = "dirs-sys-next"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ebda144c4fe02d1f7ea1a7d9641b6fc6b580adcfa024ae48797ecdeb6825b4d"
+dependencies = [
+ "libc",
+ "redox_users",
+ "winapi",
+]
+
+[[package]]
 name = "either"
 version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7fcaabb2fef8c910e7f4c7ce9f67a1283a1715879a7c230ca9d6d1ae31f16d91"
 
 [[package]]
+name = "ena"
+version = "0.14.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c533630cf40e9caa44bd91aadc88a75d75a4c3a12b4cfde353cbed41daa1e1f1"
+dependencies = [
+ "log",
+]
+
+[[package]]
+name = "encoding_rs"
+version = "0.8.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7268b386296a025e474d5140678f75d6de9493ae55a5d709eeb9dd08149945e1"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "equivalent"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "88bffebc5d80432c9b140ee17875ff173a8ab62faad5b257da912bd2f6c1c0a1"
+
+[[package]]
+name = "errno"
+version = "0.3.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a258e46cdc063eb8519c00b9fc845fc47bcfca4130e2f08e88665ceda8474245"
+dependencies = [
+ "libc",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "fixedbitset"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
+
+[[package]]
+name = "fnv"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
+name = "form_urlencoded"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e13624c2627564efccf4934284bdd98cbaa14e79b0b5a141218e507b3a823456"
+dependencies = [
+ "percent-encoding",
+]
 
 [[package]]
 name = "futures"
@@ -283,7 +537,7 @@ checksum = "53b153fd91e4b0147f4aced87be237c98248656bb01050b96bf3ee89220a8ddb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.29",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -327,6 +581,42 @@ dependencies = [
 ]
 
 [[package]]
+name = "getrandom"
+version = "0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "190092ea657667030ac6a35e305e62fc4dd69fd98ac98631e5d3a2b1575a12b5"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi",
+]
+
+[[package]]
+name = "gimli"
+version = "0.28.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4271d37baee1b8c7e4b708028c57d816cf9d2434acb33a549475f78c181f6253"
+
+[[package]]
+name = "h2"
+version = "0.3.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb2c4422095b67ee78da96fbb51a4cc413b3b25883c7717ff7ca1ab31022c9c9"
+dependencies = [
+ "bytes",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "futures-util",
+ "http",
+ "indexmap",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
 name = "half"
 version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -339,10 +629,88 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2c6201b9ff9fd90a5a3bac2e56a830d0caa509576f0e503818ee82c181b3437a"
 
 [[package]]
+name = "hermit-abi"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d3d0e0f38255e7fa3cf31335b3a56f05febd18025f4db5ef7a0cfb4f8da651f"
+
+[[package]]
 name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
+name = "http"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8947b1a6fad4393052c7ba1f4cd97bed3e953a95c79c92ad9b051a04611d9fbb"
+dependencies = [
+ "bytes",
+ "fnv",
+ "itoa",
+]
+
+[[package]]
+name = "http-body"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ceab25649e9960c0311ea418d17bee82c0dcec1bd053b5f9a66e265a693bed2"
+dependencies = [
+ "bytes",
+ "http",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "httparse"
+version = "1.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d897f394bad6a705d5f4104762e116a75639e470d80901eed05a860a95cb1904"
+
+[[package]]
+name = "httpdate"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
+
+[[package]]
+name = "hyper"
+version = "0.14.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf96e135eb83a2a8ddf766e426a841d8ddd7449d5f00d34ea02b41d2f19eef80"
+dependencies = [
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "futures-util",
+ "h2",
+ "http",
+ "http-body",
+ "httparse",
+ "httpdate",
+ "itoa",
+ "pin-project-lite",
+ "socket2",
+ "tokio",
+ "tower-service",
+ "tracing",
+ "want",
+]
+
+[[package]]
+name = "hyper-rustls"
+version = "0.24.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec3efd23720e2049821a693cbc7e65ea87c72f1c58ff2f9522ff332b1491e590"
+dependencies = [
+ "futures-util",
+ "http",
+ "hyper",
+ "rustls",
+ "tokio",
+ "tokio-rustls",
+]
 
 [[package]]
 name = "ic-cdk"
@@ -410,6 +778,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "576c539151d4769fb4d1a0c25c4108dd18facd04c5695b02cf2d226ab4e43aa5"
 
 [[package]]
+name = "idna"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "634d9b1461af396cad843f47fdba5597a4f9e6ddd4bfb6ff5d85028c25cb12f6"
+dependencies = [
+ "unicode-bidi",
+ "unicode-normalization",
+]
+
+[[package]]
 name = "indexmap"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -440,8 +818,82 @@ dependencies = [
  "candid",
  "ic-cdk",
  "ic-test-state-machine-client",
+ "pocket-ic",
  "shared_utils",
  "test_utils",
+]
+
+[[package]]
+name = "ipnet"
+version = "2.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f518f335dce6725a761382244631d86cf0ccb2863413590b31338feb467f9c3"
+
+[[package]]
+name = "is-terminal"
+version = "0.4.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bad00257d07be169d870ab665980b06cdb366d792ad690bf2e76876dc503455"
+dependencies = [
+ "hermit-abi",
+ "rustix",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "itertools"
+version = "0.10.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itoa"
+version = "1.0.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1a46d1a171d865aa5f83f92695765caa047a9b4cbae2cbf37dbd613a793fd4c"
+
+[[package]]
+name = "js-sys"
+version = "0.3.67"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a1d36f1235bc969acba30b7f5990b864423a6068a10f7c90ae8f0112e3a59d1"
+dependencies = [
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "lalrpop"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da4081d44f4611b66c6dd725e6de3169f9f63905421e8626fcb86b6a898998b8"
+dependencies = [
+ "ascii-canvas",
+ "bit-set",
+ "diff",
+ "ena",
+ "is-terminal",
+ "itertools",
+ "lalrpop-util",
+ "petgraph",
+ "pico-args",
+ "regex",
+ "regex-syntax 0.7.5",
+ "string_cache",
+ "term",
+ "tiny-keccak",
+ "unicode-xid",
+]
+
+[[package]]
+name = "lalrpop-util"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f35c735096c0293d313e8f2a641627472b83d01b937177fe76e5e2708d31e0d"
+dependencies = [
+ "regex",
 ]
 
 [[package]]
@@ -463,10 +915,136 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "302d7ab3130588088d277783b1e2d2e10c9e9e4a16dd9050e6ec93fb3e7048f4"
 
 [[package]]
+name = "libredox"
+version = "0.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85c833ca1e66078851dba29046874e38f08b2c883700aa29a03ddd3b23814ee8"
+dependencies = [
+ "bitflags 2.4.2",
+ "libc",
+ "redox_syscall",
+]
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "01cda141df6706de531b6c46c3a33ecca755538219bd484262fa09410c13539c"
+
+[[package]]
+name = "lock_api"
+version = "0.4.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c168f8615b12bc01f9c17e2eb0cc07dcae1940121185446edc3744920e8ef45"
+dependencies = [
+ "autocfg",
+ "scopeguard",
+]
+
+[[package]]
+name = "log"
+version = "0.4.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5e6163cb8c49088c2c36f57875e58ccd8c87c7427f7fbd50ea6710b2f3f2e8f"
+
+[[package]]
+name = "logos"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c000ca4d908ff18ac99b93a062cb8958d331c3220719c52e77cb19cc6ac5d2c1"
+dependencies = [
+ "logos-derive",
+]
+
+[[package]]
+name = "logos-codegen"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc487311295e0002e452025d6b580b77bb17286de87b57138f3b5db711cded68"
+dependencies = [
+ "beef",
+ "fnv",
+ "proc-macro2",
+ "quote",
+ "regex-syntax 0.6.29",
+ "syn 2.0.48",
+]
+
+[[package]]
+name = "logos-derive"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbfc0d229f1f42d790440136d941afd806bc9e949e2bcb8faa813b0f00d1267e"
+dependencies = [
+ "logos-codegen",
+]
+
+[[package]]
+name = "matchers"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8263075bb86c5a1b1427b5ae862e8889656f126e9f77c484496e8b47cf5c5558"
+dependencies = [
+ "regex-automata 0.1.10",
+]
+
+[[package]]
 name = "memchr"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
+
+[[package]]
+name = "mime"
+version = "0.3.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
+
+[[package]]
+name = "mime_guess"
+version = "2.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4192263c238a5f0d0c6bfd21f336a313a4ce1c450542449ca191bb657b4642ef"
+dependencies = [
+ "mime",
+ "unicase",
+]
+
+[[package]]
+name = "miniz_oxide"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d811f3e15f28568be3407c8e7fdb6514c1cda3cb30683f15b6a1a1dc4ea14a7"
+dependencies = [
+ "adler",
+]
+
+[[package]]
+name = "mio"
+version = "0.8.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f3d0b296e374a4e6f3c7b0a1f5a51d748a0d34c85e7dc48fc3fa9a87657fe09"
+dependencies = [
+ "libc",
+ "wasi",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "new_debug_unreachable"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e4a24736216ec316047a1fc4252e27dabb04218aa4a3f37c6e7ddbf1f9782b54"
+
+[[package]]
+name = "nu-ansi-term"
+version = "0.46.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77a8165726e8236064dbb45459242600304b42a5ea24ee2948e18e023bf7ba84"
+dependencies = [
+ "overload",
+ "winapi",
+]
 
 [[package]]
 name = "num-bigint"
@@ -479,6 +1057,12 @@ dependencies = [
  "num-traits",
  "serde",
 ]
+
+[[package]]
+name = "num-conv"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
 
 [[package]]
 name = "num-integer"
@@ -500,6 +1084,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "num_cpus"
+version = "1.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4161fcb6d602d4d2081af7c3a45852d875a03dd337a6bfdd6e06407b61342a43"
+dependencies = [
+ "hermit-abi",
+ "libc",
+]
+
+[[package]]
 name = "num_enum"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -517,7 +1111,16 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.29",
+ "syn 2.0.48",
+]
+
+[[package]]
+name = "object"
+version = "0.32.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6a622008b6e321afc04970976f62ee297fdbaa6f95318ca343e3eebb9648441"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]
@@ -527,10 +1130,70 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd8b5dd2ae5ed71462c540258bedcb51965123ad7e7ccf4b9a8cafaa4a63576d"
 
 [[package]]
+name = "overload"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
+
+[[package]]
+name = "parking_lot"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3742b2c103b9f06bc9fff0a37ff4912935851bee6d36f3c02bcc755bcfec228f"
+dependencies = [
+ "lock_api",
+ "parking_lot_core",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.9.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c42a9226546d68acdd9c0a280d17ce19bfe27a46bf68784e4066115788d008e"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_syscall",
+ "smallvec",
+ "windows-targets 0.48.5",
+]
+
+[[package]]
 name = "paste"
 version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f746c4065a8fa3fe23974dd82f15431cc8d40779821001404d10d2e79ca7d79"
+
+[[package]]
+name = "percent-encoding"
+version = "2.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
+
+[[package]]
+name = "petgraph"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1d3afd2628e69da2be385eb6f2fd57c8ac7977ceeff6dc166ff1657b0e386a9"
+dependencies = [
+ "fixedbitset",
+ "indexmap",
+]
+
+[[package]]
+name = "phf_shared"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6796ad771acdc0123d2a88dc428b5e38ef24456743ddb1744ed628f9815c096"
+dependencies = [
+ "siphasher",
+]
+
+[[package]]
+name = "pico-args"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5be167a7af36ee22fe3115051bc51f6e6c7054c9348e28deb4f49bd6f705a315"
 
 [[package]]
 name = "pin-project-lite"
@@ -545,6 +1208,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
+name = "pocket-ic"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce4c698117a4cc5fce56a909db4fce965003f041c1bf916b7cd8a6757b017586"
+dependencies = [
+ "async-trait",
+ "base64 0.13.1",
+ "candid",
+ "hex",
+ "ic-cdk",
+ "reqwest",
+ "serde",
+ "serde_bytes",
+ "serde_json",
+ "tracing",
+ "tracing-appender",
+ "tracing-subscriber",
+]
+
+[[package]]
 name = "post_cache"
 version = "0.1.0"
 dependencies = [
@@ -555,6 +1238,18 @@ dependencies = [
  "shared_utils",
  "test_utils",
 ]
+
+[[package]]
+name = "powerfmt"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
+
+[[package]]
+name = "precomputed-hash"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "925383efa346730478fb4838dbe9137d2a47675ad789c546d150a6e1dd4ab31c"
 
 [[package]]
 name = "pretty"
@@ -579,9 +1274,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.63"
+version = "1.0.78"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b368fba921b0dce7e60f5e04ec15e565b3303972b42bcfde1d0713b881959eb"
+checksum = "e2422ad645d89c99f8f3e6b88a9fdeca7fabeac836b1002371c4367c8f984aae"
 dependencies = [
  "unicode-ident",
 ]
@@ -597,11 +1292,133 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.29"
+version = "1.0.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "573015e8ab27661678357f27dc26460738fd2b6c86e46f386fde94cb5d913105"
+checksum = "291ec9ab5efd934aaf503a6466c5d5251535d108ee747472c3977cc5acc868ef"
 dependencies = [
  "proc-macro2",
+]
+
+[[package]]
+name = "redox_syscall"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4722d768eff46b75989dd134e5c353f0d6296e5aaa3132e776cbdb56be7731aa"
+dependencies = [
+ "bitflags 1.3.2",
+]
+
+[[package]]
+name = "redox_users"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a18479200779601e498ada4e8c1e1f50e3ee19deb0259c25825a98b5603b2cb4"
+dependencies = [
+ "getrandom",
+ "libredox",
+ "thiserror",
+]
+
+[[package]]
+name = "regex"
+version = "1.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12de2eff854e5fa4b1295edd650e227e9d8fb0c9e90b12e7f36d6a6811791a29"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata 0.3.7",
+ "regex-syntax 0.7.5",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c230d73fb8d8c1b9c0b3135c5142a8acee3a0558fb8db5cf1cb65f8d7862132"
+dependencies = [
+ "regex-syntax 0.6.29",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49530408a136e16e5b486e883fbb6ba058e8e4e8ae6621a77b048b314336e629"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax 0.7.5",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.6.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
+
+[[package]]
+name = "regex-syntax"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbb5fb1acd8a1a18b3dd5be62d25485eb770e05afb408a9627d14d451bae12da"
+
+[[package]]
+name = "reqwest"
+version = "0.11.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6920094eb85afde5e4a138be3f2de8bbdf28000f0029e72c45025a56b042251"
+dependencies = [
+ "base64 0.21.7",
+ "bytes",
+ "encoding_rs",
+ "futures-core",
+ "futures-util",
+ "h2",
+ "http",
+ "http-body",
+ "hyper",
+ "hyper-rustls",
+ "ipnet",
+ "js-sys",
+ "log",
+ "mime",
+ "mime_guess",
+ "once_cell",
+ "percent-encoding",
+ "pin-project-lite",
+ "rustls",
+ "rustls-pemfile",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "system-configuration",
+ "tokio",
+ "tokio-rustls",
+ "tokio-util",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "wasm-streams",
+ "web-sys",
+ "webpki-roots",
+ "winreg",
+]
+
+[[package]]
+name = "ring"
+version = "0.17.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "688c63d65483050968b2a8937f7995f443e27041a0f7700aa59b0822aedebb74"
+dependencies = [
+ "cc",
+ "getrandom",
+ "libc",
+ "spin",
+ "untrusted",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -627,16 +1444,88 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustc-demangle"
+version = "0.1.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d626bb9dae77e28219937af045c257c28bfd3f69333c512553507f5f9798cb76"
+
+[[package]]
+name = "rustix"
+version = "0.38.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72e572a5e8ca657d7366229cdde4bd14c4eb5499a9573d4d366fe1b599daa316"
+dependencies = [
+ "bitflags 2.4.2",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "rustls"
+version = "0.21.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9d5a6813c0759e4609cd494e8e725babae6a2ca7b62a5536a13daaec6fcb7ba"
+dependencies = [
+ "log",
+ "ring",
+ "rustls-webpki",
+ "sct",
+]
+
+[[package]]
+name = "rustls-pemfile"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c74cae0a4cf6ccbbf5f359f08efdf8ee7e1dc532573bf0db71968cb56b1448c"
+dependencies = [
+ "base64 0.21.7",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.101.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b6275d1ee7a1cd780b64aca7726599a1dbc893b1e64144529e55c3c2f745765"
+dependencies = [
+ "ring",
+ "untrusted",
+]
+
+[[package]]
 name = "rustversion"
 version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4f3208ce4d8448b3f3e7d168a73f5e0c43a61e32930de3bceeccedb388b6bf06"
 
 [[package]]
-name = "serde"
-version = "1.0.186"
+name = "ryu"
+version = "1.0.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f5db24220c009de9bd45e69fb2938f4b6d2df856aa9304ce377b3180f83b7c1"
+checksum = "f98d2aa92eebf49b69786be48e4477826b256916e84a57ff2a4f21923b48eb4c"
+
+[[package]]
+name = "scopeguard"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "sct"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da046153aa2352493d6cb7da4b6e5c0c057d8a1d0a9aa8560baffdd945acd414"
+dependencies = [
+ "ring",
+ "untrusted",
+]
+
+[[package]]
+name = "serde"
+version = "1.0.196"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "870026e60fa08c69f064aa766c10f10b1d62db9ccd4d0abb206472bee0ce3b32"
 dependencies = [
  "serde_derive",
 ]
@@ -652,13 +1541,24 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.186"
+version = "1.0.196"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ad697f7e0b65af4983a4ce8f56ed5b357e8d3c36651bf6a7e13639c17b8e670"
+checksum = "33c85360c95e7d137454dc81d9a4ed2b8efd8fbe19cee57357b32b9771fccb67"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.29",
+ "syn 2.0.48",
+]
+
+[[package]]
+name = "serde_json"
+version = "1.0.113"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69801b70b1c3dac963ecb03a364ba0ceda9cf60c71cfe475e99864759c8b8a79"
+dependencies = [
+ "itoa",
+ "ryu",
+ "serde",
 ]
 
 [[package]]
@@ -673,6 +1573,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_urlencoded"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
+dependencies = [
+ "form_urlencoded",
+ "itoa",
+ "ryu",
+ "serde",
+]
+
+[[package]]
 name = "sha2"
 version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -681,6 +1593,15 @@ dependencies = [
  "cfg-if",
  "cpufeatures",
  "digest",
+]
+
+[[package]]
+name = "sharded-slab"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
+dependencies = [
+ "lazy_static",
 ]
 
 [[package]]
@@ -696,6 +1617,12 @@ dependencies = [
  "serde",
  "test_utils",
 ]
+
+[[package]]
+name = "siphasher"
+version = "0.3.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38b58827f4464d87d377d175e90bf58eb00fd8716ff0a62f80356b5e61555d0d"
 
 [[package]]
 name = "slab"
@@ -716,6 +1643,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "smallvec"
+version = "1.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6ecd384b10a64542d77071bd64bd7b231f4ed5940fba55e98c3de13824cf3d7"
+
+[[package]]
+name = "socket2"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b5fac59a5cb5dd637972e5fca70daf0523c9067fcdc4842f053dae04a18f8e9"
+dependencies = [
+ "libc",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "spin"
+version = "0.9.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+
+[[package]]
 name = "stacker"
 version = "0.1.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -726,6 +1675,19 @@ dependencies = [
  "libc",
  "psm",
  "winapi",
+]
+
+[[package]]
+name = "string_cache"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f91138e76242f575eb1d3b38b4f1362f10d3a43f47d182a5b359af488a02293b"
+dependencies = [
+ "new_debug_unreachable",
+ "once_cell",
+ "parking_lot",
+ "phf_shared",
+ "precomputed-hash",
 ]
 
 [[package]]
@@ -741,13 +1703,51 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.29"
+version = "2.0.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c324c494eba9d92503e6f1ef2e6df781e78f6a7705a0202d9801b198807d518a"
+checksum = "0f3531638e407dfc0814761abb7c00a5b54992b849452a0646b7f65c9f770f3f"
 dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "sync_wrapper"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2047c6ded9c721764247e62cd3b03c09ffc529b2ba5b10ec482ae507a4a70160"
+
+[[package]]
+name = "system-configuration"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba3a3adc5c275d719af8cb4272ea1c4a6d668a777f37e115f6d11ddbc1c8e0e7"
+dependencies = [
+ "bitflags 1.3.2",
+ "core-foundation",
+ "system-configuration-sys",
+]
+
+[[package]]
+name = "system-configuration-sys"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a75fb188eb626b924683e3b95e3a48e63551fcfb51949de2f06a9d91dbee93c9"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
+name = "term"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c59df8ac95d96ff9bede18eb7300b0fda5e5d8d90960e76f8e14ae765eedbf1f"
+dependencies = [
+ "dirs-next",
+ "rustversion",
+ "winapi",
 ]
 
 [[package]]
@@ -786,7 +1786,112 @@ checksum = "f9456a42c5b0d803c8cd86e73dd7cc9edd429499f37a3550d286d5e86720569f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.29",
+ "syn 2.0.48",
+]
+
+[[package]]
+name = "thread_local"
+version = "1.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3fdd6f064ccff2d6567adcb3873ca630700f00b5ad3f060c25b5dcfd9a4ce152"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+]
+
+[[package]]
+name = "time"
+version = "0.3.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8248b6521bb14bc45b4067159b9b6ad792e2d6d754d6c41fb50e29fefe38749"
+dependencies = [
+ "deranged",
+ "itoa",
+ "num-conv",
+ "powerfmt",
+ "serde",
+ "time-core",
+ "time-macros",
+]
+
+[[package]]
+name = "time-core"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef927ca75afb808a4d64dd374f00a2adf8d0fcff8e7b184af886c3c87ec4a3f3"
+
+[[package]]
+name = "time-macros"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ba3a3ef41e6672a2f0f001392bb5dcd3ff0a9992d618ca761a11c3121547774"
+dependencies = [
+ "num-conv",
+ "time-core",
+]
+
+[[package]]
+name = "tiny-keccak"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c9d3793400a45f954c52e73d068316d76b6f4e36977e3fcebb13a2721e80237"
+dependencies = [
+ "crunchy",
+]
+
+[[package]]
+name = "tinyvec"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87cc5ceb3875bb20c2890005a4e226a4651264a5c75edb2421b52861a0a0cb50"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
+
+[[package]]
+name = "tokio"
+version = "1.36.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61285f6515fa018fb2d1e46eb21223fff441ee8db5d0f1435e8ab4f5cdb80931"
+dependencies = [
+ "backtrace",
+ "bytes",
+ "libc",
+ "mio",
+ "num_cpus",
+ "pin-project-lite",
+ "socket2",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "tokio-rustls"
+version = "0.24.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c28327cf380ac148141087fbfb9de9d7bd4e84ab5d2c28fbc911d753de8a7081"
+dependencies = [
+ "rustls",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-util"
+version = "0.7.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5419f34732d9eb6ee4c3578b7989078579b7f039cbbb9ca2c4da015749371e15"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "futures-sink",
+ "pin-project-lite",
+ "tokio",
+ "tracing",
 ]
 
 [[package]]
@@ -807,6 +1912,91 @@ dependencies = [
 ]
 
 [[package]]
+name = "tower-service"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6bc1c9ce2b5135ac7f93c72918fc37feb872bdc6a5533a8b85eb4b86bfdae52"
+
+[[package]]
+name = "tracing"
+version = "0.1.40"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3523ab5a71916ccf420eebdf5521fcef02141234bbc0b8a49f2fdc4544364ef"
+dependencies = [
+ "pin-project-lite",
+ "tracing-attributes",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-appender"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3566e8ce28cc0a3fe42519fc80e6b4c943cc4c8cef275620eb8dac2d3d4e06cf"
+dependencies = [
+ "crossbeam-channel",
+ "thiserror",
+ "time",
+ "tracing-subscriber",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.48",
+]
+
+[[package]]
+name = "tracing-core"
+version = "0.1.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c06d3da6113f116aaee68e4d601191614c9053067f9ab7f6edbcb161237daa54"
+dependencies = [
+ "once_cell",
+ "valuable",
+]
+
+[[package]]
+name = "tracing-log"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
+dependencies = [
+ "log",
+ "once_cell",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.3.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad0f048c97dbd9faa9b7df56362b8ebcaa52adb06b498c050d2f4e32f90a7a8b"
+dependencies = [
+ "matchers",
+ "nu-ansi-term",
+ "once_cell",
+ "regex",
+ "sharded-slab",
+ "smallvec",
+ "thread_local",
+ "tracing",
+ "tracing-core",
+ "tracing-log",
+]
+
+[[package]]
+name = "try-lock"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
+
+[[package]]
 name = "typed-arena"
 version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -819,10 +2009,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "497961ef93d974e23eb6f433eb5fe1b7930b659f06d12dec6fc44a8f554c0bba"
 
 [[package]]
+name = "unicase"
+version = "2.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7d2d4dafb69621809a81864c9c1b864479e1235c0dd4e199924b9742439ed89"
+dependencies = [
+ "version_check",
+]
+
+[[package]]
+name = "unicode-bidi"
+version = "0.3.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08f95100a766bf4f8f28f90d77e0a5461bbdb219042e7679bebe79004fed8d75"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b15811caf2415fb889178633e7724bad2509101cde276048e013b9def5e51fa0"
+
+[[package]]
+name = "unicode-normalization"
+version = "0.1.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c5713f0fc4b5db668a2ac63cdb7bb4469d8c9fed047b1d0292cc7b0ce2ba921"
+dependencies = [
+ "tinyvec",
+]
 
 [[package]]
 name = "unicode-segmentation"
@@ -837,6 +2051,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0edd1e5b14653f783770bce4a4dabb4a5108a5370a5f5d8cfe8710c361f6c8b"
 
 [[package]]
+name = "unicode-xid"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f962df74c8c05a667b5ee8bcf162993134c104e96440b663c8daa176dc772d8c"
+
+[[package]]
+name = "untrusted"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
+
+[[package]]
+name = "url"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "31e6302e3bb753d46e83516cae55ae196fc0c309407cf11ab35cc51a4c2a4633"
+dependencies = [
+ "form_urlencoded",
+ "idna",
+ "percent-encoding",
+]
+
+[[package]]
 name = "user_index"
 version = "0.1.0"
 dependencies = [
@@ -849,10 +2086,126 @@ dependencies = [
 ]
 
 [[package]]
+name = "valuable"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "830b7e5d4d90034032940e4ace0d9a9a057e7a45cd94e6c007832e39edb82f6d"
+
+[[package]]
 name = "version_check"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
+
+[[package]]
+name = "want"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfa7760aed19e106de2c7c0b581b509f2f25d3dacaf737cb82ac61bc6d760b0e"
+dependencies = [
+ "try-lock",
+]
+
+[[package]]
+name = "wasi"
+version = "0.11.0+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
+
+[[package]]
+name = "wasm-bindgen"
+version = "0.2.90"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1223296a201415c7fad14792dbefaace9bd52b62d33453ade1c5b5f07555406"
+dependencies = [
+ "cfg-if",
+ "wasm-bindgen-macro",
+]
+
+[[package]]
+name = "wasm-bindgen-backend"
+version = "0.2.90"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fcdc935b63408d58a32f8cc9738a0bffd8f05cc7c002086c6ef20b7312ad9dcd"
+dependencies = [
+ "bumpalo",
+ "log",
+ "once_cell",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.48",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-futures"
+version = "0.4.40"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bde2032aeb86bdfaecc8b261eef3cba735cc426c1f3a3416d1e0791be95fc461"
+dependencies = [
+ "cfg-if",
+ "js-sys",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.90"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e4c238561b2d428924c49815533a8b9121c664599558a5d9ec51f8a1740a999"
+dependencies = [
+ "quote",
+ "wasm-bindgen-macro-support",
+]
+
+[[package]]
+name = "wasm-bindgen-macro-support"
+version = "0.2.90"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bae1abb6806dc1ad9e560ed242107c0f6c84335f1749dd4e8ddb012ebd5e25a7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.48",
+ "wasm-bindgen-backend",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-shared"
+version = "0.2.90"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d91413b1c31d7539ba5ef2451af3f0b833a005eb27a631cec32bc0635a8602b"
+
+[[package]]
+name = "wasm-streams"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b65dc4c90b63b118468cf747d8bf3566c1913ef60be765b5730ead9e0a3ba129"
+dependencies = [
+ "futures-util",
+ "js-sys",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+]
+
+[[package]]
+name = "web-sys"
+version = "0.3.67"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "58cd2333b6e0be7a39605f0e255892fd7418a682d8da8fe042fe25128794d2ed"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "0.25.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f20c57d8d7db6d3b86154206ae5d8fba62dd39573114de97c2cb0578251f8e1"
 
 [[package]]
 name = "winapi"
@@ -886,10 +2239,152 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
+name = "windows-sys"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
+dependencies = [
+ "windows-targets 0.48.5",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets 0.52.0",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
+dependencies = [
+ "windows_aarch64_gnullvm 0.48.5",
+ "windows_aarch64_msvc 0.48.5",
+ "windows_i686_gnu 0.48.5",
+ "windows_i686_msvc 0.48.5",
+ "windows_x86_64_gnu 0.48.5",
+ "windows_x86_64_gnullvm 0.48.5",
+ "windows_x86_64_msvc 0.48.5",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a18201040b24831fbb9e4eb208f8892e1f50a37feb53cc7ff887feb8f50e7cd"
+dependencies = [
+ "windows_aarch64_gnullvm 0.52.0",
+ "windows_aarch64_msvc 0.52.0",
+ "windows_i686_gnu 0.52.0",
+ "windows_i686_msvc 0.52.0",
+ "windows_x86_64_gnu 0.52.0",
+ "windows_x86_64_gnullvm 0.52.0",
+ "windows_x86_64_msvc 0.52.0",
+]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb7764e35d4db8a7921e09562a0304bf2f93e0a51bfccee0bd0bb0b666b015ea"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbaa0368d4f1d2aaefc55b6fcfee13f41544ddf36801e793edbbfd7d7df075ef"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a28637cb1fa3560a16915793afb20081aba2c92ee8af57b4d5f28e4b3e7df313"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ffe5e8e31046ce6230cc7215707b816e339ff4d4d67c65dffa206fd0f7aa7b9a"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d6fa32db2bc4a2f5abeacf2b69f7992cd09dca97498da74a151a3132c26befd"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a657e1e9d3f514745a572a6846d3c7aa7dbe1658c056ed9c3344c4109a6949e"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dff9641d1cd4be8d1a070daf9e3773c5f67e78b4d9d42263020c057706765c04"
+
+[[package]]
 name = "winnow"
 version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ca0ace3845f0d96209f0375e6d367e3eb87eb65d27d445bdc9f1843a26f39448"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "winreg"
+version = "0.50.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "524e57b2c537c0f9b1e69f1965311ec12182b4122e45035b1508cd24d2adadb1"
+dependencies = [
+ "cfg-if",
+ "windows-sys 0.48.0",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -819,6 +819,7 @@ dependencies = [
  "ic-cdk",
  "ic-test-state-machine-client",
  "pocket-ic",
+ "serde",
  "shared_utils",
  "test_utils",
 ]

--- a/scripts/canisters/local_deploy/install_all_canisters.sh
+++ b/scripts/canisters/local_deploy/install_all_canisters.sh
@@ -1,9 +1,9 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-usage() { 
-  printf "Usage: \n[-s Skip test] \n[-h Display help] \n"; 
-  exit 0; 
+usage() {
+  printf "Usage: \n[-s Skip test] \n[-h Display help] \n";
+  exit 0;
 }
 
 skip_test=false
@@ -13,7 +13,7 @@ while getopts "sih" arg; do
     s)
       skip_test=true
       ;;
-    h) 
+    h)
       usage
       ;;
   esac
@@ -31,8 +31,9 @@ dfx build configuration
 dfx build data_backup
 dfx build user_index
 dfx build post_cache
+gzip -f -1 ./target/wasm32-unknown-unknown/release/post_cache.wasm
 
-if [[ $skip_test != true ]] 
+if [[ $skip_test != true ]]
 then
   cargo test
 fi

--- a/scripts/canisters/local_deploy/upgrade_all_canisters.sh
+++ b/scripts/canisters/local_deploy/upgrade_all_canisters.sh
@@ -1,9 +1,9 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-usage() { 
-  printf "Usage: \n[-s Skip test] \n[-h Display help] \n"; 
-  exit 0; 
+usage() {
+  printf "Usage: \n[-s Skip test] \n[-h Display help] \n";
+  exit 0;
 }
 
 skip_test=false
@@ -13,7 +13,7 @@ while getopts "sh" arg; do
     s)
       skip_test=true
       ;;
-    h) 
+    h)
       usage
       ;;
   esac
@@ -26,14 +26,16 @@ dfx build data_backup
 dfx build user_index
 dfx build post_cache
 
-if [[ $skip_test != true ]] 
+if [[ $skip_test != true ]]
 then
   cargo test
 fi
 
 dfx canister install configuration --mode upgrade --argument "(record {})"
 dfx canister install data_backup --mode upgrade --argument "(record {})"
-dfx canister install post_cache --mode upgrade --argument "(record {})"
+dfx canister install post_cache --mode upgrade --argument "(record {
+    version= \"v1.1.0\"
+})"
 dfx canister install user_index --mode upgrade --argument "(record {
   version= \"v1.1.0\"
 })"

--- a/scripts/canisters/local_deploy/upgrade_all_canisters.sh
+++ b/scripts/canisters/local_deploy/upgrade_all_canisters.sh
@@ -25,6 +25,7 @@ dfx build configuration
 dfx build data_backup
 dfx build user_index
 dfx build post_cache
+gzip -f -1 ./target/wasm32-unknown-unknown/release/post_cache.wasm
 
 if [[ $skip_test != true ]]
 then

--- a/src/canister/data_backup/src/api/individual_user_backup/receive_all_user_posts_from_individual_user_canister.rs
+++ b/src/canister/data_backup/src/api/individual_user_backup/receive_all_user_posts_from_individual_user_canister.rs
@@ -68,12 +68,15 @@ fn receive_all_user_posts_from_individual_user_canister_impl(
 mod test {
     use std::{collections::HashSet, time::SystemTime};
 
-    use shared_utils::canister_specific::{
-        data_backup::types::all_user_data::{AllUserData, UserOwnedCanisterData},
-        individual_user_template::types::{
-            hot_or_not::HotOrNotDetails,
-            post::{FeedScore, PostStatus, PostViewStatistics},
+    use shared_utils::{
+        canister_specific::{
+            data_backup::types::all_user_data::{AllUserData, UserOwnedCanisterData},
+            individual_user_template::types::{
+                hot_or_not::HotOrNotDetails,
+                post::{FeedScore, PostViewStatistics},
+            },
         },
+        common::types::top_posts::post_score_index_item::PostStatus,
     };
     use test_utils::setup::test_constants::{
         get_mock_user_alice_canister_id, get_mock_user_alice_principal_id,

--- a/src/canister/individual_user_template/can.did
+++ b/src/canister/individual_user_template/can.did
@@ -277,6 +277,9 @@ service : (IndividualUserTemplateInitArgs) -> {
   add_post_v2 : (PostDetailsFromFrontend) -> (Result);
   backup_data_to_backup_canister : (principal, principal) -> ();
   bet_on_currently_viewing_post : (PlaceBetArg) -> (Result_1);
+  check_and_update_scores_and_share_with_post_cache_if_difference_beyond_threshold : (
+      vec nat64,
+    ) -> ();
   do_i_follow_this_user : (FolloweeArg) -> (Result_2) query;
   get_entire_individual_post_detail_by_id : (nat64) -> (Result_3) query;
   get_hot_or_not_bet_details_for_this_post : (nat64) -> (BettingStatus) query;

--- a/src/canister/individual_user_template/src/api/hot_or_not_bet/get_hot_or_not_bet_details_for_this_post.rs
+++ b/src/canister/individual_user_template/src/api/hot_or_not_bet/get_hot_or_not_bet_details_for_this_post.rs
@@ -43,9 +43,12 @@ mod test {
         time::{Duration, SystemTime},
     };
 
-    use shared_utils::canister_specific::individual_user_template::types::{
-        hot_or_not::HotOrNotDetails,
-        post::{FeedScore, Post, PostStatus, PostViewStatistics},
+    use shared_utils::{
+        canister_specific::individual_user_template::types::{
+            hot_or_not::HotOrNotDetails,
+            post::{FeedScore, Post, PostViewStatistics},
+        },
+        common::types::top_posts::post_score_index_item::PostStatus,
     };
 
     use super::*;

--- a/src/canister/individual_user_template/src/api/hot_or_not_bet/reenqueue_timers_for_pending_bet_outcomes.rs
+++ b/src/canister/individual_user_template/src/api/hot_or_not_bet/reenqueue_timers_for_pending_bet_outcomes.rs
@@ -80,9 +80,12 @@ fn reenqueue_timers_for_these_posts(
 mod test {
     use std::collections::HashSet;
 
-    use shared_utils::canister_specific::individual_user_template::types::{
-        hot_or_not::HotOrNotDetails,
-        post::{FeedScore, Post, PostStatus, PostViewStatistics},
+    use shared_utils::{
+        canister_specific::individual_user_template::types::{
+            hot_or_not::HotOrNotDetails,
+            post::{FeedScore, Post, PostViewStatistics},
+        },
+        common::types::top_posts::post_score_index_item::PostStatus,
     };
 
     use super::*;

--- a/src/canister/individual_user_template/src/api/post/mod.rs
+++ b/src/canister/individual_user_template/src/api/post/mod.rs
@@ -2,6 +2,7 @@ pub mod add_post_v2;
 pub mod get_entire_individual_post_detail_by_id;
 pub mod get_individual_post_details_by_id;
 pub mod get_posts_of_this_user_profile_with_pagination;
+pub mod send_update_post_cache;
 pub mod update_post_add_view_details;
 pub mod update_post_as_ready_to_view;
 pub mod update_post_increment_share_count;

--- a/src/canister/individual_user_template/src/api/post/send_update_post_cache.rs
+++ b/src/canister/individual_user_template/src/api/post/send_update_post_cache.rs
@@ -1,16 +1,30 @@
-use ic_cdk::api::call;
-use shared_utils::common::types::known_principal::KnownPrincipalType;
+use std::time::SystemTime;
 
-use crate::CANISTER_DATA;
+use candid::Principal;
+use ic_cdk::api::call;
+use shared_utils::common::{
+    types::{
+        known_principal::KnownPrincipalType, top_posts::post_score_index_item::PostScoreIndexItemV1,
+    },
+    utils::system_time,
+};
+
+use crate::{data_model::CanisterData, CANISTER_DATA};
 
 pub fn send_update_post_cache(post_id: &u64) {
-    let post_item = CANISTER_DATA.with(|canister_data_ref_cell| {
-        canister_data_ref_cell
-            .borrow()
-            .all_created_posts
-            .get(&post_id)
-            .cloned()
-            .unwrap()
+    let current_time = system_time::get_current_system_time();
+    let canisters_own_principal_id = ic_cdk::id();
+
+    let (home_feed_index_score_item, hot_or_not_index_score_item): (
+        Option<PostScoreIndexItemV1>,
+        Option<PostScoreIndexItemV1>,
+    ) = CANISTER_DATA.with(|canister_data_ref_cell| {
+        update_local_cache_get_items(
+            &mut canister_data_ref_cell.borrow_mut(),
+            *post_id,
+            current_time,
+            canisters_own_principal_id,
+        )
     });
 
     let post_cache_canister_principal_id = CANISTER_DATA.with(|canister_data_ref_cell| {
@@ -25,12 +39,78 @@ pub fn send_update_post_cache(post_id: &u64) {
     let _ = call::notify(
         post_cache_canister_principal_id,
         "update_post_home_feed",
-        (post_item.clone(),),
+        (home_feed_index_score_item.unwrap(),),
     );
 
     let _ = call::notify(
         post_cache_canister_principal_id,
         "update_post_hot_or_not_feed",
-        (post_item,),
+        (hot_or_not_index_score_item.unwrap(),),
     );
+}
+
+pub fn update_local_cache_get_items(
+    canister_data: &mut CanisterData,
+    post_id: u64,
+    current_time: SystemTime,
+    canisters_own_principal_id: Principal,
+) -> (Option<PostScoreIndexItemV1>, Option<PostScoreIndexItemV1>) {
+    let all_posts = &mut canister_data.all_created_posts;
+    if !all_posts.contains_key(&post_id) {
+        return (None, None);
+    }
+    let mut home_feed_index_score_item: Option<PostScoreIndexItemV1> = None;
+    let mut hot_or_not_index_score_item: Option<PostScoreIndexItemV1> = None;
+
+    let mut post_to_synchronise = all_posts.get(&post_id).unwrap().clone();
+
+    post_to_synchronise.recalculate_home_feed_score(&current_time);
+
+    let current_home_feed_score = post_to_synchronise.home_feed_score.current_score;
+
+    home_feed_index_score_item = Some(PostScoreIndexItemV1 {
+        post_id: post_to_synchronise.id,
+        score: current_home_feed_score,
+        publisher_canister_id: canisters_own_principal_id,
+        is_nsfw: post_to_synchronise.is_nsfw,
+        status: post_to_synchronise.status,
+        created_at: Some(post_to_synchronise.created_at),
+    });
+    post_to_synchronise.home_feed_score.last_synchronized_score = current_home_feed_score;
+    post_to_synchronise.home_feed_score.last_synchronized_at = current_time;
+
+    if post_to_synchronise.hot_or_not_details.is_some() {
+        post_to_synchronise.recalculate_hot_or_not_feed_score(&current_time);
+        let current_hot_or_not_feed_score = post_to_synchronise
+            .hot_or_not_details
+            .as_ref()
+            .unwrap()
+            .hot_or_not_feed_score
+            .current_score;
+
+        hot_or_not_index_score_item = Some(PostScoreIndexItemV1 {
+            post_id: post_to_synchronise.id,
+            score: current_hot_or_not_feed_score,
+            publisher_canister_id: canisters_own_principal_id,
+            is_nsfw: post_to_synchronise.is_nsfw,
+            status: post_to_synchronise.status,
+            created_at: Some(post_to_synchronise.created_at),
+        });
+        post_to_synchronise
+            .hot_or_not_details
+            .as_mut()
+            .unwrap()
+            .hot_or_not_feed_score
+            .last_synchronized_score = current_hot_or_not_feed_score;
+        post_to_synchronise
+            .hot_or_not_details
+            .as_mut()
+            .unwrap()
+            .hot_or_not_feed_score
+            .last_synchronized_at = current_time;
+    }
+
+    all_posts.insert(post_id, post_to_synchronise);
+
+    (home_feed_index_score_item, hot_or_not_index_score_item)
 }

--- a/src/canister/individual_user_template/src/api/post/send_update_post_cache.rs
+++ b/src/canister/individual_user_template/src/api/post/send_update_post_cache.rs
@@ -1,3 +1,8 @@
+use ic_cdk::api::call;
+use shared_utils::common::types::known_principal::KnownPrincipalType;
+
+use crate::CANISTER_DATA;
+
 pub fn send_update_post_cache(post_id: &u64) {
     let post_item = CANISTER_DATA.with(|canister_data_ref_cell| {
         canister_data_ref_cell
@@ -20,12 +25,12 @@ pub fn send_update_post_cache(post_id: &u64) {
     let _ = call::notify(
         post_cache_canister_principal_id,
         "update_post_home_feed",
-        (post_item),
+        (post_item.clone(),),
     );
 
     let _ = call::notify(
         post_cache_canister_principal_id,
         "update_post_hot_or_not_feed",
-        (post_item),
+        (post_item,),
     );
 }

--- a/src/canister/individual_user_template/src/api/post/send_update_post_cache.rs
+++ b/src/canister/individual_user_template/src/api/post/send_update_post_cache.rs
@@ -1,0 +1,31 @@
+pub fn send_update_post_cache(post_id: &u64) {
+    let post_item = CANISTER_DATA.with(|canister_data_ref_cell| {
+        canister_data_ref_cell
+            .borrow()
+            .all_created_posts
+            .get(&post_id)
+            .cloned()
+            .unwrap()
+    });
+
+    let post_cache_canister_principal_id = CANISTER_DATA.with(|canister_data_ref_cell| {
+        canister_data_ref_cell
+            .borrow()
+            .known_principal_ids
+            .get(&KnownPrincipalType::CanisterIdPostCache)
+            .cloned()
+            .unwrap()
+    });
+
+    let _ = call::notify(
+        post_cache_canister_principal_id,
+        "update_post_home_feed",
+        (post_item),
+    );
+
+    let _ = call::notify(
+        post_cache_canister_principal_id,
+        "update_post_hot_or_not_feed",
+        (post_item),
+    );
+}

--- a/src/canister/individual_user_template/src/api/post/update_post_as_ready_to_view.rs
+++ b/src/canister/individual_user_template/src/api/post/update_post_as_ready_to_view.rs
@@ -1,6 +1,5 @@
-use shared_utils::{
-    canister_specific::individual_user_template::types::post::PostStatus,
-    common::types::known_principal::KnownPrincipalType,
+use shared_utils::common::types::{
+    known_principal::KnownPrincipalType, top_posts::post_score_index_item::PostStatus,
 };
 
 use crate::CANISTER_DATA;

--- a/src/canister/individual_user_template/src/api/post/update_post_as_ready_to_view.rs
+++ b/src/canister/individual_user_template/src/api/post/update_post_as_ready_to_view.rs
@@ -4,6 +4,8 @@ use shared_utils::common::types::{
 
 use crate::CANISTER_DATA;
 
+use super::send_update_post_cache::send_update_post_cache;
+
 #[ic_cdk::update]
 #[candid::candid_method(update)]
 fn update_post_as_ready_to_view(id: u64) {
@@ -37,4 +39,6 @@ fn update_post_as_ready_to_view(id: u64) {
             .all_created_posts
             .insert(id, post_to_update);
     });
+
+    send_update_post_cache(&id);
 }

--- a/src/canister/individual_user_template/src/api/post/update_scores_and_share_with_post_cache_if_difference_beyond_threshold.rs
+++ b/src/canister/individual_user_template/src/api/post/update_scores_and_share_with_post_cache_if_difference_beyond_threshold.rs
@@ -1,7 +1,7 @@
 use std::time::SystemTime;
 
 use candid::Principal;
-use ic_cdk::api::call;
+use ic_cdk::{api::call, update};
 use shared_utils::{
     common::{
         types::{
@@ -17,6 +17,16 @@ use shared_utils::{
 };
 
 use crate::{data_model::CanisterData, CANISTER_DATA};
+
+#[ic_cdk::update]
+#[candid::candid_method(update)]
+fn check_and_update_scores_and_share_with_post_cache_if_difference_beyond_threshold(
+    post_ids: Vec<u64>,
+) {
+    post_ids.iter().for_each(|post_id| {
+        update_scores_and_share_with_post_cache_if_difference_beyond_threshold(post_id);
+    });
+}
 
 pub fn update_scores_and_share_with_post_cache_if_difference_beyond_threshold(post_id: &u64) {
     let current_time = system_time::get_current_system_time_from_ic();

--- a/src/canister/individual_user_template/src/data_model/mod.rs
+++ b/src/canister/individual_user_template/src/data_model/mod.rs
@@ -10,13 +10,10 @@ use shared_utils::{
     },
     common::types::{
         app_primitive_type::PostId, known_principal::KnownPrincipalMap,
-        top_posts::post_score_index::PostScoreIndex,
+        top_posts::post_score_index::PostScoreIndex, version_details::VersionDetails,
     },
 };
 
-use self::version_details::VersionDetails;
-
-pub mod version_details;
 pub mod memory;
 
 #[derive(Default, Deserialize, Serialize)]

--- a/src/canister/individual_user_template/src/test.rs
+++ b/src/canister/individual_user_template/src/test.rs
@@ -1,3 +1,4 @@
+
 #[test]
 fn save_candid() {
     use crate::export_candid;

--- a/src/canister/post_cache/Cargo.toml
+++ b/src/canister/post_cache/Cargo.toml
@@ -17,3 +17,12 @@ serde = { workspace = true }
 
 [dev-dependencies]
 test_utils = { workspace = true }
+
+
+[dev-dependencies.shared_utils]
+path = "../../lib/shared_utils"
+features = ["mockdata"]
+
+
+[features]
+mockdata = []

--- a/src/canister/post_cache/can.did
+++ b/src/canister/post_cache/can.did
@@ -29,7 +29,15 @@ service : (PostCacheInitArgs) -> {
       nat64,
       nat64,
     ) -> (Result) query;
+  get_top_posts_aggregated_from_canisters_on_this_network_for_home_feed_cursor : (
+      nat64,
+      nat64,
+    ) -> (Result) query;
   get_top_posts_aggregated_from_canisters_on_this_network_for_hot_or_not_feed : (
+      nat64,
+      nat64,
+    ) -> (Result) query;
+  get_top_posts_aggregated_from_canisters_on_this_network_for_hot_or_not_feed_cursor : (
       nat64,
       nat64,
     ) -> (Result) query;

--- a/src/canister/post_cache/can.did
+++ b/src/canister/post_cache/can.did
@@ -18,7 +18,32 @@ type PostScoreIndexItem = record {
   score : nat64;
   publisher_canister_id : principal;
 };
+type PostScoreIndexItemV1 = record {
+  is_nsfw : bool;
+  status : PostStatus;
+  post_id : nat64;
+  created_at : opt SystemTime;
+  score : nat64;
+  publisher_canister_id : principal;
+};
+type PostStatus = variant {
+  BannedForExplicitness;
+  BannedDueToUserReporting;
+  Uploaded;
+  CheckingExplicitness;
+  ReadyToView;
+  Transcoding;
+  Deleted;
+};
 type Result = variant { Ok : vec PostScoreIndexItem; Err : TopPostsFetchError };
+type Result_1 = variant {
+  Ok : vec PostScoreIndexItemV1;
+  Err : TopPostsFetchError;
+};
+type SystemTime = record {
+  nanos_since_epoch : nat32;
+  secs_since_epoch : nat64;
+};
 type TopPostsFetchError = variant {
   ReachedEndOfItemsList;
   InvalidBoundsPassed;
@@ -32,7 +57,9 @@ service : (PostCacheInitArgs) -> {
   get_top_posts_aggregated_from_canisters_on_this_network_for_home_feed_cursor : (
       nat64,
       nat64,
-    ) -> (Result) query;
+      opt bool,
+      opt PostStatus,
+    ) -> (Result_1) query;
   get_top_posts_aggregated_from_canisters_on_this_network_for_hot_or_not_feed : (
       nat64,
       nat64,
@@ -40,7 +67,9 @@ service : (PostCacheInitArgs) -> {
   get_top_posts_aggregated_from_canisters_on_this_network_for_hot_or_not_feed_cursor : (
       nat64,
       nat64,
-    ) -> (Result) query;
+      opt bool,
+      opt PostStatus,
+    ) -> (Result_1) query;
   get_well_known_principal_value : (KnownPrincipalType) -> (
       opt principal,
     ) query;

--- a/src/canister/post_cache/can.did
+++ b/src/canister/post_cache/can.did
@@ -12,6 +12,8 @@ type KnownPrincipalType = variant {
 };
 type PostCacheInitArgs = record {
   known_principal_ids : opt vec record { KnownPrincipalType; principal };
+  version : text;
+  upgrade_version_number : opt nat64;
 };
 type PostScoreIndexItem = record {
   post_id : nat64;
@@ -74,10 +76,12 @@ service : (PostCacheInitArgs) -> {
       opt principal,
     ) query;
   receive_top_home_feed_posts_from_publishing_canister : (
-      vec PostScoreIndexItem,
+      vec PostScoreIndexItemV1,
     ) -> ();
   receive_top_hot_or_not_feed_posts_from_publishing_canister : (
-      vec PostScoreIndexItem,
+      vec PostScoreIndexItemV1,
     ) -> ();
   remove_all_feed_entries : () -> ();
+  update_post_home_feed : (PostScoreIndexItemV1) -> ();
+  update_post_hot_or_not_feed : (PostScoreIndexItemV1) -> ();
 }

--- a/src/canister/post_cache/src/api/canister_lifecycle/post_upgrade.rs
+++ b/src/canister/post_cache/src/api/canister_lifecycle/post_upgrade.rs
@@ -1,6 +1,19 @@
 use std::time::Duration;
 
-use shared_utils::common::utils::stable_memory_serializer_deserializer;
+use ic_cdk::api::call;
+use shared_utils::{
+    canister_specific::{
+        individual_user_template::types::post::PostDetailsForFrontend,
+        post_cache::types::arg::PostCacheInitArgs,
+    },
+    common::{
+        types::{
+            top_posts::{post_score_home_index, post_score_index_item::PostScoreIndexItemV1},
+            version_details::VersionDetails,
+        },
+        utils::stable_memory_serializer_deserializer,
+    },
+};
 
 use crate::{
     api::well_known_principal::update_locally_stored_well_known_principals,
@@ -12,7 +25,9 @@ use super::pre_upgrade::BUFFER_SIZE_BYTES;
 #[ic_cdk::post_upgrade]
 fn post_upgrade() {
     restore_data_from_stable_memory();
+    save_upgrade_args_to_memory();
     refetch_well_known_principals();
+    migrate_data();
 }
 
 fn restore_data_from_stable_memory() {
@@ -31,9 +46,112 @@ fn restore_data_from_stable_memory() {
     }
 }
 
+fn save_upgrade_args_to_memory() {
+    let upgrade_args = ic_cdk::api::call::arg_data::<(PostCacheInitArgs,)>().0;
+
+    CANISTER_DATA.with(|canister_data_ref_cell| {
+        let mut canister_data_ref_cell = canister_data_ref_cell.borrow_mut();
+
+        if let Some(upgrade_version_number) = upgrade_args.upgrade_version_number {
+            canister_data_ref_cell.version_details.version_number = upgrade_version_number;
+        }
+
+        canister_data_ref_cell.version_details.version = upgrade_args.version;
+    });
+}
+
 const DELAY_FOR_REFETCHING_WELL_KNOWN_PRINCIPALS: Duration = Duration::from_secs(1);
 fn refetch_well_known_principals() {
     ic_cdk_timers::set_timer(DELAY_FOR_REFETCHING_WELL_KNOWN_PRINCIPALS, || {
         ic_cdk::spawn(update_locally_stored_well_known_principals::update_locally_stored_well_known_principals())
     });
+}
+
+const DELAY_FOR_MIGRATING_DATA: Duration = Duration::from_secs(1);
+fn migrate_data() {
+    ic_cdk_timers::set_timer(DELAY_FOR_MIGRATING_DATA, || {
+        ic_cdk::spawn(migrate_data_impl());
+    });
+}
+
+async fn migrate_data_impl() {
+    // Migrate Home Feed
+
+    let old_post_score_home_index = CANISTER_DATA.with(|canister_data_ref_cell| {
+        let canister_data_ref_cell = canister_data_ref_cell.borrow_mut();
+
+        canister_data_ref_cell
+            .posts_index_sorted_by_home_feed_score
+            .clone()
+    });
+
+    for post in old_post_score_home_index.iter() {
+        let post_id = post.post_id;
+        let publisher_canister_id = post.publisher_canister_id;
+
+        let (post_details,): (PostDetailsForFrontend,) = call::call(
+            publisher_canister_id,
+            "get_individual_post_details_by_id",
+            (post_id,),
+        )
+        .await
+        .expect("Call failed: get_individual_post_details_by_id");
+
+        let new_post = PostScoreIndexItemV1 {
+            score: post_details.home_feed_ranking_score,
+            post_id: post_details.id,
+            publisher_canister_id,
+            is_nsfw: post_details.is_nsfw,
+            created_at: Some(post_details.created_at),
+            status: post_details.status,
+        };
+
+        CANISTER_DATA.with(|canister_data_ref_cell| {
+            let mut canister_data_ref_cell = canister_data_ref_cell.borrow_mut();
+            canister_data_ref_cell
+                .posts_index_sorted_by_home_feed_score_v1
+                .replace(&new_post);
+        });
+    }
+
+    // Migrate Hot or Not Feed
+
+    let old_post_score_hot_or_not_index = CANISTER_DATA.with(|canister_data_ref_cell| {
+        let canister_data_ref_cell = canister_data_ref_cell.borrow_mut();
+
+        canister_data_ref_cell
+            .posts_index_sorted_by_hot_or_not_feed_score
+            .clone()
+    });
+
+    for post in old_post_score_hot_or_not_index.iter() {
+        let post_id = post.post_id;
+        let publisher_canister_id = post.publisher_canister_id;
+
+        let (post_details,): (PostDetailsForFrontend,) = call::call(
+            publisher_canister_id,
+            "get_individual_post_details_by_id",
+            (post_id,),
+        )
+        .await
+        .expect("Call failed: get_individual_post_details_by_id");
+
+        if let Some(hot_or_not_feed_ranking_score) = post_details.hot_or_not_feed_ranking_score {
+            let new_post = PostScoreIndexItemV1 {
+                score: hot_or_not_feed_ranking_score,
+                post_id: post_details.id,
+                publisher_canister_id,
+                is_nsfw: post_details.is_nsfw,
+                created_at: Some(post_details.created_at),
+                status: post_details.status,
+            };
+
+            CANISTER_DATA.with(|canister_data_ref_cell| {
+                let mut canister_data_ref_cell = canister_data_ref_cell.borrow_mut();
+                canister_data_ref_cell
+                    .posts_index_sorted_by_hot_or_not_feed_score_v1
+                    .replace(&new_post);
+            });
+        }
+    }
 }

--- a/src/canister/post_cache/src/api/feed/mod.rs
+++ b/src/canister/post_cache/src/api/feed/mod.rs
@@ -1,1 +1,2 @@
 pub mod remove_all_feed_entries;
+pub mod trigger_update_indexes;

--- a/src/canister/post_cache/src/api/feed/trigger_update_indexes.rs
+++ b/src/canister/post_cache/src/api/feed/trigger_update_indexes.rs
@@ -1,0 +1,180 @@
+use std::{
+    cell::RefCell,
+    time::{Duration, SystemTime},
+};
+
+use shared_utils::common::types::top_posts::{
+    post_score_index_item::PostScoreIndexItemV1, LATEST_POSTS_WINDOW,
+};
+
+use crate::{data_model::CanisterData, CANISTER_DATA};
+
+const TRIGGER_UPDATE_HOT_OR_NOT_INDEX: Duration = Duration::from_secs(60 * 60);
+
+fn trigger_update_hot_or_not_index() {
+    let last_updated_hot_or_not_timestamp_index = CANISTER_DATA.with(|canister_data| {
+        canister_data
+            .borrow()
+            .metadata
+            .last_updated_hot_or_not_timestamp_index
+    });
+
+    let now = SystemTime::now();
+    if now
+        .duration_since(
+            last_updated_hot_or_not_timestamp_index
+                .unwrap_or_else(|| now - TRIGGER_UPDATE_HOT_OR_NOT_INDEX),
+        )
+        .unwrap_or_default()
+        >= TRIGGER_UPDATE_HOT_OR_NOT_INDEX
+    {
+        // Update the hot or not index
+
+        let old_post_ids = CANISTER_DATA.with(|canister_data| {
+            let canister_data = canister_data.borrow();
+
+            canister_data
+                .posts_index_sorted_by_hot_or_not_feed_score_v1
+                .item_time_index
+                .iter()
+                .take_while(|(&created_at, _)| {
+                    now.duration_since(created_at).unwrap_or_default() >= LATEST_POSTS_WINDOW
+                })
+                .map(|(_, post_ids)| post_ids)
+                .flatten()
+                .cloned()
+                .map(|post_id| {
+                    canister_data
+                        .posts_index_sorted_by_hot_or_not_feed_score_v1
+                        .item_presence_index
+                        .get(&post_id)
+                        .unwrap()
+                        .clone()
+                })
+                .collect::<Vec<PostScoreIndexItemV1>>()
+        });
+
+        CANISTER_DATA.with(|canister_data| {
+            let mut canister_data = canister_data.borrow_mut();
+            let hot_or_not_index =
+                &mut canister_data.posts_index_sorted_by_hot_or_not_feed_score_v1;
+            // Replace the old post ids
+            for post in old_post_ids {
+                hot_or_not_index.replace(&post);
+            }
+
+            canister_data
+                .metadata
+                .last_updated_hot_or_not_timestamp_index = Some(now);
+        });
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::thread;
+
+    use candid::Principal;
+    use shared_utils::common::types::top_posts::post_score_index_item::{
+        PostScoreIndexItemV1, PostStatus,
+    };
+
+    use super::*;
+
+    #[test]
+    fn test_trigger_update_hot_or_not_index() {
+        let canister_data = CanisterData::default();
+        CANISTER_DATA.with(|data| {
+            *data.borrow_mut() = canister_data;
+        });
+
+        let created_at_now = SystemTime::now();
+        let creted_at_earlier = created_at_now - (LATEST_POSTS_WINDOW - Duration::from_secs(5));
+
+        let posts = vec![
+            PostScoreIndexItemV1 {
+                score: 1,
+                post_id: 1,
+                publisher_canister_id: Principal::from_text("w4nuc-waaaa-aaaao-aal2a-cai").unwrap(),
+                is_nsfw: false,
+                status: PostStatus::ReadyToView,
+                created_at: Some(created_at_now),
+            },
+            PostScoreIndexItemV1 {
+                score: 2,
+                post_id: 2,
+                publisher_canister_id: Principal::from_text("w4nuc-waaaa-aaaao-aal2a-cai").unwrap(),
+                is_nsfw: false,
+                status: PostStatus::ReadyToView,
+                created_at: Some(created_at_now),
+            },
+            PostScoreIndexItemV1 {
+                score: 3,
+                post_id: 3,
+                publisher_canister_id: Principal::from_text("w4nuc-waaaa-aaaao-aal2a-cai").unwrap(),
+                is_nsfw: false,
+                status: PostStatus::ReadyToView,
+                created_at: Some(creted_at_earlier),
+            },
+            PostScoreIndexItemV1 {
+                score: 4,
+                post_id: 4,
+                publisher_canister_id: Principal::from_text("w4nuc-waaaa-aaaao-aal2a-cai").unwrap(),
+                is_nsfw: false,
+                status: PostStatus::ReadyToView,
+                created_at: Some(creted_at_earlier),
+            },
+            PostScoreIndexItemV1 {
+                score: 5,
+                post_id: 5,
+                publisher_canister_id: Principal::from_text("w4nuc-waaaa-aaaao-aal2a-cai").unwrap(),
+                is_nsfw: false,
+                status: PostStatus::ReadyToView,
+                created_at: Some(creted_at_earlier),
+            },
+        ];
+
+        // Replace in CanisterData
+        CANISTER_DATA.with(|canister_data| {
+            let mut canister_data = canister_data.borrow_mut();
+            let hot_or_not_index =
+                &mut canister_data.posts_index_sorted_by_hot_or_not_feed_score_v1;
+            for post in posts {
+                hot_or_not_index.replace(&post);
+            }
+        });
+
+        // Check if the posts are in the right order in CANISTER
+        let post_score_index = CANISTER_DATA.with(|canister_data| {
+            let canister_data = canister_data.borrow();
+            canister_data
+                .posts_index_sorted_by_hot_or_not_feed_score_v1
+                .clone()
+        });
+        let mut post_score_index_iter = post_score_index.iter();
+        assert_eq!(post_score_index_iter.next().unwrap().post_id, 5);
+        assert_eq!(post_score_index_iter.next().unwrap().post_id, 4);
+        assert_eq!(post_score_index_iter.next().unwrap().post_id, 3);
+        assert_eq!(post_score_index_iter.next().unwrap().post_id, 2);
+        assert_eq!(post_score_index_iter.next().unwrap().post_id, 1);
+        assert_eq!(post_score_index_iter.next(), None);
+
+        thread::sleep(Duration::from_secs(5));
+
+        trigger_update_hot_or_not_index();
+
+        let post_score_index = CANISTER_DATA.with(|canister_data| {
+            let canister_data = canister_data.borrow();
+            canister_data
+                .posts_index_sorted_by_hot_or_not_feed_score_v1
+                .clone()
+        });
+        let mut post_score_index_iter = post_score_index.iter();
+        assert_eq!(post_score_index_iter.next().unwrap().post_id, 2);
+        assert_eq!(post_score_index_iter.next().unwrap().post_id, 1);
+        assert_eq!(post_score_index_iter.next().unwrap().post_id, 5);
+        assert_eq!(post_score_index_iter.next().unwrap().post_id, 4);
+        assert_eq!(post_score_index_iter.next().unwrap().post_id, 3);
+        assert_eq!(post_score_index_iter.next(), None);
+    }
+}

--- a/src/canister/post_cache/src/api/home_feed/get_top_posts_aggregated_from_canisters_on_this_network_for_home_feed.rs
+++ b/src/canister/post_cache/src/api/home_feed/get_top_posts_aggregated_from_canisters_on_this_network_for_home_feed.rs
@@ -50,6 +50,50 @@ fn get_top_posts_aggregated_from_canisters_on_this_network_for_home_feed_impl(
         .collect())
 }
 
+#[ic_cdk::query]
+#[candid::candid_method(query)]
+fn get_top_posts_aggregated_from_canisters_on_this_network_for_home_feed_cursor(
+    from_inclusive_index: u64,
+    limit: u64,
+) -> Result<Vec<PostScoreIndexItem>, TopPostsFetchError> {
+    CANISTER_DATA.with(|canister_data| {
+        let canister_data = canister_data.borrow();
+
+        get_top_posts_aggregated_from_canisters_on_this_network_for_home_feed_cursor_impl(
+            from_inclusive_index,
+            limit,
+            &canister_data,
+        )
+    })
+}
+
+fn get_top_posts_aggregated_from_canisters_on_this_network_for_home_feed_cursor_impl(
+    from_inclusive_index: u64,
+    limit: u64,
+    canister_data: &CanisterData,
+) -> Result<Vec<PostScoreIndexItem>, TopPostsFetchError> {
+    let all_posts = &canister_data.posts_index_sorted_by_home_feed_score;
+    let (from_inclusive_index, limit) = pagination::get_pagination_bounds_cursor(
+        from_inclusive_index,
+        limit,
+        all_posts.iter().count() as u64,
+    )
+    .map_err(|e| match e {
+        PaginationError::InvalidBoundsPassed => TopPostsFetchError::InvalidBoundsPassed,
+        PaginationError::ReachedEndOfItemsList => TopPostsFetchError::ReachedEndOfItemsList,
+        PaginationError::ExceededMaxNumberOfItemsAllowedInOneRequest => {
+            TopPostsFetchError::ExceededMaxNumberOfItemsAllowedInOneRequest
+        }
+    })?;
+
+    Ok(all_posts
+        .iter()
+        .skip(from_inclusive_index as usize)
+        .take(limit as usize)
+        .cloned()
+        .collect::<Vec<PostScoreIndexItem>>())
+}
+
 #[cfg(test)]
 mod test {
     use candid::Principal;
@@ -106,11 +150,12 @@ mod test {
         assert!(result.is_ok());
         assert_eq!(result.unwrap().len(), 2,);
     }
-    
+
     #[test]
-    fn test_get_top_posts_aggregated_from_canisters_on_this_network_for_home_feed_impl_with_indexes() {
+    fn test_get_top_posts_aggregated_from_canisters_on_this_network_for_home_feed_impl_with_indexes(
+    ) {
         let mut canister_data = CanisterData::default();
-        
+
         let post_score_index_item_1 = PostScoreIndexItem {
             post_id: 1,
             score: 1,
@@ -136,7 +181,7 @@ mod test {
             score: 5,
             publisher_canister_id: Principal::anonymous(),
         };
-        
+
         canister_data
             .posts_index_sorted_by_home_feed_score
             .replace(&post_score_index_item_1);
@@ -151,7 +196,7 @@ mod test {
         canister_data
             .posts_index_sorted_by_home_feed_score
             .replace(&post_score_index_item_4);
-        
+
         canister_data
             .posts_index_sorted_by_home_feed_score
             .replace(&post_score_index_item_5);
@@ -163,13 +208,87 @@ mod test {
                 &canister_data,
             );
         assert!(result.is_ok());
-        
+
         let posts = result.unwrap();
         assert_eq!(posts.len(), 1);
 
         let third_post = posts.get(0).unwrap();
         assert_eq!(third_post.post_id, 3);
         assert_eq!(third_post.score, 3);
+    }
 
+    #[test]
+    fn test_get_top_posts_aggregated_from_canisters_on_this_network_for_home_feed_cursor_impl() {
+        let mut canister_data = CanisterData::default();
+
+        let post_scores = vec![
+            PostScoreIndexItem {
+                post_id: 1,
+                score: 1,
+                publisher_canister_id: Principal::anonymous(),
+            },
+            PostScoreIndexItem {
+                post_id: 2,
+                score: 2,
+                publisher_canister_id: Principal::anonymous(),
+            },
+            PostScoreIndexItem {
+                post_id: 3,
+                score: 3,
+                publisher_canister_id: Principal::anonymous(),
+            },
+            PostScoreIndexItem {
+                post_id: 4,
+                score: 4,
+                publisher_canister_id: Principal::anonymous(),
+            },
+            PostScoreIndexItem {
+                post_id: 5,
+                score: 5,
+                publisher_canister_id: Principal::anonymous(),
+            },
+        ];
+
+        for post_score in post_scores {
+            canister_data
+                .posts_index_sorted_by_home_feed_score
+                .replace(&post_score);
+        }
+
+        // Test with cursor 0
+        let result
+            = super::get_top_posts_aggregated_from_canisters_on_this_network_for_home_feed_cursor_impl(
+                    0,
+                    3,
+                    &canister_data);
+
+        assert!(result.is_ok());
+        let posts = result.unwrap();
+        assert_eq!(posts.len(), 3);
+        assert_eq!(posts[0].post_id, 5);
+        assert_eq!(posts[1].post_id, 4);
+        assert_eq!(posts[2].post_id, 3);
+
+        // Test with cursor 3
+        let result
+            = super::get_top_posts_aggregated_from_canisters_on_this_network_for_home_feed_cursor_impl(
+                        3,
+                        3,
+                        &canister_data);
+
+        assert!(result.is_ok());
+        let posts = result.unwrap();
+        assert_eq!(posts.len(), 2);
+        assert_eq!(posts[0].post_id, 2);
+        assert_eq!(posts[1].post_id, 1);
+
+        // Test with cursor 5
+        let result
+            = super::get_top_posts_aggregated_from_canisters_on_this_network_for_home_feed_cursor_impl(
+                        5,
+                        3,
+                        &canister_data);
+
+        assert_eq!(result, Err(TopPostsFetchError::ReachedEndOfItemsList));
     }
 }

--- a/src/canister/post_cache/src/api/home_feed/get_top_posts_aggregated_from_canisters_on_this_network_for_home_feed.rs
+++ b/src/canister/post_cache/src/api/home_feed/get_top_posts_aggregated_from_canisters_on_this_network_for_home_feed.rs
@@ -1,6 +1,8 @@
 use crate::{data_model::CanisterData, CANISTER_DATA};
 use shared_utils::{
-    common::types::top_posts::post_score_index_item::PostScoreIndexItem,
+    common::types::top_posts::post_score_index_item::{
+        PostScoreIndexItem, PostScoreIndexItemV1, PostStatus,
+    },
     pagination::{self, PaginationError},
     types::canister_specific::post_cache::error_types::TopPostsFetchError,
 };
@@ -55,7 +57,9 @@ fn get_top_posts_aggregated_from_canisters_on_this_network_for_home_feed_impl(
 fn get_top_posts_aggregated_from_canisters_on_this_network_for_home_feed_cursor(
     from_inclusive_index: u64,
     limit: u64,
-) -> Result<Vec<PostScoreIndexItem>, TopPostsFetchError> {
+    is_nsfw: Option<bool>,
+    status: Option<PostStatus>,
+) -> Result<Vec<PostScoreIndexItemV1>, TopPostsFetchError> {
     CANISTER_DATA.with(|canister_data| {
         let canister_data = canister_data.borrow();
 
@@ -63,6 +67,8 @@ fn get_top_posts_aggregated_from_canisters_on_this_network_for_home_feed_cursor(
             from_inclusive_index,
             limit,
             &canister_data,
+            is_nsfw,
+            status,
         )
     })
 }
@@ -71,12 +77,33 @@ fn get_top_posts_aggregated_from_canisters_on_this_network_for_home_feed_cursor_
     from_inclusive_index: u64,
     limit: u64,
     canister_data: &CanisterData,
-) -> Result<Vec<PostScoreIndexItem>, TopPostsFetchError> {
-    let all_posts = &canister_data.posts_index_sorted_by_home_feed_score;
+    is_nsfw: Option<bool>,
+    status: Option<PostStatus>,
+) -> Result<Vec<PostScoreIndexItemV1>, TopPostsFetchError> {
+    let all_posts = &canister_data.posts_index_sorted_by_home_feed_score_v1;
+    let filter_fn = |post_item: &PostScoreIndexItemV1| {
+        if let Some(is_nsfw) = is_nsfw {
+            if post_item.is_nsfw != is_nsfw {
+                return false;
+            }
+        }
+
+        if let Some(status) = status.clone() {
+            if post_item.status != status {
+                return false;
+            }
+        }
+
+        true
+    };
+
     let (from_inclusive_index, limit) = pagination::get_pagination_bounds_cursor(
         from_inclusive_index,
         limit,
-        all_posts.iter().count() as u64,
+        all_posts
+            .iter()
+            .filter(|&post_item| filter_fn(post_item))
+            .count() as u64,
     )
     .map_err(|e| match e {
         PaginationError::InvalidBoundsPassed => TopPostsFetchError::InvalidBoundsPassed,
@@ -88,10 +115,11 @@ fn get_top_posts_aggregated_from_canisters_on_this_network_for_home_feed_cursor_
 
     Ok(all_posts
         .iter()
+        .filter(|&post_item| filter_fn(post_item))
         .skip(from_inclusive_index as usize)
         .take(limit as usize)
         .cloned()
-        .collect::<Vec<PostScoreIndexItem>>())
+        .collect::<Vec<PostScoreIndexItemV1>>())
 }
 
 #[cfg(test)]
@@ -222,36 +250,59 @@ mod test {
         let mut canister_data = CanisterData::default();
 
         let post_scores = vec![
-            PostScoreIndexItem {
+            PostScoreIndexItemV1 {
                 post_id: 1,
                 score: 1,
                 publisher_canister_id: Principal::anonymous(),
+                is_nsfw: false,
+                status: PostStatus::ReadyToView,
+                created_at: None,
             },
-            PostScoreIndexItem {
+            PostScoreIndexItemV1 {
                 post_id: 2,
                 score: 2,
                 publisher_canister_id: Principal::anonymous(),
+                is_nsfw: false,
+                status: PostStatus::ReadyToView,
+                created_at: None,
             },
-            PostScoreIndexItem {
+            PostScoreIndexItemV1 {
                 post_id: 3,
                 score: 3,
                 publisher_canister_id: Principal::anonymous(),
+                is_nsfw: false,
+                status: PostStatus::ReadyToView,
+                created_at: None,
             },
-            PostScoreIndexItem {
+            PostScoreIndexItemV1 {
                 post_id: 4,
                 score: 4,
                 publisher_canister_id: Principal::anonymous(),
+                is_nsfw: false,
+                status: PostStatus::ReadyToView,
+                created_at: None,
             },
-            PostScoreIndexItem {
+            PostScoreIndexItemV1 {
                 post_id: 5,
                 score: 5,
                 publisher_canister_id: Principal::anonymous(),
+                is_nsfw: false,
+                status: PostStatus::ReadyToView,
+                created_at: None,
+            },
+            PostScoreIndexItemV1 {
+                post_id: 1,
+                score: 6,
+                publisher_canister_id: Principal::anonymous(),
+                is_nsfw: true,
+                status: PostStatus::ReadyToView,
+                created_at: None,
             },
         ];
 
         for post_score in post_scores {
             canister_data
-                .posts_index_sorted_by_home_feed_score
+                .posts_index_sorted_by_home_feed_score_v1
                 .replace(&post_score);
         }
 
@@ -260,35 +311,136 @@ mod test {
             = super::get_top_posts_aggregated_from_canisters_on_this_network_for_home_feed_cursor_impl(
                     0,
                     3,
-                    &canister_data);
+                    &canister_data, None, None);
 
         assert!(result.is_ok());
         let posts = result.unwrap();
         assert_eq!(posts.len(), 3);
-        assert_eq!(posts[0].post_id, 5);
-        assert_eq!(posts[1].post_id, 4);
-        assert_eq!(posts[2].post_id, 3);
+        assert_eq!(posts[0].post_id, 1);
+        assert_eq!(posts[1].post_id, 5);
+        assert_eq!(posts[2].post_id, 4);
 
         // Test with cursor 3
         let result
             = super::get_top_posts_aggregated_from_canisters_on_this_network_for_home_feed_cursor_impl(
                         3,
                         3,
-                        &canister_data);
+                        &canister_data, None, None);
 
         assert!(result.is_ok());
         let posts = result.unwrap();
         assert_eq!(posts.len(), 2);
-        assert_eq!(posts[0].post_id, 2);
-        assert_eq!(posts[1].post_id, 1);
+        assert_eq!(posts[0].post_id, 3);
+        assert_eq!(posts[1].post_id, 2);
 
         // Test with cursor 5
         let result
             = super::get_top_posts_aggregated_from_canisters_on_this_network_for_home_feed_cursor_impl(
                         5,
                         3,
-                        &canister_data);
+                        &canister_data, None, None);
 
         assert_eq!(result, Err(TopPostsFetchError::ReachedEndOfItemsList));
+    }
+
+    #[test]
+    fn test_get_top_posts_aggregated_from_canisters_on_this_network_for_home_feed_cursor_impl_with_filter(
+    ) {
+        let mut canister_data = CanisterData::default();
+
+        let post_scores = vec![
+            PostScoreIndexItemV1 {
+                post_id: 1,
+                score: 1,
+                publisher_canister_id: Principal::anonymous(),
+                is_nsfw: false,
+                status: PostStatus::ReadyToView,
+                created_at: None,
+            },
+            PostScoreIndexItemV1 {
+                post_id: 2,
+                score: 2,
+                publisher_canister_id: Principal::anonymous(),
+                is_nsfw: false,
+                status: PostStatus::ReadyToView,
+                created_at: None,
+            },
+            PostScoreIndexItemV1 {
+                post_id: 3,
+                score: 3,
+                publisher_canister_id: Principal::anonymous(),
+                is_nsfw: true,
+                status: PostStatus::Deleted,
+                created_at: None,
+            },
+            PostScoreIndexItemV1 {
+                post_id: 4,
+                score: 4,
+                publisher_canister_id: Principal::anonymous(),
+                is_nsfw: true,
+                status: PostStatus::Uploaded,
+                created_at: None,
+            },
+            PostScoreIndexItemV1 {
+                post_id: 5,
+                score: 5,
+                publisher_canister_id: Principal::anonymous(),
+                is_nsfw: false,
+                status: PostStatus::ReadyToView,
+                created_at: None,
+            },
+            PostScoreIndexItemV1 {
+                post_id: 1,
+                score: 6,
+                publisher_canister_id: Principal::anonymous(),
+                is_nsfw: true,
+                status: PostStatus::ReadyToView,
+                created_at: None,
+            },
+        ];
+
+        for post_score in post_scores {
+            canister_data
+                .posts_index_sorted_by_home_feed_score_v1
+                .replace(&post_score);
+        }
+
+        // Test with NSFW filter
+        let result
+            = super::get_top_posts_aggregated_from_canisters_on_this_network_for_home_feed_cursor_impl(
+                    0,
+                    3,
+                    &canister_data, Some(false), None);
+
+        assert!(result.is_ok());
+        let posts = result.unwrap();
+        assert_eq!(posts.len(), 2);
+        assert_eq!(posts[0].post_id, 5);
+        assert_eq!(posts[1].post_id, 2);
+
+        // Test with status filter
+        let result
+            = super::get_top_posts_aggregated_from_canisters_on_this_network_for_home_feed_cursor_impl(
+                    0,
+                    3,
+                    &canister_data, None, Some(PostStatus::Uploaded));
+
+        assert!(result.is_ok());
+        let posts = result.unwrap();
+        assert_eq!(posts.len(), 1);
+        assert_eq!(posts[0].post_id, 4);
+
+        // Test with both filters
+
+        let result
+            = super::get_top_posts_aggregated_from_canisters_on_this_network_for_home_feed_cursor_impl(
+                    0,
+                    3,
+                    &canister_data, Some(true), Some(PostStatus::Deleted));
+
+        assert!(result.is_ok());
+        let posts = result.unwrap();
+        assert_eq!(posts.len(), 1);
+        assert_eq!(posts[0].post_id, 3);
     }
 }

--- a/src/canister/post_cache/src/api/home_feed/mod.rs
+++ b/src/canister/post_cache/src/api/home_feed/mod.rs
@@ -1,2 +1,3 @@
 pub mod get_top_posts_aggregated_from_canisters_on_this_network_for_home_feed;
 pub mod receive_top_home_feed_posts_from_publishing_canister;
+pub mod update_post_home_feed;

--- a/src/canister/post_cache/src/api/home_feed/receive_top_home_feed_posts_from_publishing_canister.rs
+++ b/src/canister/post_cache/src/api/home_feed/receive_top_home_feed_posts_from_publishing_canister.rs
@@ -1,4 +1,6 @@
-use shared_utils::common::types::top_posts::post_score_index_item::PostScoreIndexItemV1;
+use shared_utils::common::types::top_posts::post_score_index_item::{
+    PostScoreIndexItem, PostScoreIndexItemV1,
+};
 
 use crate::{data_model::CanisterData, CANISTER_DATA};
 
@@ -24,8 +26,31 @@ fn receive_top_home_feed_posts_from_publishing_canister_impl(
     let posts_index_sorted_by_home_feed_score =
         &mut canister_data.posts_index_sorted_by_home_feed_score_v1;
 
-    for post_score_index_item in top_posts_from_publishing_canister {
+    for post_score_index_item in top_posts_from_publishing_canister.clone() {
         posts_index_sorted_by_home_feed_score.replace(&post_score_index_item);
+    }
+
+    if posts_index_sorted_by_home_feed_score.iter().count() > 1500 {
+        *posts_index_sorted_by_home_feed_score = posts_index_sorted_by_home_feed_score
+            .into_iter()
+            .take(1000)
+            .cloned()
+            .collect();
+    }
+
+    // old code
+    // TODO: remove this post filter migration
+
+    let posts_index_sorted_by_home_feed_score =
+        &mut canister_data.posts_index_sorted_by_home_feed_score;
+
+    for post_score_index_item in top_posts_from_publishing_canister {
+        let old_post = PostScoreIndexItem {
+            score: post_score_index_item.score,
+            post_id: post_score_index_item.post_id,
+            publisher_canister_id: post_score_index_item.publisher_canister_id,
+        };
+        posts_index_sorted_by_home_feed_score.replace(&old_post);
     }
 
     if posts_index_sorted_by_home_feed_score.iter().count() > 1500 {

--- a/src/canister/post_cache/src/api/home_feed/receive_top_home_feed_posts_from_publishing_canister.rs
+++ b/src/canister/post_cache/src/api/home_feed/receive_top_home_feed_posts_from_publishing_canister.rs
@@ -1,11 +1,11 @@
-use shared_utils::common::types::top_posts::post_score_index_item::PostScoreIndexItem;
+use shared_utils::common::types::top_posts::post_score_index_item::PostScoreIndexItemV1;
 
 use crate::{data_model::CanisterData, CANISTER_DATA};
 
 #[ic_cdk::update]
 #[candid::candid_method(update)]
 fn receive_top_home_feed_posts_from_publishing_canister(
-    top_posts_from_publishing_canister: Vec<PostScoreIndexItem>,
+    top_posts_from_publishing_canister: Vec<PostScoreIndexItemV1>,
 ) {
     CANISTER_DATA.with(|canister_data| {
         let mut canister_data = canister_data.borrow_mut();
@@ -18,11 +18,11 @@ fn receive_top_home_feed_posts_from_publishing_canister(
 }
 
 fn receive_top_home_feed_posts_from_publishing_canister_impl(
-    top_posts_from_publishing_canister: Vec<PostScoreIndexItem>,
+    top_posts_from_publishing_canister: Vec<PostScoreIndexItemV1>,
     canister_data: &mut CanisterData,
 ) {
     let posts_index_sorted_by_home_feed_score =
-        &mut canister_data.posts_index_sorted_by_home_feed_score;
+        &mut canister_data.posts_index_sorted_by_home_feed_score_v1;
 
     for post_score_index_item in top_posts_from_publishing_canister {
         posts_index_sorted_by_home_feed_score.replace(&post_score_index_item);
@@ -39,29 +39,42 @@ fn receive_top_home_feed_posts_from_publishing_canister_impl(
 
 #[cfg(test)]
 mod test {
+    use std::time::SystemTime;
+
     use candid::Principal;
+    use shared_utils::common::types::top_posts::post_score_index_item::PostStatus;
 
     use super::*;
 
     #[test]
     fn test_receive_top_home_feed_posts_from_publishing_canister_impl() {
         let mut canister_data = CanisterData::default();
+        let created_at_now = SystemTime::now();
 
         let top_posts_from_publishing_canister = vec![
-            PostScoreIndexItem {
+            PostScoreIndexItemV1 {
                 post_id: 1,
                 score: 1,
                 publisher_canister_id: Principal::from_text("aaaaa-aa").unwrap(),
+                is_nsfw: false,
+                status: PostStatus::ReadyToView,
+                created_at: Some(created_at_now),
             },
-            PostScoreIndexItem {
+            PostScoreIndexItemV1 {
                 post_id: 2,
                 score: 2,
                 publisher_canister_id: Principal::from_text("aaaaa-aa").unwrap(),
+                is_nsfw: false,
+                status: PostStatus::ReadyToView,
+                created_at: Some(created_at_now),
             },
-            PostScoreIndexItem {
+            PostScoreIndexItemV1 {
                 post_id: 3,
                 score: 3,
                 publisher_canister_id: Principal::from_text("aaaaa-aa").unwrap(),
+                is_nsfw: false,
+                status: PostStatus::ReadyToView,
+                created_at: Some(created_at_now),
             },
         ];
 
@@ -71,7 +84,7 @@ mod test {
         );
 
         let posts_index_sorted_by_home_feed_score =
-            &canister_data.posts_index_sorted_by_home_feed_score;
+            &canister_data.posts_index_sorted_by_home_feed_score_v1;
 
         assert_eq!(posts_index_sorted_by_home_feed_score.iter().count(), 3);
         assert_eq!(

--- a/src/canister/post_cache/src/api/home_feed/update_post_home_feed.rs
+++ b/src/canister/post_cache/src/api/home_feed/update_post_home_feed.rs
@@ -1,0 +1,81 @@
+use shared_utils::common::types::top_posts::post_score_index_item::PostScoreIndexItemV1;
+
+use crate::{data_model::CanisterData, CANISTER_DATA};
+
+#[ic_cdk::update]
+#[candid::candid_method(update)]
+fn update_post_home_feed(post: PostScoreIndexItemV1) {
+    CANISTER_DATA.with(|canister_data| {
+        let mut canister_data = canister_data.borrow_mut();
+
+        update_post_home_feed_impl(post, &mut canister_data);
+    });
+}
+
+fn update_post_home_feed_impl(post: PostScoreIndexItemV1, canister_data: &mut CanisterData) {
+    let item_prescence_index = &mut canister_data
+        .posts_index_sorted_by_home_feed_score_v1
+        .item_presence_index;
+
+    let global_id = (post.publisher_canister_id, post.post_id);
+    if let Some(_) = item_prescence_index.get(&global_id) {
+        canister_data
+            .posts_index_sorted_by_home_feed_score_v1
+            .replace(&post);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use candid::Principal;
+    use shared_utils::common::types::top_posts::post_score_index_item::PostStatus;
+    use std::time::SystemTime;
+
+    use super::*;
+
+    #[test]
+    fn test_update_post_home_feed_impl() {
+        let mut canister_data = CanisterData::default();
+        let created_at_now = SystemTime::now();
+
+        let post = PostScoreIndexItemV1 {
+            post_id: 1,
+            score: 1,
+            publisher_canister_id: Principal::from_text("aaaaa-aa").unwrap(),
+            is_nsfw: false,
+            status: PostStatus::ReadyToView,
+            created_at: Some(created_at_now),
+        };
+
+        canister_data
+            .posts_index_sorted_by_home_feed_score_v1
+            .replace(&post);
+
+        let new_post = PostScoreIndexItemV1 {
+            post_id: 1,
+            score: 10,
+            publisher_canister_id: Principal::from_text("aaaaa-aa").unwrap(),
+            is_nsfw: true,
+            status: PostStatus::BannedDueToUserReporting,
+            created_at: Some(created_at_now),
+        };
+
+        update_post_home_feed_impl(new_post, &mut canister_data);
+
+        let iter_posts = canister_data
+            .posts_index_sorted_by_home_feed_score_v1
+            .iter()
+            .collect::<Vec<_>>();
+
+        assert_eq!(iter_posts.len(), 1);
+        assert_eq!(iter_posts[0].post_id, 1);
+        assert_eq!(iter_posts[0].score, 10);
+        assert_eq!(
+            iter_posts[0].publisher_canister_id,
+            Principal::from_text("aaaaa-aa").unwrap()
+        );
+        assert_eq!(iter_posts[0].is_nsfw, true);
+        assert_eq!(iter_posts[0].status, PostStatus::BannedDueToUserReporting);
+        assert_eq!(iter_posts[0].created_at, Some(created_at_now));
+    }
+}

--- a/src/canister/post_cache/src/api/hot_or_not_feed/get_top_posts_aggregated_from_canisters_on_this_network_for_hot_or_not_feed.rs
+++ b/src/canister/post_cache/src/api/hot_or_not_feed/get_top_posts_aggregated_from_canisters_on_this_network_for_hot_or_not_feed.rs
@@ -50,6 +50,51 @@ fn get_top_posts_aggregated_from_canisters_on_this_network_for_hot_or_not_feed_i
         .collect())
 }
 
+#[ic_cdk::query]
+#[candid::candid_method(query)]
+fn get_top_posts_aggregated_from_canisters_on_this_network_for_hot_or_not_feed_cursor(
+    from_inclusive_index: u64,
+    limit: u64,
+) -> Result<Vec<PostScoreIndexItem>, TopPostsFetchError> {
+    CANISTER_DATA.with(|canister_data| {
+        let canister_data = canister_data.borrow();
+
+        get_top_posts_aggregated_from_canisters_on_this_network_for_hot_or_not_feed_cursor_impl(
+            from_inclusive_index,
+            limit,
+            &canister_data,
+        )
+    })
+}
+
+fn get_top_posts_aggregated_from_canisters_on_this_network_for_hot_or_not_feed_cursor_impl(
+    from_inclusive_index: u64,
+    limit: u64,
+    canister_data: &CanisterData,
+) -> Result<Vec<PostScoreIndexItem>, TopPostsFetchError> {
+    let all_posts = &canister_data.posts_index_sorted_by_hot_or_not_feed_score;
+
+    let (from_inclusive_index, limit) = pagination::get_pagination_bounds_cursor(
+        from_inclusive_index,
+        limit,
+        all_posts.iter().count() as u64,
+    )
+    .map_err(|e| match e {
+        PaginationError::InvalidBoundsPassed => TopPostsFetchError::InvalidBoundsPassed,
+        PaginationError::ReachedEndOfItemsList => TopPostsFetchError::ReachedEndOfItemsList,
+        PaginationError::ExceededMaxNumberOfItemsAllowedInOneRequest => {
+            TopPostsFetchError::ExceededMaxNumberOfItemsAllowedInOneRequest
+        }
+    })?;
+
+    Ok(all_posts
+        .iter()
+        .skip(from_inclusive_index as usize)
+        .take(limit as usize)
+        .cloned()
+        .collect::<Vec<PostScoreIndexItem>>())
+}
+
 #[cfg(test)]
 mod test {
     use candid::Principal;
@@ -112,12 +157,12 @@ mod test {
             .len() == 2
         );
     }
-    
-    
+
     #[test]
-    fn test_get_top_posts_aggregated_from_canisters_on_this_network_for_hot_or_not_feed_impl_with_indexes() {
+    fn test_get_top_posts_aggregated_from_canisters_on_this_network_for_hot_or_not_feed_impl_with_indexes(
+    ) {
         let mut canister_data = CanisterData::default();
-        
+
         let post_score_index_item_1 = PostScoreIndexItem {
             post_id: 1,
             score: 1,
@@ -143,7 +188,7 @@ mod test {
             score: 5,
             publisher_canister_id: Principal::anonymous(),
         };
-        
+
         canister_data
             .posts_index_sorted_by_hot_or_not_feed_score
             .replace(&post_score_index_item_1);
@@ -158,7 +203,7 @@ mod test {
         canister_data
             .posts_index_sorted_by_hot_or_not_feed_score
             .replace(&post_score_index_item_4);
-        
+
         canister_data
             .posts_index_sorted_by_hot_or_not_feed_score
             .replace(&post_score_index_item_5);
@@ -170,13 +215,88 @@ mod test {
                 &canister_data,
             );
         assert!(result.is_ok());
-        
+
         let posts = result.unwrap();
         assert_eq!(posts.len(), 1);
 
         let third_post = posts.get(0).unwrap();
         assert_eq!(third_post.post_id, 3);
         assert_eq!(third_post.score, 3);
+    }
 
+    #[test]
+    fn test_get_top_posts_aggregated_from_canisters_on_this_network_for_hot_or_not_feed_cursor_impl(
+    ) {
+        let mut canister_data = CanisterData::default();
+
+        let post_scores = vec![
+            PostScoreIndexItem {
+                post_id: 1,
+                score: 1,
+                publisher_canister_id: Principal::anonymous(),
+            },
+            PostScoreIndexItem {
+                post_id: 2,
+                score: 2,
+                publisher_canister_id: Principal::anonymous(),
+            },
+            PostScoreIndexItem {
+                post_id: 3,
+                score: 3,
+                publisher_canister_id: Principal::anonymous(),
+            },
+            PostScoreIndexItem {
+                post_id: 4,
+                score: 4,
+                publisher_canister_id: Principal::anonymous(),
+            },
+            PostScoreIndexItem {
+                post_id: 5,
+                score: 5,
+                publisher_canister_id: Principal::anonymous(),
+            },
+        ];
+
+        for post_score in post_scores {
+            canister_data
+                .posts_index_sorted_by_hot_or_not_feed_score
+                .replace(&post_score);
+        }
+
+        // Test with cursor 0
+        let result
+            = super::get_top_posts_aggregated_from_canisters_on_this_network_for_hot_or_not_feed_cursor_impl(
+                    0,
+                    3,
+                    &canister_data);
+
+        assert!(result.is_ok());
+        let posts = result.unwrap();
+        assert_eq!(posts.len(), 3);
+        assert_eq!(posts[0].post_id, 5);
+        assert_eq!(posts[1].post_id, 4);
+        assert_eq!(posts[2].post_id, 3);
+
+        // Test with cursor 3
+        let result
+            = super::get_top_posts_aggregated_from_canisters_on_this_network_for_hot_or_not_feed_cursor_impl(
+                        3,
+                        3,
+                        &canister_data);
+
+        assert!(result.is_ok());
+        let posts = result.unwrap();
+        assert_eq!(posts.len(), 2);
+        assert_eq!(posts[0].post_id, 2);
+        assert_eq!(posts[1].post_id, 1);
+
+        // Test with cursor 5
+        let result
+            = super::get_top_posts_aggregated_from_canisters_on_this_network_for_hot_or_not_feed_cursor_impl(
+                        5,
+                        3,
+                        &canister_data);
+
+        assert_eq!(result, Err(TopPostsFetchError::ReachedEndOfItemsList));
     }
 }

--- a/src/canister/post_cache/src/api/hot_or_not_feed/get_top_posts_aggregated_from_canisters_on_this_network_for_hot_or_not_feed.rs
+++ b/src/canister/post_cache/src/api/hot_or_not_feed/get_top_posts_aggregated_from_canisters_on_this_network_for_hot_or_not_feed.rs
@@ -1,6 +1,8 @@
 use crate::{data_model::CanisterData, CANISTER_DATA};
 use shared_utils::{
-    common::types::top_posts::post_score_index_item::PostScoreIndexItem,
+    common::types::top_posts::post_score_index_item::{
+        PostScoreIndexItem, PostScoreIndexItemV1, PostStatus,
+    },
     pagination::{self, PaginationError},
     types::canister_specific::post_cache::error_types::TopPostsFetchError,
 };
@@ -55,7 +57,9 @@ fn get_top_posts_aggregated_from_canisters_on_this_network_for_hot_or_not_feed_i
 fn get_top_posts_aggregated_from_canisters_on_this_network_for_hot_or_not_feed_cursor(
     from_inclusive_index: u64,
     limit: u64,
-) -> Result<Vec<PostScoreIndexItem>, TopPostsFetchError> {
+    is_nsfw: Option<bool>,
+    status: Option<PostStatus>,
+) -> Result<Vec<PostScoreIndexItemV1>, TopPostsFetchError> {
     CANISTER_DATA.with(|canister_data| {
         let canister_data = canister_data.borrow();
 
@@ -63,6 +67,8 @@ fn get_top_posts_aggregated_from_canisters_on_this_network_for_hot_or_not_feed_c
             from_inclusive_index,
             limit,
             &canister_data,
+            is_nsfw,
+            status,
         )
     })
 }
@@ -71,13 +77,33 @@ fn get_top_posts_aggregated_from_canisters_on_this_network_for_hot_or_not_feed_c
     from_inclusive_index: u64,
     limit: u64,
     canister_data: &CanisterData,
-) -> Result<Vec<PostScoreIndexItem>, TopPostsFetchError> {
-    let all_posts = &canister_data.posts_index_sorted_by_hot_or_not_feed_score;
+    is_nsfw: Option<bool>,
+    status: Option<PostStatus>,
+) -> Result<Vec<PostScoreIndexItemV1>, TopPostsFetchError> {
+    let all_posts = &canister_data.posts_index_sorted_by_hot_or_not_feed_score_v1;
+    let filter_fn = |post_item: &PostScoreIndexItemV1| {
+        if let Some(is_nsfw) = is_nsfw {
+            if post_item.is_nsfw != is_nsfw {
+                return false;
+            }
+        }
+
+        if let Some(status) = status.clone() {
+            if post_item.status != status {
+                return false;
+            }
+        }
+
+        true
+    };
 
     let (from_inclusive_index, limit) = pagination::get_pagination_bounds_cursor(
         from_inclusive_index,
         limit,
-        all_posts.iter().count() as u64,
+        all_posts
+            .iter()
+            .filter(|&post_item| filter_fn(post_item))
+            .count() as u64,
     )
     .map_err(|e| match e {
         PaginationError::InvalidBoundsPassed => TopPostsFetchError::InvalidBoundsPassed,
@@ -89,10 +115,11 @@ fn get_top_posts_aggregated_from_canisters_on_this_network_for_hot_or_not_feed_c
 
     Ok(all_posts
         .iter()
+        .filter(|&post_item| filter_fn(post_item))
         .skip(from_inclusive_index as usize)
         .take(limit as usize)
         .cloned()
-        .collect::<Vec<PostScoreIndexItem>>())
+        .collect::<Vec<PostScoreIndexItemV1>>())
 }
 
 #[cfg(test)]
@@ -228,38 +255,63 @@ mod test {
     fn test_get_top_posts_aggregated_from_canisters_on_this_network_for_hot_or_not_feed_cursor_impl(
     ) {
         let mut canister_data = CanisterData::default();
+        let created_at_now = std::time::SystemTime::now();
+        let created_at_earlier = created_at_now - std::time::Duration::from_secs(48 * 60 * 60 + 1);
 
         let post_scores = vec![
-            PostScoreIndexItem {
+            PostScoreIndexItemV1 {
                 post_id: 1,
                 score: 1,
                 publisher_canister_id: Principal::anonymous(),
+                is_nsfw: false,
+                status: PostStatus::ReadyToView,
+                created_at: Some(created_at_now),
             },
-            PostScoreIndexItem {
+            PostScoreIndexItemV1 {
                 post_id: 2,
                 score: 2,
                 publisher_canister_id: Principal::anonymous(),
+                is_nsfw: false,
+                status: PostStatus::ReadyToView,
+                created_at: Some(created_at_now),
             },
-            PostScoreIndexItem {
+            PostScoreIndexItemV1 {
                 post_id: 3,
                 score: 3,
                 publisher_canister_id: Principal::anonymous(),
+                is_nsfw: false,
+                status: PostStatus::ReadyToView,
+                created_at: Some(created_at_earlier),
             },
-            PostScoreIndexItem {
+            PostScoreIndexItemV1 {
                 post_id: 4,
                 score: 4,
                 publisher_canister_id: Principal::anonymous(),
+                is_nsfw: false,
+                status: PostStatus::ReadyToView,
+                created_at: Some(created_at_earlier),
             },
-            PostScoreIndexItem {
+            PostScoreIndexItemV1 {
                 post_id: 5,
                 score: 5,
                 publisher_canister_id: Principal::anonymous(),
+                is_nsfw: false,
+                status: PostStatus::ReadyToView,
+                created_at: Some(created_at_earlier),
+            },
+            PostScoreIndexItemV1 {
+                post_id: 1,
+                score: 6,
+                publisher_canister_id: Principal::anonymous(),
+                is_nsfw: true,
+                status: PostStatus::ReadyToView,
+                created_at: Some(created_at_earlier),
             },
         ];
 
         for post_score in post_scores {
             canister_data
-                .posts_index_sorted_by_hot_or_not_feed_score
+                .posts_index_sorted_by_hot_or_not_feed_score_v1
                 .replace(&post_score);
         }
 
@@ -267,36 +319,142 @@ mod test {
         let result
             = super::get_top_posts_aggregated_from_canisters_on_this_network_for_hot_or_not_feed_cursor_impl(
                     0,
-                    3,
-                    &canister_data);
+                    10,
+                    &canister_data, None, None);
 
         assert!(result.is_ok());
         let posts = result.unwrap();
-        assert_eq!(posts.len(), 3);
-        assert_eq!(posts[0].post_id, 5);
-        assert_eq!(posts[1].post_id, 4);
-        assert_eq!(posts[2].post_id, 3);
+        assert_eq!(posts.len(), 5);
+        assert_eq!(posts[0].post_id, 2);
+        assert_eq!(posts[1].post_id, 1);
+        assert_eq!(posts[2].post_id, 5);
+        assert_eq!(posts[3].post_id, 4);
+        assert_eq!(posts[4].post_id, 3);
 
         // Test with cursor 3
         let result
             = super::get_top_posts_aggregated_from_canisters_on_this_network_for_hot_or_not_feed_cursor_impl(
                         3,
                         3,
-                        &canister_data);
+                        &canister_data, None, None);
 
         assert!(result.is_ok());
         let posts = result.unwrap();
         assert_eq!(posts.len(), 2);
-        assert_eq!(posts[0].post_id, 2);
-        assert_eq!(posts[1].post_id, 1);
+        assert_eq!(posts[0].post_id, 4);
+        assert_eq!(posts[1].post_id, 3);
 
         // Test with cursor 5
         let result
             = super::get_top_posts_aggregated_from_canisters_on_this_network_for_hot_or_not_feed_cursor_impl(
                         5,
                         3,
-                        &canister_data);
+                        &canister_data, None, None);
 
         assert_eq!(result, Err(TopPostsFetchError::ReachedEndOfItemsList));
+    }
+
+    #[test]
+    fn test_get_top_posts_aggregated_from_canisters_on_this_network_for_hot_or_not_feed_cursor_impl_with_nsfw_filter(
+    ) {
+        let mut canister_data = CanisterData::default();
+        let created_at_now = std::time::SystemTime::now();
+        let created_at_earlier = created_at_now - std::time::Duration::from_secs(48 * 60 * 60 + 1);
+
+        let post_scores = vec![
+            PostScoreIndexItemV1 {
+                post_id: 1,
+                score: 1,
+                publisher_canister_id: Principal::anonymous(),
+                is_nsfw: false,
+                status: PostStatus::ReadyToView,
+                created_at: Some(created_at_now),
+            },
+            PostScoreIndexItemV1 {
+                post_id: 2,
+                score: 2,
+                publisher_canister_id: Principal::anonymous(),
+                is_nsfw: false,
+                status: PostStatus::ReadyToView,
+                created_at: Some(created_at_now),
+            },
+            PostScoreIndexItemV1 {
+                post_id: 3,
+                score: 3,
+                publisher_canister_id: Principal::anonymous(),
+                is_nsfw: true,
+                status: PostStatus::Deleted,
+                created_at: Some(created_at_earlier),
+            },
+            PostScoreIndexItemV1 {
+                post_id: 4,
+                score: 4,
+                publisher_canister_id: Principal::anonymous(),
+                is_nsfw: true,
+                status: PostStatus::Uploaded,
+                created_at: Some(created_at_earlier),
+            },
+            PostScoreIndexItemV1 {
+                post_id: 5,
+                score: 5,
+                publisher_canister_id: Principal::anonymous(),
+                is_nsfw: false,
+                status: PostStatus::ReadyToView,
+                created_at: Some(created_at_earlier),
+            },
+            PostScoreIndexItemV1 {
+                post_id: 1,
+                score: 6,
+                publisher_canister_id: Principal::anonymous(),
+                is_nsfw: true,
+                status: PostStatus::Deleted,
+                created_at: Some(created_at_earlier),
+            },
+        ];
+
+        for post_score in post_scores {
+            canister_data
+                .posts_index_sorted_by_hot_or_not_feed_score_v1
+                .replace(&post_score);
+        }
+
+        // Test with NSFW filter
+        let result
+            = super::get_top_posts_aggregated_from_canisters_on_this_network_for_hot_or_not_feed_cursor_impl(
+                    0,
+                    3,
+                    &canister_data, Some(false), None);
+
+        assert!(result.is_ok());
+        let posts = result.unwrap();
+        assert_eq!(posts.len(), 2);
+        assert_eq!(posts[0].post_id, 2);
+        assert_eq!(posts[1].post_id, 5);
+
+        // Test with status filter
+        let result
+            = super::get_top_posts_aggregated_from_canisters_on_this_network_for_hot_or_not_feed_cursor_impl(
+                    0,
+                    3,
+                    &canister_data, None, Some(PostStatus::Uploaded));
+
+        assert!(result.is_ok());
+        let posts = result.unwrap();
+        assert_eq!(posts.len(), 1);
+        assert_eq!(posts[0].post_id, 4);
+
+        // Test with both filters
+
+        let result
+            = super::get_top_posts_aggregated_from_canisters_on_this_network_for_hot_or_not_feed_cursor_impl(
+                    0,
+                    3,
+                    &canister_data, Some(true), Some(PostStatus::Deleted));
+
+        assert!(result.is_ok());
+        let posts = result.unwrap();
+        assert_eq!(posts.len(), 2);
+        assert_eq!(posts[0].post_id, 1);
+        assert_eq!(posts[1].post_id, 3);
     }
 }

--- a/src/canister/post_cache/src/api/hot_or_not_feed/mod.rs
+++ b/src/canister/post_cache/src/api/hot_or_not_feed/mod.rs
@@ -1,2 +1,3 @@
 pub mod get_top_posts_aggregated_from_canisters_on_this_network_for_hot_or_not_feed;
 pub mod receive_top_hot_or_not_feed_posts_from_publishing_canister;
+pub mod update_post_hot_or_not_feed;

--- a/src/canister/post_cache/src/api/hot_or_not_feed/receive_top_hot_or_not_feed_posts_from_publishing_canister.rs
+++ b/src/canister/post_cache/src/api/hot_or_not_feed/receive_top_hot_or_not_feed_posts_from_publishing_canister.rs
@@ -1,11 +1,11 @@
-use shared_utils::common::types::top_posts::post_score_index_item::PostScoreIndexItem;
+use shared_utils::common::types::top_posts::post_score_index_item::PostScoreIndexItemV1;
 
 use crate::{data_model::CanisterData, CANISTER_DATA};
 
 #[ic_cdk::update]
 #[candid::candid_method(update)]
 fn receive_top_hot_or_not_feed_posts_from_publishing_canister(
-    top_posts_from_publishing_canister: Vec<PostScoreIndexItem>,
+    top_posts_from_publishing_canister: Vec<PostScoreIndexItemV1>,
 ) {
     CANISTER_DATA.with(|canister_data| {
         let mut canister_data = canister_data.borrow_mut();
@@ -18,11 +18,11 @@ fn receive_top_hot_or_not_feed_posts_from_publishing_canister(
 }
 
 fn receive_top_hot_or_not_feed_posts_from_publishing_canister_impl(
-    top_posts_from_publishing_canister: Vec<PostScoreIndexItem>,
+    top_posts_from_publishing_canister: Vec<PostScoreIndexItemV1>,
     canister_data: &mut CanisterData,
 ) {
     let posts_index_sorted_by_hot_or_not_feed_score =
-        &mut canister_data.posts_index_sorted_by_hot_or_not_feed_score;
+        &mut canister_data.posts_index_sorted_by_hot_or_not_feed_score_v1;
 
     for post_score_index_item in top_posts_from_publishing_canister {
         posts_index_sorted_by_hot_or_not_feed_score.replace(&post_score_index_item);
@@ -39,29 +39,42 @@ fn receive_top_hot_or_not_feed_posts_from_publishing_canister_impl(
 
 #[cfg(test)]
 mod test {
+    use std::time::SystemTime;
+
     use candid::Principal;
+    use shared_utils::common::types::top_posts::post_score_index_item::PostStatus;
 
     use super::*;
 
     #[test]
     fn test_receive_top_hot_or_not_feed_posts_from_publishing_canister_impl() {
         let mut canister_data = CanisterData::default();
+        let created_at_now = SystemTime::now();
 
         let top_posts_from_publishing_canister = vec![
-            PostScoreIndexItem {
+            PostScoreIndexItemV1 {
                 post_id: 1,
                 score: 1,
                 publisher_canister_id: Principal::from_text("aaaaa-aa").unwrap(),
+                is_nsfw: false,
+                status: PostStatus::ReadyToView,
+                created_at: Some(created_at_now),
             },
-            PostScoreIndexItem {
+            PostScoreIndexItemV1 {
+                post_id: 2,
+                score: 2,
+                publisher_canister_id: Principal::from_text("aaaaa-aa").unwrap(),
+                is_nsfw: false,
+                status: PostStatus::ReadyToView,
+                created_at: Some(created_at_now),
+            },
+            PostScoreIndexItemV1 {
                 post_id: 3,
                 score: 3,
-                publisher_canister_id: Principal::anonymous(),
-            },
-            PostScoreIndexItem {
-                post_id: 5,
-                score: 5,
                 publisher_canister_id: Principal::from_text("aaaaa-aa").unwrap(),
+                is_nsfw: false,
+                status: PostStatus::ReadyToView,
+                created_at: Some(created_at_now),
             },
         ];
 
@@ -71,7 +84,7 @@ mod test {
         );
 
         let posts_index_sorted_by_hot_or_not_feed_score =
-            &canister_data.posts_index_sorted_by_hot_or_not_feed_score;
+            &canister_data.posts_index_sorted_by_hot_or_not_feed_score_v1;
 
         assert_eq!(
             posts_index_sorted_by_hot_or_not_feed_score.iter().count(),

--- a/src/canister/post_cache/src/api/hot_or_not_feed/receive_top_hot_or_not_feed_posts_from_publishing_canister.rs
+++ b/src/canister/post_cache/src/api/hot_or_not_feed/receive_top_hot_or_not_feed_posts_from_publishing_canister.rs
@@ -1,4 +1,6 @@
-use shared_utils::common::types::top_posts::post_score_index_item::PostScoreIndexItemV1;
+use shared_utils::common::types::top_posts::post_score_index_item::{
+    PostScoreIndexItem, PostScoreIndexItemV1,
+};
 
 use crate::{
     api::feed::trigger_update_indexes::{
@@ -33,8 +35,31 @@ fn receive_top_hot_or_not_feed_posts_from_publishing_canister_impl(
     let posts_index_sorted_by_hot_or_not_feed_score =
         &mut canister_data.posts_index_sorted_by_hot_or_not_feed_score_v1;
 
-    for post_score_index_item in top_posts_from_publishing_canister {
+    for post_score_index_item in top_posts_from_publishing_canister.clone() {
         posts_index_sorted_by_hot_or_not_feed_score.replace(&post_score_index_item);
+    }
+
+    if posts_index_sorted_by_hot_or_not_feed_score.iter().count() > 1500 {
+        *posts_index_sorted_by_hot_or_not_feed_score = posts_index_sorted_by_hot_or_not_feed_score
+            .into_iter()
+            .take(1000)
+            .cloned()
+            .collect();
+    }
+
+    // old code
+    // TODO: remove this after filter migration
+
+    let posts_index_sorted_by_hot_or_not_feed_score =
+        &mut canister_data.posts_index_sorted_by_hot_or_not_feed_score;
+
+    for post_score_index_item in top_posts_from_publishing_canister {
+        let old_post = PostScoreIndexItem {
+            score: post_score_index_item.score,
+            post_id: post_score_index_item.post_id,
+            publisher_canister_id: post_score_index_item.publisher_canister_id,
+        };
+        posts_index_sorted_by_hot_or_not_feed_score.replace(&old_post);
     }
 
     if posts_index_sorted_by_hot_or_not_feed_score.iter().count() > 1500 {

--- a/src/canister/post_cache/src/api/hot_or_not_feed/receive_top_hot_or_not_feed_posts_from_publishing_canister.rs
+++ b/src/canister/post_cache/src/api/hot_or_not_feed/receive_top_hot_or_not_feed_posts_from_publishing_canister.rs
@@ -1,6 +1,12 @@
 use shared_utils::common::types::top_posts::post_score_index_item::PostScoreIndexItemV1;
 
-use crate::{data_model::CanisterData, CANISTER_DATA};
+use crate::{
+    api::feed::trigger_update_indexes::{
+        self, trigger_reconcile_scores, trigger_update_hot_or_not_index,
+    },
+    data_model::CanisterData,
+    CANISTER_DATA,
+};
 
 #[ic_cdk::update]
 #[candid::candid_method(update)]
@@ -15,6 +21,9 @@ fn receive_top_hot_or_not_feed_posts_from_publishing_canister(
             &mut canister_data,
         );
     });
+
+    trigger_update_hot_or_not_index();
+    trigger_reconcile_scores();
 }
 
 fn receive_top_hot_or_not_feed_posts_from_publishing_canister_impl(

--- a/src/canister/post_cache/src/api/hot_or_not_feed/update_post_hot_or_not_feed.rs
+++ b/src/canister/post_cache/src/api/hot_or_not_feed/update_post_hot_or_not_feed.rs
@@ -1,0 +1,95 @@
+use shared_utils::common::types::top_posts::post_score_index_item::PostScoreIndexItemV1;
+
+use crate::{data_model::CanisterData, CANISTER_DATA};
+
+#[ic_cdk::update]
+#[candid::candid_method(update)]
+fn update_post_hot_or_not_feed(post: PostScoreIndexItemV1) {
+    CANISTER_DATA.with(|canister_data| {
+        let mut canister_data = canister_data.borrow_mut();
+
+        update_post_hot_or_not_feed_impl(post, &mut canister_data);
+    });
+}
+
+fn update_post_hot_or_not_feed_impl(post: PostScoreIndexItemV1, canister_data: &mut CanisterData) {
+    let item_prescence_index = &mut canister_data
+        .posts_index_sorted_by_hot_or_not_feed_score_v1
+        .item_presence_index;
+
+    let global_id = (post.publisher_canister_id, post.post_id);
+    if let Some(_) = item_prescence_index.get(&global_id) {
+        canister_data
+            .posts_index_sorted_by_hot_or_not_feed_score_v1
+            .replace(&post);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use candid::Principal;
+    use shared_utils::common::types::top_posts::post_score_index_item::PostStatus;
+    use std::time::{Duration, SystemTime};
+
+    use super::*;
+
+    #[test]
+    fn test_update_post_hot_or_not_feed_impl() {
+        let mut canister_data = CanisterData::default();
+        let created_at_now = SystemTime::now();
+        let created_at_ealier = created_at_now - Duration::from_secs(48 * 60 * 60 + 1);
+
+        let post_1 = PostScoreIndexItemV1 {
+            post_id: 1,
+            score: 1,
+            publisher_canister_id: Principal::from_text("aaaaa-aa").unwrap(),
+            is_nsfw: false,
+            status: PostStatus::ReadyToView,
+            created_at: Some(created_at_now),
+        };
+        let post_2 = PostScoreIndexItemV1 {
+            post_id: 2,
+            score: 2,
+            publisher_canister_id: Principal::from_text("aaaaa-aa").unwrap(),
+            is_nsfw: false,
+            status: PostStatus::ReadyToView,
+            created_at: Some(created_at_now),
+        };
+
+        canister_data
+            .posts_index_sorted_by_hot_or_not_feed_score_v1
+            .replace(&post_1);
+        canister_data
+            .posts_index_sorted_by_hot_or_not_feed_score_v1
+            .replace(&post_2);
+
+        let iter_posts = canister_data
+            .posts_index_sorted_by_hot_or_not_feed_score_v1
+            .iter()
+            .collect::<Vec<_>>();
+
+        assert_eq!(iter_posts.len(), 2);
+        assert_eq!(iter_posts[0], &post_2);
+        assert_eq!(iter_posts[1], &post_1);
+
+        let new_post_2 = PostScoreIndexItemV1 {
+            post_id: 2,
+            score: 10,
+            publisher_canister_id: Principal::from_text("aaaaa-aa").unwrap(),
+            is_nsfw: true,
+            status: PostStatus::BannedDueToUserReporting,
+            created_at: Some(created_at_ealier),
+        };
+
+        update_post_hot_or_not_feed_impl(new_post_2.clone(), &mut canister_data);
+
+        let iter_posts = canister_data
+            .posts_index_sorted_by_hot_or_not_feed_score_v1
+            .iter()
+            .collect::<Vec<_>>();
+
+        assert_eq!(iter_posts.len(), 2);
+        assert_eq!(iter_posts[0], &post_1);
+        assert_eq!(iter_posts[1], &new_post_2);
+    }
+}

--- a/src/canister/post_cache/src/data_model/mod.rs
+++ b/src/canister/post_cache/src/data_model/mod.rs
@@ -6,6 +6,7 @@ use shared_utils::common::types::{
         post_score_home_index::PostScoreHomeIndex,
         post_score_hot_or_not_index::PostScoreHotOrNotIndex, post_score_index::PostScoreIndex,
     },
+    version_details::VersionDetails,
 };
 
 #[derive(Default, CandidType, Deserialize, Serialize)]
@@ -17,4 +18,6 @@ pub struct CanisterData {
     pub posts_index_sorted_by_home_feed_score_v1: PostScoreHomeIndex,
     #[serde(default)]
     pub posts_index_sorted_by_hot_or_not_feed_score_v1: PostScoreHotOrNotIndex,
+    #[serde(default)]
+    pub version_details: Option<VersionDetails>,
 }

--- a/src/canister/post_cache/src/data_model/mod.rs
+++ b/src/canister/post_cache/src/data_model/mod.rs
@@ -23,7 +23,7 @@ pub struct CanisterData {
     #[serde(default)]
     pub metadata: Metadata,
     #[serde(default)]
-    pub version_details: Option<VersionDetails>,
+    pub version_details: VersionDetails,
 }
 
 #[derive(Default, CandidType, Deserialize, Serialize)]

--- a/src/canister/post_cache/src/data_model/mod.rs
+++ b/src/canister/post_cache/src/data_model/mod.rs
@@ -1,3 +1,5 @@
+use std::time::SystemTime;
+
 use candid::{CandidType, Deserialize};
 use serde::Serialize;
 use shared_utils::common::types::{
@@ -19,5 +21,13 @@ pub struct CanisterData {
     #[serde(default)]
     pub posts_index_sorted_by_hot_or_not_feed_score_v1: PostScoreHotOrNotIndex,
     #[serde(default)]
+    pub metadata: Metadata,
+    #[serde(default)]
     pub version_details: Option<VersionDetails>,
+}
+
+#[derive(Default, CandidType, Deserialize, Serialize)]
+pub struct Metadata {
+    pub last_updated_hot_or_not_timestamp_index: Option<SystemTime>,
+    pub last_updated_reconcile_scores: Option<SystemTime>,
 }

--- a/src/canister/post_cache/src/data_model/mod.rs
+++ b/src/canister/post_cache/src/data_model/mod.rs
@@ -1,7 +1,11 @@
 use candid::{CandidType, Deserialize};
 use serde::Serialize;
 use shared_utils::common::types::{
-    known_principal::KnownPrincipalMap, top_posts::post_score_index::PostScoreIndex,
+    known_principal::KnownPrincipalMap,
+    top_posts::{
+        post_score_home_index::PostScoreHomeIndex,
+        post_score_hot_or_not_index::PostScoreHotOrNotIndex, post_score_index::PostScoreIndex,
+    },
 };
 
 #[derive(Default, CandidType, Deserialize, Serialize)]
@@ -9,4 +13,8 @@ pub struct CanisterData {
     pub known_principal_ids: KnownPrincipalMap,
     pub posts_index_sorted_by_home_feed_score: PostScoreIndex,
     pub posts_index_sorted_by_hot_or_not_feed_score: PostScoreIndex,
+    #[serde(default)]
+    pub posts_index_sorted_by_home_feed_score_v1: PostScoreHomeIndex,
+    #[serde(default)]
+    pub posts_index_sorted_by_hot_or_not_feed_score_v1: PostScoreHotOrNotIndex,
 }

--- a/src/canister/post_cache/src/lib.rs
+++ b/src/canister/post_cache/src/lib.rs
@@ -6,7 +6,8 @@ use data_model::CanisterData;
 use shared_utils::{
     canister_specific::post_cache::types::arg::PostCacheInitArgs,
     common::types::{
-        known_principal::KnownPrincipalType, top_posts::post_score_index_item::PostScoreIndexItem,
+        known_principal::KnownPrincipalType,
+        top_posts::post_score_index_item::{PostScoreIndexItem, PostScoreIndexItemV1, PostStatus},
     },
     types::canister_specific::post_cache::error_types::TopPostsFetchError,
 };

--- a/src/canister/user_index/src/api/canister_lifecycle/post_upgrade.rs
+++ b/src/canister/user_index/src/api/canister_lifecycle/post_upgrade.rs
@@ -1,13 +1,16 @@
 use std::time::Duration;
 
-use shared_utils::{common::utils::{stable_memory_serializer_deserializer, system_time}, canister_specific::user_index::types::args::UserIndexInitArgs};
+use shared_utils::{
+    canister_specific::user_index::types::args::UserIndexInitArgs,
+    common::utils::{stable_memory_serializer_deserializer, system_time},
+};
 
 use crate::{
     api::{
         upgrade_individual_user_template::update_user_index_upgrade_user_canisters_with_latest_wasm,
         well_known_principal::update_locally_stored_well_known_principals,
     },
-    data_model::{configuration::Configuration, CanisterData, canister_upgrade::UpgradeStatus},
+    data_model::{canister_upgrade::UpgradeStatus, configuration::Configuration, CanisterData},
     CANISTER_DATA,
 };
 
@@ -17,23 +20,22 @@ use super::pre_upgrade::BUFFER_SIZE_BYTES;
 fn post_upgrade() {
     restore_data_from_stable_memory();
     update_version_from_args();
-    // upgrade_all_indexed_user_canisters();
+    upgrade_all_indexed_user_canisters();
 }
 
 fn update_version_from_args() {
-    let (upgrade_args, ) = ic_cdk::api::call::arg_data::<(UserIndexInitArgs,)>();
+    let (upgrade_args,) = ic_cdk::api::call::arg_data::<(UserIndexInitArgs,)>();
     CANISTER_DATA.with(|canister_data_ref| {
-      let last_upgrade_status = canister_data_ref.borrow().last_run_upgrade_status.clone();
-       let upgrade_status = UpgradeStatus {
-        last_run_on: system_time::get_current_system_time_from_ic(),
-        failed_canister_ids: vec![],
-        version_number: last_upgrade_status.version_number,
-        successful_upgrade_count: 0,
-        version: upgrade_args.version
-       };
-       canister_data_ref.borrow_mut().last_run_upgrade_status = upgrade_status;
+        let last_upgrade_status = canister_data_ref.borrow().last_run_upgrade_status.clone();
+        let upgrade_status = UpgradeStatus {
+            last_run_on: system_time::get_current_system_time_from_ic(),
+            failed_canister_ids: vec![],
+            version_number: last_upgrade_status.version_number,
+            successful_upgrade_count: 0,
+            version: upgrade_args.version,
+        };
+        canister_data_ref.borrow_mut().last_run_upgrade_status = upgrade_status;
     })
-
 }
 
 fn restore_data_from_stable_memory() {

--- a/src/lib/integration_tests/Cargo.toml
+++ b/src/lib/integration_tests/Cargo.toml
@@ -8,6 +8,7 @@ edition = "2021"
 [dependencies]
 candid = { workspace = true }
 ic-cdk = { workspace = true }
+pocket-ic = "2.0.1"
 shared_utils = { workspace = true }
 
 [dev-dependencies]

--- a/src/lib/integration_tests/Cargo.toml
+++ b/src/lib/integration_tests/Cargo.toml
@@ -15,3 +15,7 @@ shared_utils = { workspace = true }
 ic-test-state-machine-client = { workspace = true }
 serde.workspace = true
 test_utils = { workspace = true }
+
+
+[features]
+feed_filter_upgrade_test = []

--- a/src/lib/integration_tests/Cargo.toml
+++ b/src/lib/integration_tests/Cargo.toml
@@ -13,4 +13,5 @@ shared_utils = { workspace = true }
 
 [dev-dependencies]
 ic-test-state-machine-client = { workspace = true }
+serde.workspace = true
 test_utils = { workspace = true }

--- a/src/lib/integration_tests/tests/hot_or_not/hot_or_not_timely_index_update_test.rs
+++ b/src/lib/integration_tests/tests/hot_or_not/hot_or_not_timely_index_update_test.rs
@@ -1,0 +1,279 @@
+use std::{collections::HashMap, thread, time::Duration};
+
+use candid::encode_one;
+use pocket_ic::{PocketIc, WasmResult};
+use shared_utils::{
+    canister_specific::{
+        individual_user_template::types::{
+            arg::IndividualUserTemplateInitArgs, post::PostDetailsFromFrontend,
+        },
+        post_cache::types::arg::PostCacheInitArgs,
+    },
+    common::types::{
+        known_principal::KnownPrincipalType, top_posts::post_score_index_item::PostScoreIndexItemV1,
+    },
+    types::canister_specific::post_cache::error_types::TopPostsFetchError,
+};
+use test_utils::setup::test_constants::{
+    get_mock_user_alice_principal_id, get_mock_user_bob_principal_id,
+    get_mock_user_charlie_principal_id, get_mock_user_dan_principal_id,
+};
+
+const POST_CACHE_WASM_PATH: &str =
+    "../../../target/wasm32-unknown-unknown/release/post_cache.wasm.gz";
+const INDIVIDUAL_TEMPLATE_WASM_PATH: &str =
+    "../../../target/wasm32-unknown-unknown/release/individual_user_template.wasm.gz";
+
+#[test]
+fn hot_or_not_timely_update_test() {
+    let pic = PocketIc::new();
+
+    let alice_principal_id = get_mock_user_alice_principal_id();
+    let bob_principal_id = get_mock_user_bob_principal_id();
+    let charlie_prinicipal_id = get_mock_user_charlie_principal_id();
+    let dan_prinicipal_id = get_mock_user_dan_principal_id();
+
+    // Init post cache canister
+
+    let post_cache_canister_id = pic.create_canister();
+    pic.add_cycles(post_cache_canister_id, 2_000_000_000_000);
+
+    let post_cache_wasm_bytes = post_cache_canister_wasm();
+    let post_cache_args = PostCacheInitArgs {
+        known_principal_ids: None,
+        upgrade_version_number: None,
+        version: "1".to_string(),
+    };
+    let post_cache_args_bytes = encode_one(post_cache_args).unwrap();
+
+    pic.install_canister(
+        post_cache_canister_id,
+        post_cache_wasm_bytes,
+        post_cache_args_bytes,
+        None,
+    );
+
+    // Individual template canisters
+
+    let individual_template_wasm_bytes = individual_template_canister_wasm();
+    let mut known_prinicipal_values = HashMap::new();
+    known_prinicipal_values.insert(
+        KnownPrincipalType::CanisterIdPostCache,
+        post_cache_canister_id,
+    );
+
+    // Init individual template canister - alice
+
+    let alice_individual_template_canister_id = pic.create_canister();
+    pic.add_cycles(alice_individual_template_canister_id, 2_000_000_000_000);
+
+    let individual_template_args = IndividualUserTemplateInitArgs {
+        known_principal_ids: Some(known_prinicipal_values.clone()),
+        profile_owner: Some(alice_principal_id),
+        upgrade_version_number: None,
+        url_to_send_canister_metrics_to: None,
+        version: "1".to_string(),
+    };
+    let individual_template_args_bytes = encode_one(individual_template_args).unwrap();
+
+    pic.install_canister(
+        alice_individual_template_canister_id,
+        individual_template_wasm_bytes.clone(),
+        individual_template_args_bytes,
+        None,
+    );
+
+    // Init individual template canister - bob
+
+    let bob_individual_template_canister_id = pic.create_canister();
+    pic.add_cycles(bob_individual_template_canister_id, 2_000_000_000_000);
+
+    let individual_template_args = IndividualUserTemplateInitArgs {
+        known_principal_ids: Some(known_prinicipal_values.clone()),
+        profile_owner: Some(bob_principal_id),
+        upgrade_version_number: None,
+        url_to_send_canister_metrics_to: None,
+        version: "1".to_string(),
+    };
+    let individual_template_args_bytes = encode_one(individual_template_args).unwrap();
+
+    pic.install_canister(
+        bob_individual_template_canister_id,
+        individual_template_wasm_bytes.clone(),
+        individual_template_args_bytes,
+        None,
+    );
+
+    // Init individual template canister - charlie
+
+    let charlie_individual_template_canister_id = pic.create_canister();
+    pic.add_cycles(charlie_individual_template_canister_id, 2_000_000_000_000);
+
+    let individual_template_args = IndividualUserTemplateInitArgs {
+        known_principal_ids: Some(known_prinicipal_values.clone()),
+        profile_owner: Some(charlie_prinicipal_id),
+        upgrade_version_number: None,
+        url_to_send_canister_metrics_to: None,
+        version: "1".to_string(),
+    };
+    let individual_template_args_bytes = encode_one(individual_template_args).unwrap();
+
+    pic.install_canister(
+        charlie_individual_template_canister_id,
+        individual_template_wasm_bytes.clone(),
+        individual_template_args_bytes,
+        None,
+    );
+
+    // Init individual template canister - dan
+
+    let dan_individual_template_canister_id = pic.create_canister();
+    pic.add_cycles(dan_individual_template_canister_id, 2_000_000_000_000);
+
+    let individual_template_args = IndividualUserTemplateInitArgs {
+        known_principal_ids: Some(known_prinicipal_values.clone()),
+        profile_owner: Some(dan_prinicipal_id),
+        upgrade_version_number: None,
+        url_to_send_canister_metrics_to: None,
+        version: "1".to_string(),
+    };
+    let individual_template_args_bytes = encode_one(individual_template_args).unwrap();
+
+    pic.install_canister(
+        dan_individual_template_canister_id,
+        individual_template_wasm_bytes.clone(),
+        individual_template_args_bytes,
+        None,
+    );
+
+    // Create posts
+    // Alice creates a post
+
+    let alice_post_1 = PostDetailsFromFrontend {
+        is_nsfw: false,
+        description: "This is a fun video to watch".to_string(),
+        hashtags: vec!["fun".to_string(), "video".to_string()],
+        video_uid: "abcd#1234".to_string(),
+        creator_consent_for_inclusion_in_hot_or_not: true,
+    };
+    let res = pic
+        .update_call(
+            alice_individual_template_canister_id,
+            alice_principal_id,
+            "add_post_v2",
+            encode_one(alice_post_1).unwrap(),
+        )
+        .map(|reply_payload| {
+            let newly_created_post_id_result: Result<u64, String> = match reply_payload {
+                WasmResult::Reply(payload) => candid::decode_one(&payload).unwrap(),
+                _ => panic!("\n🛑 add_post failed\n"),
+            };
+            newly_created_post_id_result.unwrap()
+        })
+        .unwrap();
+
+    let alice_post_2 = PostDetailsFromFrontend {
+        is_nsfw: false,
+        description: "This is a fun video to watch 2".to_string(),
+        hashtags: vec!["fun".to_string(), "video".to_string()],
+        video_uid: "abcd#12345".to_string(),
+        creator_consent_for_inclusion_in_hot_or_not: true,
+    };
+    let res = pic
+        .update_call(
+            alice_individual_template_canister_id,
+            alice_principal_id,
+            "add_post_v2",
+            encode_one(alice_post_2).unwrap(),
+        )
+        .map(|reply_payload| {
+            let newly_created_post_id_result: Result<u64, String> = match reply_payload {
+                WasmResult::Reply(payload) => candid::decode_one(&payload).unwrap(),
+                _ => panic!("\n🛑 add_post failed\n"),
+            };
+            newly_created_post_id_result.unwrap()
+        })
+        .unwrap();
+
+    // Forward timer
+    pic.advance_time(Duration::from_secs(48 * 60 * 60 + 1));
+
+    let alice_post_3 = PostDetailsFromFrontend {
+        is_nsfw: false,
+        description: "This is a fun video to watch - alice".to_string(),
+        hashtags: vec!["fun".to_string(), "video".to_string()],
+        video_uid: "abcd#123456".to_string(),
+        creator_consent_for_inclusion_in_hot_or_not: true,
+    };
+    let res = pic
+        .update_call(
+            alice_individual_template_canister_id,
+            alice_principal_id,
+            "add_post_v2",
+            encode_one(alice_post_3).unwrap(),
+        )
+        .map(|reply_payload| {
+            let newly_created_post_id_result: Result<u64, String> = match reply_payload {
+                WasmResult::Reply(payload) => candid::decode_one(&payload).unwrap(),
+                _ => panic!("\n🛑 add_post failed\n"),
+            };
+            newly_created_post_id_result.unwrap()
+        })
+        .unwrap();
+
+    // thread::sleep(Duration::from_secs(5));
+
+    // Call post cache canister to get the home feed posts
+    let res = pic
+        .query_call(
+            post_cache_canister_id,
+            bob_principal_id,
+            "get_top_posts_aggregated_from_canisters_on_this_network_for_home_feed_cursor",
+            candid::encode_args((0 as u64, 10 as u64)).unwrap(),
+        )
+        .map(|reply_payload| {
+            let posts: Result<Vec<PostScoreIndexItemV1>, TopPostsFetchError> = match reply_payload {
+                WasmResult::Reply(payload) => candid::decode_one(&payload).unwrap(),
+                _ => panic!("\n🛑 get_posts failed\n"),
+            };
+            posts
+        })
+        .unwrap();
+
+    let posts = res.unwrap();
+    assert_eq!(posts.len(), 3);
+    assert_eq!(posts[0].post_id, 0);
+    assert_eq!(posts[1].post_id, 1);
+    assert_eq!(posts[2].post_id, 2);
+
+    // Call post cache canister to get the hot or not feed posts
+    let res = pic
+        .query_call(
+            post_cache_canister_id,
+            bob_principal_id,
+            "get_top_posts_aggregated_from_canisters_on_this_network_for_hot_or_not_feed_cursor",
+            candid::encode_args((0 as u64, 10 as u64)).unwrap(),
+        )
+        .map(|reply_payload| {
+            let posts: Result<Vec<PostScoreIndexItemV1>, TopPostsFetchError> = match reply_payload {
+                WasmResult::Reply(payload) => candid::decode_one(&payload).unwrap(),
+                _ => panic!("\n🛑 get_posts failed\n"),
+            };
+            posts
+        })
+        .unwrap();
+
+    let posts = res.unwrap();
+    assert_eq!(posts.len(), 3);
+    assert_eq!(posts[0].post_id, 2);
+    assert_eq!(posts[1].post_id, 0);
+    assert_eq!(posts[2].post_id, 1);
+}
+
+fn individual_template_canister_wasm() -> Vec<u8> {
+    std::fs::read(INDIVIDUAL_TEMPLATE_WASM_PATH).unwrap()
+}
+
+fn post_cache_canister_wasm() -> Vec<u8> {
+    std::fs::read(POST_CACHE_WASM_PATH).unwrap()
+}

--- a/src/lib/integration_tests/tests/hot_or_not/hot_or_not_timely_index_update_test.rs
+++ b/src/lib/integration_tests/tests/hot_or_not/hot_or_not_timely_index_update_test.rs
@@ -1,4 +1,4 @@
-use std::{collections::HashMap, thread, time::Duration};
+use std::{collections::HashMap, time::Duration};
 
 use candid::encode_one;
 use pocket_ic::{PocketIc, WasmResult};
@@ -30,8 +30,6 @@ fn hot_or_not_timely_update_test() {
 
     let alice_principal_id = get_mock_user_alice_principal_id();
     let bob_principal_id = get_mock_user_bob_principal_id();
-    let charlie_prinicipal_id = get_mock_user_charlie_principal_id();
-    let dan_prinicipal_id = get_mock_user_dan_principal_id();
 
     // Init post cache canister
 
@@ -78,69 +76,6 @@ fn hot_or_not_timely_update_test() {
 
     pic.install_canister(
         alice_individual_template_canister_id,
-        individual_template_wasm_bytes.clone(),
-        individual_template_args_bytes,
-        None,
-    );
-
-    // Init individual template canister - bob
-
-    let bob_individual_template_canister_id = pic.create_canister();
-    pic.add_cycles(bob_individual_template_canister_id, 2_000_000_000_000);
-
-    let individual_template_args = IndividualUserTemplateInitArgs {
-        known_principal_ids: Some(known_prinicipal_values.clone()),
-        profile_owner: Some(bob_principal_id),
-        upgrade_version_number: None,
-        url_to_send_canister_metrics_to: None,
-        version: "1".to_string(),
-    };
-    let individual_template_args_bytes = encode_one(individual_template_args).unwrap();
-
-    pic.install_canister(
-        bob_individual_template_canister_id,
-        individual_template_wasm_bytes.clone(),
-        individual_template_args_bytes,
-        None,
-    );
-
-    // Init individual template canister - charlie
-
-    let charlie_individual_template_canister_id = pic.create_canister();
-    pic.add_cycles(charlie_individual_template_canister_id, 2_000_000_000_000);
-
-    let individual_template_args = IndividualUserTemplateInitArgs {
-        known_principal_ids: Some(known_prinicipal_values.clone()),
-        profile_owner: Some(charlie_prinicipal_id),
-        upgrade_version_number: None,
-        url_to_send_canister_metrics_to: None,
-        version: "1".to_string(),
-    };
-    let individual_template_args_bytes = encode_one(individual_template_args).unwrap();
-
-    pic.install_canister(
-        charlie_individual_template_canister_id,
-        individual_template_wasm_bytes.clone(),
-        individual_template_args_bytes,
-        None,
-    );
-
-    // Init individual template canister - dan
-
-    let dan_individual_template_canister_id = pic.create_canister();
-    pic.add_cycles(dan_individual_template_canister_id, 2_000_000_000_000);
-
-    let individual_template_args = IndividualUserTemplateInitArgs {
-        known_principal_ids: Some(known_prinicipal_values.clone()),
-        profile_owner: Some(dan_prinicipal_id),
-        upgrade_version_number: None,
-        url_to_send_canister_metrics_to: None,
-        version: "1".to_string(),
-    };
-    let individual_template_args_bytes = encode_one(individual_template_args).unwrap();
-
-    pic.install_canister(
-        dan_individual_template_canister_id,
         individual_template_wasm_bytes.clone(),
         individual_template_args_bytes,
         None,

--- a/src/lib/integration_tests/tests/hot_or_not/main.rs
+++ b/src/lib/integration_tests/tests/hot_or_not/main.rs
@@ -1,1 +1,2 @@
+pub mod hot_or_not_timely_index_update_test;
 pub mod when_bob_charlie_dan_place_bet_on_alice_created_post_then_expected_outcomes_occur;

--- a/src/lib/integration_tests/tests/upgrade/feed_filter_upgrade_test.rs
+++ b/src/lib/integration_tests/tests/upgrade/feed_filter_upgrade_test.rs
@@ -33,6 +33,7 @@ struct OldPostCacheInitArgs {
     pub known_principal_ids: Option<KnownPrincipalMap>,
 }
 
+#[cfg(feature = "feed_filter_upgrade_test")]
 #[test]
 fn feed_filter_upgrade_test() {
     let pic = PocketIc::new();

--- a/src/lib/integration_tests/tests/upgrade/feed_filter_upgrade_test.rs
+++ b/src/lib/integration_tests/tests/upgrade/feed_filter_upgrade_test.rs
@@ -1,0 +1,2 @@
+#[test]
+fn feed_filter_upgrade_test() {}

--- a/src/lib/integration_tests/tests/upgrade/feed_filter_upgrade_test.rs
+++ b/src/lib/integration_tests/tests/upgrade/feed_filter_upgrade_test.rs
@@ -1,2 +1,431 @@
+use std::{collections::HashMap, thread, time::Duration};
+
+use candid::{encode_one, CandidType, Deserialize};
+use pocket_ic::{PocketIc, WasmResult};
+use shared_utils::{
+    canister_specific::{
+        individual_user_template::types::{
+            arg::IndividualUserTemplateInitArgs, post::PostDetailsFromFrontend,
+        },
+        post_cache::types::arg::PostCacheInitArgs,
+    },
+    common::types::{
+        known_principal::{KnownPrincipalMap, KnownPrincipalType},
+        top_posts::post_score_index_item::{PostScoreIndexItem, PostScoreIndexItemV1},
+    },
+    types::canister_specific::post_cache::error_types::TopPostsFetchError,
+};
+use test_utils::setup::test_constants::{
+    get_mock_user_alice_principal_id, get_mock_user_bob_principal_id,
+};
+
+const OLD_POST_CACHE_WASM_PATH: &str =
+    "../../../target/wasm32-unknown-unknown/release/old_post_cache.wasm.gz";
+const OLD_INDIVIDUAL_TEMPLATE_WASM_PATH: &str =
+    "../../../target/wasm32-unknown-unknown/release/old_individual_user_template.wasm.gz";
+const POST_CACHE_WASM_PATH: &str =
+    "../../../target/wasm32-unknown-unknown/release/post_cache.wasm.gz";
+const INDIVIDUAL_TEMPLATE_WASM_PATH: &str =
+    "../../../target/wasm32-unknown-unknown/release/individual_user_template.wasm.gz";
+
+#[derive(Deserialize, CandidType, Default)]
+struct OldPostCacheInitArgs {
+    pub known_principal_ids: Option<KnownPrincipalMap>,
+}
+
 #[test]
-fn feed_filter_upgrade_test() {}
+fn feed_filter_upgrade_test() {
+    let pic = PocketIc::new();
+
+    let alice_principal_id = get_mock_user_alice_principal_id();
+    let bob_principal_id = get_mock_user_bob_principal_id();
+
+    let post_cache_canister_id = pic.create_canister();
+    pic.add_cycles(post_cache_canister_id, 2_000_000_000_000);
+
+    let post_cache_wasm_bytes = old_post_cache_canister_wasm();
+    let post_cache_args = OldPostCacheInitArgs {
+        known_principal_ids: None,
+    };
+    let post_cache_args_bytes = encode_one(post_cache_args).unwrap();
+    pic.install_canister(
+        post_cache_canister_id,
+        post_cache_wasm_bytes,
+        post_cache_args_bytes,
+        None,
+    );
+
+    // Individual template canisters
+
+    let individual_template_wasm_bytes = old_individual_template_canister_wasm();
+    let mut known_prinicipal_values = HashMap::new();
+    known_prinicipal_values.insert(
+        KnownPrincipalType::CanisterIdPostCache,
+        post_cache_canister_id,
+    );
+
+    // Init individual template canister - alice
+
+    let alice_individual_template_canister_id = pic.create_canister();
+    pic.add_cycles(alice_individual_template_canister_id, 2_000_000_000_000);
+
+    let individual_template_args = IndividualUserTemplateInitArgs {
+        known_principal_ids: Some(known_prinicipal_values.clone()),
+        profile_owner: Some(alice_principal_id),
+        upgrade_version_number: None,
+        url_to_send_canister_metrics_to: None,
+        version: "1".to_string(),
+    };
+    let individual_template_args_bytes = encode_one(individual_template_args).unwrap();
+
+    pic.install_canister(
+        alice_individual_template_canister_id,
+        individual_template_wasm_bytes.clone(),
+        individual_template_args_bytes,
+        None,
+    );
+
+    // Init individual template canister - bob
+
+    let bob_individual_template_canister_id = pic.create_canister();
+    pic.add_cycles(bob_individual_template_canister_id, 2_000_000_000_000);
+
+    let individual_template_args = IndividualUserTemplateInitArgs {
+        known_principal_ids: Some(known_prinicipal_values.clone()),
+        profile_owner: Some(bob_principal_id),
+        upgrade_version_number: None,
+        url_to_send_canister_metrics_to: None,
+        version: "1".to_string(),
+    };
+    let individual_template_args_bytes = encode_one(individual_template_args).unwrap();
+
+    pic.install_canister(
+        bob_individual_template_canister_id,
+        individual_template_wasm_bytes.clone(),
+        individual_template_args_bytes,
+        None,
+    );
+
+    // Create posts
+    // Alice creates a post
+
+    let alice_post_1 = PostDetailsFromFrontend {
+        is_nsfw: false,
+        description: "This is a fun video to watch".to_string(),
+        hashtags: vec!["fun".to_string(), "video".to_string()],
+        video_uid: "abcd#1234".to_string(),
+        creator_consent_for_inclusion_in_hot_or_not: true,
+    };
+    let res = pic
+        .update_call(
+            alice_individual_template_canister_id,
+            alice_principal_id,
+            "add_post_v2",
+            encode_one(alice_post_1).unwrap(),
+        )
+        .map(|reply_payload| {
+            let newly_created_post_id_result: Result<u64, String> = match reply_payload {
+                WasmResult::Reply(payload) => candid::decode_one(&payload).unwrap(),
+                _ => panic!("\n🛑 add_post failed\n"),
+            };
+            newly_created_post_id_result.unwrap()
+        })
+        .unwrap();
+
+    let alice_post_2 = PostDetailsFromFrontend {
+        is_nsfw: false,
+        description: "This is a fun video to watch 2".to_string(),
+        hashtags: vec!["fun".to_string(), "video".to_string()],
+        video_uid: "abcd#12345".to_string(),
+        creator_consent_for_inclusion_in_hot_or_not: true,
+    };
+    let res = pic
+        .update_call(
+            alice_individual_template_canister_id,
+            alice_principal_id,
+            "add_post_v2",
+            encode_one(alice_post_2).unwrap(),
+        )
+        .map(|reply_payload| {
+            let newly_created_post_id_result: Result<u64, String> = match reply_payload {
+                WasmResult::Reply(payload) => candid::decode_one(&payload).unwrap(),
+                _ => panic!("\n🛑 add_post failed\n"),
+            };
+            newly_created_post_id_result.unwrap()
+        })
+        .unwrap();
+
+    // Bob creates a post
+
+    let bob_post_1 = PostDetailsFromFrontend {
+        is_nsfw: true,
+        description: "This is a fun video to watch - bob".to_string(),
+        hashtags: vec!["fun".to_string(), "video".to_string()],
+        video_uid: "abcd#1234bob".to_string(),
+        creator_consent_for_inclusion_in_hot_or_not: true,
+    };
+    let res = pic
+        .update_call(
+            bob_individual_template_canister_id,
+            bob_principal_id,
+            "add_post_v2",
+            encode_one(bob_post_1).unwrap(),
+        )
+        .map(|reply_payload| {
+            let newly_created_post_id_result: Result<u64, String> = match reply_payload {
+                WasmResult::Reply(payload) => candid::decode_one(&payload).unwrap(),
+                _ => panic!("\n🛑 add_post failed\n"),
+            };
+            newly_created_post_id_result.unwrap()
+        })
+        .unwrap();
+
+    // Call post cache canister to get the home feed posts
+    let res = pic
+        .query_call(
+            post_cache_canister_id,
+            bob_principal_id,
+            "get_top_posts_aggregated_from_canisters_on_this_network_for_home_feed",
+            candid::encode_args((0 as u64, 10 as u64)).unwrap(),
+        )
+        .map(|reply_payload| {
+            let posts: Result<Vec<PostScoreIndexItem>, TopPostsFetchError> = match reply_payload {
+                WasmResult::Reply(payload) => candid::decode_one(&payload).unwrap(),
+                _ => panic!("\n🛑 get_posts failed\n"),
+            };
+            posts
+        })
+        .unwrap();
+
+    let posts = res.unwrap();
+    assert_eq!(posts.len(), 3);
+    assert_eq!(posts[0].post_id, 0);
+    assert_eq!(posts[1].post_id, 1);
+    assert_eq!(posts[2].post_id, 0);
+
+    // Upgrade canister
+
+    let individual_template_wasm_bytes = individual_template_canister_wasm();
+
+    let individual_template_args = IndividualUserTemplateInitArgs {
+        known_principal_ids: Some(known_prinicipal_values.clone()),
+        profile_owner: Some(alice_principal_id),
+        upgrade_version_number: None,
+        url_to_send_canister_metrics_to: None,
+        version: "1".to_string(),
+    };
+    let individual_template_args_bytes = encode_one(individual_template_args).unwrap();
+
+    let res = pic.upgrade_canister(
+        alice_individual_template_canister_id,
+        individual_template_wasm_bytes.clone(),
+        individual_template_args_bytes,
+        None,
+    );
+    if let Err(e) = res {
+        panic!("Error: {:?}", e);
+    }
+
+    let individual_template_args = IndividualUserTemplateInitArgs {
+        known_principal_ids: Some(known_prinicipal_values.clone()),
+        profile_owner: Some(bob_principal_id),
+        upgrade_version_number: None,
+        url_to_send_canister_metrics_to: None,
+        version: "1".to_string(),
+    };
+    let individual_template_args_bytes = encode_one(individual_template_args).unwrap();
+
+    let res = pic.upgrade_canister(
+        bob_individual_template_canister_id,
+        individual_template_wasm_bytes,
+        individual_template_args_bytes,
+        None,
+    );
+    if let Err(e) = res {
+        panic!("Error: {:?}", e);
+    }
+
+    // Upgrade post cache canister
+
+    let post_cache_wasm_bytes = post_cache_canister_wasm();
+
+    let post_cache_args = PostCacheInitArgs {
+        known_principal_ids: Some(known_prinicipal_values.clone()),
+        upgrade_version_number: Some(1),
+        version: "1".to_string(),
+    };
+    let post_cache_args_bytes = encode_one(post_cache_args).unwrap();
+
+    let res = pic.upgrade_canister(
+        post_cache_canister_id,
+        post_cache_wasm_bytes,
+        post_cache_args_bytes,
+        None,
+    );
+    if let Err(e) = res {
+        panic!("Error: {:?}", e);
+    }
+
+    pic.advance_time(Duration::from_secs(5));
+    pic.tick();
+
+    // Call post cache canister to get the home feed posts
+    let res = pic
+        .query_call(
+            post_cache_canister_id,
+            bob_principal_id,
+            "get_top_posts_aggregated_from_canisters_on_this_network_for_home_feed_cursor",
+            candid::encode_args((0 as u64, 10 as u64)).unwrap(),
+        )
+        .map(|reply_payload| {
+            let posts: Result<Vec<PostScoreIndexItem>, TopPostsFetchError> = match reply_payload {
+                WasmResult::Reply(payload) => candid::decode_one(&payload).unwrap(),
+                _ => panic!("\n🛑 get_posts failed\n"),
+            };
+            posts
+        })
+        .unwrap();
+
+    let posts = res.unwrap();
+    assert_eq!(posts.len(), 3);
+    assert_eq!(posts[0].post_id, 0);
+    assert_eq!(posts[1].post_id, 1);
+    assert_eq!(posts[2].post_id, 0);
+
+    // Call post cache canister to get the hot or not feed posts
+    let res = pic
+        .query_call(
+            post_cache_canister_id,
+            bob_principal_id,
+            "get_top_posts_aggregated_from_canisters_on_this_network_for_hot_or_not_feed_cursor",
+            candid::encode_args((0 as u64, 10 as u64)).unwrap(),
+        )
+        .map(|reply_payload| {
+            let posts: Result<Vec<PostScoreIndexItemV1>, TopPostsFetchError> = match reply_payload {
+                WasmResult::Reply(payload) => candid::decode_one(&payload).unwrap(),
+                _ => panic!("\n🛑 get_posts failed\n"),
+            };
+            posts
+        })
+        .unwrap();
+
+    let posts = res.unwrap();
+    assert_eq!(posts.len(), 3);
+    assert_eq!(posts[0].post_id, 0);
+    assert_eq!(posts[1].post_id, 1);
+    assert_eq!(posts[2].post_id, 0);
+    assert_eq!(posts[2].is_nsfw, true);
+
+    // Bob creates a post
+
+    let bob_post_2 = PostDetailsFromFrontend {
+        is_nsfw: true,
+        description: "This is a fun video to watch - bob2".to_string(),
+        hashtags: vec!["fun".to_string(), "video".to_string()],
+        video_uid: "abcd#1234bob2".to_string(),
+        creator_consent_for_inclusion_in_hot_or_not: true,
+    };
+    let res = pic
+        .update_call(
+            bob_individual_template_canister_id,
+            bob_principal_id,
+            "add_post_v2",
+            encode_one(bob_post_2).unwrap(),
+        )
+        .map(|reply_payload| {
+            let newly_created_post_id_result: Result<u64, String> = match reply_payload {
+                WasmResult::Reply(payload) => candid::decode_one(&payload).unwrap(),
+                _ => panic!("\n🛑 add_post failed\n"),
+            };
+            newly_created_post_id_result.unwrap()
+        })
+        .unwrap();
+
+    // Call post cache canister to get the hot or not feed posts
+    let res = pic
+        .query_call(
+            post_cache_canister_id,
+            bob_principal_id,
+            "get_top_posts_aggregated_from_canisters_on_this_network_for_hot_or_not_feed_cursor",
+            candid::encode_args((0 as u64, 10 as u64)).unwrap(),
+        )
+        .map(|reply_payload| {
+            let posts: Result<Vec<PostScoreIndexItemV1>, TopPostsFetchError> = match reply_payload {
+                WasmResult::Reply(payload) => candid::decode_one(&payload).unwrap(),
+                _ => panic!("\n🛑 get_posts failed\n"),
+            };
+            posts
+        })
+        .unwrap();
+
+    let posts = res.unwrap();
+    assert_eq!(posts.len(), 4);
+    assert_eq!(posts[0].post_id, 0);
+    assert_eq!(posts[1].post_id, 1);
+    assert_eq!(posts[2].post_id, 0);
+    assert_eq!(posts[3].post_id, 1);
+
+    // Call post cache canister to get the home feed posts - old function to verify backward compatibitlity
+    let res = pic
+        .query_call(
+            post_cache_canister_id,
+            bob_principal_id,
+            "get_top_posts_aggregated_from_canisters_on_this_network_for_home_feed",
+            candid::encode_args((0 as u64, 10 as u64)).unwrap(),
+        )
+        .map(|reply_payload| {
+            let posts: Result<Vec<PostScoreIndexItem>, TopPostsFetchError> = match reply_payload {
+                WasmResult::Reply(payload) => candid::decode_one(&payload).unwrap(),
+                _ => panic!("\n🛑 get_posts failed\n"),
+            };
+            posts
+        })
+        .unwrap();
+
+    let posts = res.unwrap();
+    assert_eq!(posts.len(), 4);
+    assert_eq!(posts[0].post_id, 0);
+    assert_eq!(posts[1].post_id, 1);
+    assert_eq!(posts[2].post_id, 0);
+    assert_eq!(posts[3].post_id, 1);
+
+    // Call post cache canister to get the hot or not feed posts - old function to verify backward compatibitlity
+    let res = pic
+        .query_call(
+            post_cache_canister_id,
+            bob_principal_id,
+            "get_top_posts_aggregated_from_canisters_on_this_network_for_hot_or_not_feed",
+            candid::encode_args((0 as u64, 10 as u64)).unwrap(),
+        )
+        .map(|reply_payload| {
+            let posts: Result<Vec<PostScoreIndexItem>, TopPostsFetchError> = match reply_payload {
+                WasmResult::Reply(payload) => candid::decode_one(&payload).unwrap(),
+                _ => panic!("\n🛑 get_posts failed\n"),
+            };
+            posts
+        })
+        .unwrap();
+
+    let posts = res.unwrap();
+    assert_eq!(posts.len(), 4);
+    assert_eq!(posts[0].post_id, 0);
+    assert_eq!(posts[1].post_id, 1);
+    assert_eq!(posts[2].post_id, 0);
+    assert_eq!(posts[3].post_id, 1);
+}
+
+fn old_individual_template_canister_wasm() -> Vec<u8> {
+    std::fs::read(OLD_INDIVIDUAL_TEMPLATE_WASM_PATH).unwrap()
+}
+
+fn old_post_cache_canister_wasm() -> Vec<u8> {
+    std::fs::read(OLD_POST_CACHE_WASM_PATH).unwrap()
+}
+
+fn individual_template_canister_wasm() -> Vec<u8> {
+    std::fs::read(INDIVIDUAL_TEMPLATE_WASM_PATH).unwrap()
+}
+
+fn post_cache_canister_wasm() -> Vec<u8> {
+    std::fs::read(POST_CACHE_WASM_PATH).unwrap()
+}

--- a/src/lib/integration_tests/tests/upgrade/main.rs
+++ b/src/lib/integration_tests/tests/upgrade/main.rs
@@ -1,1 +1,2 @@
+pub mod feed_filter_upgrade_test;
 pub mod on_every_upgrade_fetch_the_latest_list_of_well_known_principals_and_update_canisters;

--- a/src/lib/shared_utils/Cargo.toml
+++ b/src/lib/shared_utils/Cargo.toml
@@ -16,3 +16,6 @@ serde = { workspace = true }
 
 [dev-dependencies]
 test_utils = { workspace = true }
+
+[features]
+mockdata = []

--- a/src/lib/shared_utils/src/canister_specific/individual_user_template/types/post/mod.rs
+++ b/src/lib/shared_utils/src/canister_specific/individual_user_template/types/post/mod.rs
@@ -5,7 +5,10 @@ use std::{
     time::{Duration, SystemTime},
 };
 
-use crate::canister_specific::individual_user_template::types::profile::UserProfileDetailsForFrontend;
+use crate::{
+    canister_specific::individual_user_template::types::profile::UserProfileDetailsForFrontend,
+    common::types::top_posts::post_score_index_item::PostStatus,
+};
 
 use super::hot_or_not::{BettingStatus, HotOrNotDetails};
 
@@ -24,7 +27,7 @@ pub struct Post {
     pub creator_consent_for_inclusion_in_hot_or_not: bool,
     pub hot_or_not_details: Option<HotOrNotDetails>,
     #[serde(default)]
-    pub is_nsfw: bool
+    pub is_nsfw: bool,
 }
 
 #[derive(CandidType, Clone, Deserialize, Debug, Serialize)]
@@ -63,18 +66,6 @@ pub struct PostViewStatistics {
     pub average_watch_percentage: u8,
 }
 
-#[derive(Serialize, Deserialize, CandidType, Clone, Default, Debug)]
-pub enum PostStatus {
-    #[default]
-    Uploaded,
-    Transcoding,
-    CheckingExplicitness,
-    BannedForExplicitness,
-    ReadyToView,
-    BannedDueToUserReporting,
-    Deleted,
-}
-
 #[derive(Serialize, CandidType, Deserialize, Debug)]
 pub struct PostDetailsForFrontend {
     pub id: u64,
@@ -93,7 +84,7 @@ pub struct PostDetailsForFrontend {
     pub home_feed_ranking_score: u64,
     pub hot_or_not_feed_ranking_score: Option<u64>,
     pub hot_or_not_betting_status: Option<BettingStatus>,
-    pub is_nsfw: bool
+    pub is_nsfw: bool,
 }
 
 #[derive(Serialize, CandidType, Deserialize)]
@@ -102,7 +93,7 @@ pub struct PostDetailsFromFrontend {
     pub hashtags: Vec<String>,
     pub video_uid: String,
     pub creator_consent_for_inclusion_in_hot_or_not: bool,
-    pub is_nsfw: bool
+    pub is_nsfw: bool,
 }
 
 impl Post {
@@ -411,7 +402,7 @@ mod test {
                 hashtags: vec!["#fun".to_string(), "#post".to_string()],
                 video_uid: "abcd1234".to_string(),
                 creator_consent_for_inclusion_in_hot_or_not: false,
-                is_nsfw: false
+                is_nsfw: false,
             },
             &SystemTime::now(),
         );
@@ -425,7 +416,7 @@ mod test {
                 hashtags: vec!["#fun".to_string(), "#post".to_string()],
                 video_uid: "abcd1234".to_string(),
                 creator_consent_for_inclusion_in_hot_or_not: true,
-                is_nsfw: false
+                is_nsfw: false,
             },
             &SystemTime::now(),
         );
@@ -451,7 +442,7 @@ mod test {
                 hashtags: vec!["doggo".into(), "pupper".into()],
                 video_uid: "abcd#1234".into(),
                 creator_consent_for_inclusion_in_hot_or_not: true,
-                is_nsfw: false
+                is_nsfw: false,
             },
             &post_created_at,
         );
@@ -527,7 +518,7 @@ mod test {
                 hashtags: vec!["doggo".into(), "pupper".into()],
                 video_uid: "abcd#1234".into(),
                 creator_consent_for_inclusion_in_hot_or_not: true,
-                is_nsfw: false
+                is_nsfw: false,
             },
             &post_created_at,
         );
@@ -603,7 +594,7 @@ mod test {
                 hashtags: vec!["doggo".into(), "pupper".into()],
                 video_uid: "abcd#1234".into(),
                 creator_consent_for_inclusion_in_hot_or_not: true,
-                is_nsfw: false
+                is_nsfw: false,
             },
             &post_created_at,
         );
@@ -682,7 +673,7 @@ mod test {
                 hashtags: vec!["doggo".into(), "pupper".into()],
                 video_uid: "abcd#1234".into(),
                 creator_consent_for_inclusion_in_hot_or_not: true,
-                is_nsfw: false
+                is_nsfw: false,
             },
             &post_created_at,
         );
@@ -763,7 +754,7 @@ mod test {
                 hashtags: vec!["doggo".into(), "pupper".into()],
                 video_uid: "abcd#1234".into(),
                 creator_consent_for_inclusion_in_hot_or_not: true,
-                is_nsfw: false
+                is_nsfw: false,
             },
             &post_created_at,
         );
@@ -844,7 +835,7 @@ mod test {
                 hashtags: vec!["doggo".into(), "pupper".into()],
                 video_uid: "abcd#1234".into(),
                 creator_consent_for_inclusion_in_hot_or_not: true,
-                is_nsfw: false
+                is_nsfw: false,
             },
             &post_created_at,
         );
@@ -925,7 +916,7 @@ mod test {
                 hashtags: vec!["doggo".into(), "pupper".into()],
                 video_uid: "abcd#1234".into(),
                 creator_consent_for_inclusion_in_hot_or_not: true,
-                is_nsfw: false
+                is_nsfw: false,
             },
             &post_created_at,
         );
@@ -1006,7 +997,7 @@ mod test {
                 hashtags: vec!["doggo".into(), "pupper".into()],
                 video_uid: "abcd#1234".into(),
                 creator_consent_for_inclusion_in_hot_or_not: true,
-                is_nsfw: false
+                is_nsfw: false,
             },
             &post_created_at,
         );
@@ -1087,7 +1078,7 @@ mod test {
                 hashtags: vec!["doggo".into(), "pupper".into()],
                 video_uid: "abcd#1234".into(),
                 creator_consent_for_inclusion_in_hot_or_not: true,
-                is_nsfw: false
+                is_nsfw: false,
             },
             &post_created_at,
         );
@@ -1168,7 +1159,7 @@ mod test {
                 hashtags: vec!["doggo".into(), "pupper".into()],
                 video_uid: "abcd#1234".into(),
                 creator_consent_for_inclusion_in_hot_or_not: true,
-                is_nsfw: false
+                is_nsfw: false,
             },
             &post_created_at,
         );
@@ -1249,7 +1240,7 @@ mod test {
                 hashtags: vec!["doggo".into(), "pupper".into()],
                 video_uid: "abcd#1234".into(),
                 creator_consent_for_inclusion_in_hot_or_not: true,
-                is_nsfw: false
+                is_nsfw: false,
             },
             &post_created_at,
         );
@@ -1339,7 +1330,7 @@ mod test {
                 hashtags: vec!["doggo".into(), "pupper".into()],
                 video_uid: "abcd#1234".into(),
                 creator_consent_for_inclusion_in_hot_or_not: true,
-                is_nsfw: false
+                is_nsfw: false,
             },
             &post_created_at,
         );
@@ -1429,7 +1420,7 @@ mod test {
                 hashtags: vec!["doggo".into(), "pupper".into()],
                 video_uid: "abcd#1234".into(),
                 creator_consent_for_inclusion_in_hot_or_not: true,
-                is_nsfw: false
+                is_nsfw: false,
             },
             &post_created_at,
         );
@@ -1522,7 +1513,7 @@ mod test {
                 hashtags: vec!["doggo".into(), "pupper".into()],
                 video_uid: "abcd#1234".into(),
                 creator_consent_for_inclusion_in_hot_or_not: true,
-                is_nsfw: false
+                is_nsfw: false,
             },
             &post_created_at,
         );
@@ -1617,7 +1608,7 @@ mod test {
                 hashtags: vec!["doggo".into(), "pupper".into()],
                 video_uid: "abcd#1234".into(),
                 creator_consent_for_inclusion_in_hot_or_not: true,
-                is_nsfw: false
+                is_nsfw: false,
             },
             &post_created_at,
         );
@@ -1712,7 +1703,7 @@ mod test {
                 hashtags: vec!["doggo".into(), "pupper".into()],
                 video_uid: "abcd#1234".into(),
                 creator_consent_for_inclusion_in_hot_or_not: true,
-                is_nsfw: false
+                is_nsfw: false,
             },
             &post_created_at,
         );
@@ -1807,7 +1798,7 @@ mod test {
                 hashtags: vec!["doggo".into(), "pupper".into()],
                 video_uid: "abcd#1234".into(),
                 creator_consent_for_inclusion_in_hot_or_not: true,
-                is_nsfw: false
+                is_nsfw: false,
             },
             &post_created_at,
         );
@@ -1902,7 +1893,7 @@ mod test {
                 hashtags: vec!["doggo".into(), "pupper".into()],
                 video_uid: "abcd#1234".into(),
                 creator_consent_for_inclusion_in_hot_or_not: true,
-                is_nsfw: false
+                is_nsfw: false,
             },
             &post_created_at,
         );
@@ -1997,7 +1988,7 @@ mod test {
                 hashtags: vec!["doggo".into(), "pupper".into()],
                 video_uid: "abcd#1234".into(),
                 creator_consent_for_inclusion_in_hot_or_not: true,
-                is_nsfw: false
+                is_nsfw: false,
             },
             &post_created_at,
         );
@@ -2092,7 +2083,7 @@ mod test {
                 hashtags: vec!["doggo".into(), "pupper".into()],
                 video_uid: "abcd#1234".into(),
                 creator_consent_for_inclusion_in_hot_or_not: true,
-                is_nsfw: false
+                is_nsfw: false,
             },
             &post_created_at,
         );
@@ -2181,7 +2172,7 @@ mod test {
                 hashtags: vec!["doggo".into(), "pupper".into()],
                 video_uid: "abcd#1234".into(),
                 creator_consent_for_inclusion_in_hot_or_not: true,
-                is_nsfw: false
+                is_nsfw: false,
             },
             &post_created_at,
         );

--- a/src/lib/shared_utils/src/canister_specific/post_cache/types/arg.rs
+++ b/src/lib/shared_utils/src/canister_specific/post_cache/types/arg.rs
@@ -5,4 +5,6 @@ use crate::common::types::known_principal::KnownPrincipalMap;
 #[derive(Deserialize, CandidType, Default)]
 pub struct PostCacheInitArgs {
     pub known_principal_ids: Option<KnownPrincipalMap>,
+    pub upgrade_version_number: Option<u64>,
+    pub version: String,
 }

--- a/src/lib/shared_utils/src/common/types/mod.rs
+++ b/src/lib/shared_utils/src/common/types/mod.rs
@@ -3,3 +3,4 @@ pub mod known_principal;
 pub mod storable_principal;
 pub mod top_posts;
 pub mod utility_token;
+pub mod version_details;

--- a/src/lib/shared_utils/src/common/types/top_posts/mod.rs
+++ b/src/lib/shared_utils/src/common/types/top_posts/mod.rs
@@ -1,4 +1,4 @@
-use std::time::SystemTime;
+use std::time::{Duration, SystemTime};
 
 use candid::Principal;
 
@@ -12,3 +12,6 @@ pub type PostId = u64;
 pub type Score = u64;
 pub type CreatedAt = SystemTime;
 pub type GlobalPostId = (PublisherCanisterId, PostId);
+
+// Latest posts within 48 hrs
+pub const LATEST_POSTS_WINDOW: Duration = Duration::from_secs(48 * 60 * 60);

--- a/src/lib/shared_utils/src/common/types/top_posts/mod.rs
+++ b/src/lib/shared_utils/src/common/types/top_posts/mod.rs
@@ -1,2 +1,14 @@
+use std::time::SystemTime;
+
+use candid::Principal;
+
+pub mod post_score_home_index;
+pub mod post_score_hot_or_not_index;
 pub mod post_score_index;
 pub mod post_score_index_item;
+
+pub type PublisherCanisterId = Principal;
+pub type PostId = u64;
+pub type Score = u64;
+pub type CreatedAt = SystemTime;
+pub type GlobalPostId = (PublisherCanisterId, PostId);

--- a/src/lib/shared_utils/src/common/types/top_posts/post_score_home_index/mod.rs
+++ b/src/lib/shared_utils/src/common/types/top_posts/post_score_home_index/mod.rs
@@ -10,9 +10,6 @@ use std::{
 
 use super::{post_score_index_item::PostScoreIndexItemV1, CreatedAt, GlobalPostId, Score};
 
-// Latest posts within 48 hrs
-pub const LATEST_POSTS_WINDOW: Duration = Duration::from_secs(48 * 60 * 60);
-
 #[derive(Default, Debug, Clone, CandidType, Deserialize, Serialize)]
 pub struct PostScoreHomeIndex {
     pub items_sorted_by_score: BTreeMap<Score, Vec<GlobalPostId>>,

--- a/src/lib/shared_utils/src/common/types/top_posts/post_score_home_index/mod.rs
+++ b/src/lib/shared_utils/src/common/types/top_posts/post_score_home_index/mod.rs
@@ -1,0 +1,301 @@
+use candid::{CandidType, Deserialize};
+use serde::Serialize;
+use std::{
+    collections::{btree_map::Iter, BTreeMap, HashMap},
+    iter::{Chain, Rev},
+    slice,
+    time::{Duration, SystemTime},
+    vec,
+};
+
+use super::{post_score_index_item::PostScoreIndexItemV1, CreatedAt, GlobalPostId, Score};
+
+// Latest posts within 48 hrs
+pub const LATEST_POSTS_WINDOW: Duration = Duration::from_secs(48 * 60 * 60);
+
+#[derive(Default, Debug, Clone, CandidType, Deserialize, Serialize)]
+pub struct PostScoreHomeIndex {
+    pub items_sorted_by_score: BTreeMap<Score, Vec<GlobalPostId>>,
+    pub item_presence_index: HashMap<GlobalPostId, PostScoreIndexItemV1>,
+    // TODO: Add below indexes
+    // pub item_nsfw_index: HashMap<IsNsfw, HashSet<GlobalPostId>>,
+    // pub item_status_index: HashMap<PostStatus, HashSet<GlobalPostId>>,
+}
+
+impl PostScoreHomeIndex {
+    pub fn replace(&mut self, item: &PostScoreIndexItemV1) {
+        // insert the item into the presence index accounting
+        //  for already present items
+        let item_presence_index_entry = (item.publisher_canister_id, item.post_id);
+        let item_score = item.score;
+
+        let _ = self.remove(item);
+        self.item_presence_index
+            .insert(item_presence_index_entry, item.clone());
+
+        // insert the item into the sorted index, nsfw, time and sorted and latest sorted indexes
+
+        let score_index_entry = self
+            .items_sorted_by_score
+            .entry(item_score)
+            .or_insert_with(Vec::new);
+        score_index_entry.push(item_presence_index_entry);
+    }
+
+    pub fn remove(&mut self, item: &PostScoreIndexItemV1) -> Option<PostScoreIndexItemV1> {
+        // remove the item from the presence index
+        let item_presence_index_entry = (item.publisher_canister_id, item.post_id);
+
+        let old_item = self.item_presence_index.remove(&item_presence_index_entry);
+
+        // if the item was already present, remove it from the sorted index, latest sorted, nsfw, status, time
+        if let Some(old_item) = old_item.clone() {
+            let old_score = old_item.score;
+
+            if let Some(old_score_index_entry) = self.items_sorted_by_score.get_mut(&old_score) {
+                old_score_index_entry.retain(|old_item| {
+                    old_item.0 != item.publisher_canister_id || old_item.1 != item.post_id
+                });
+            }
+        }
+
+        old_item
+    }
+
+    pub fn iter(&self) -> PostScoreHomeIndexIterator {
+        PostScoreHomeIndexIterator {
+            id_to_item: &self.item_presence_index,
+            inner: self.items_sorted_by_score.iter().rev(),
+            current_vec: None,
+        }
+    }
+}
+
+pub struct PostScoreHomeIndexIterator<'a> {
+    id_to_item: &'a HashMap<GlobalPostId, PostScoreIndexItemV1>,
+    inner: Rev<Iter<'a, Score, Vec<GlobalPostId>>>,
+    current_vec: Option<slice::Iter<'a, GlobalPostId>>,
+}
+
+impl<'a> Iterator for PostScoreHomeIndexIterator<'a> {
+    type Item = &'a PostScoreIndexItemV1;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if let Some(current_vec) = &mut self.current_vec {
+            if let Some(item) = current_vec.next() {
+                return Some(self.id_to_item.get(item).unwrap());
+            }
+        }
+
+        if let Some((_, vec)) = self.inner.next() {
+            self.current_vec = Some(vec.iter());
+            return self.next();
+        }
+
+        None
+    }
+}
+
+impl<'a> IntoIterator for &'a PostScoreHomeIndex {
+    type Item = &'a PostScoreIndexItemV1;
+    type IntoIter = PostScoreHomeIndexIterator<'a>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.iter()
+    }
+}
+
+impl FromIterator<PostScoreIndexItemV1> for PostScoreHomeIndex {
+    fn from_iter<T: IntoIterator<Item = PostScoreIndexItemV1>>(iter: T) -> Self {
+        let mut post_score_index_items = PostScoreHomeIndex::default();
+
+        for item in iter {
+            post_score_index_items.replace(&item);
+        }
+
+        post_score_index_items
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use candid::Principal;
+
+    use crate::common::types::top_posts::post_score_index_item::PostStatus;
+
+    use super::*;
+
+    #[test]
+    fn test_post_score_index_v1_normal_functionality() {
+        let mut post_score_index = PostScoreHomeIndex::default();
+        let created_at_now = SystemTime::now();
+        let created_at_earlier = created_at_now - Duration::from_secs(60 * 60 * 48 + 1);
+
+        let posts = vec![
+            PostScoreIndexItemV1 {
+                score: 1,
+                post_id: 1,
+                publisher_canister_id: Principal::from_text("w4nuc-waaaa-aaaao-aal2a-cai").unwrap(),
+                is_nsfw: false,
+                status: PostStatus::ReadyToView,
+                created_at: Some(created_at_now),
+            },
+            PostScoreIndexItemV1 {
+                score: 2,
+                post_id: 2,
+                publisher_canister_id: Principal::from_text("w4nuc-waaaa-aaaao-aal2a-cai").unwrap(),
+                is_nsfw: false,
+                status: PostStatus::ReadyToView,
+                created_at: Some(created_at_now),
+            },
+            PostScoreIndexItemV1 {
+                score: 3,
+                post_id: 3,
+                publisher_canister_id: Principal::from_text("w4nuc-waaaa-aaaao-aal2a-cai").unwrap(),
+                is_nsfw: false,
+                status: PostStatus::ReadyToView,
+                created_at: Some(created_at_earlier),
+            },
+            PostScoreIndexItemV1 {
+                score: 4,
+                post_id: 4,
+                publisher_canister_id: Principal::from_text("w4nuc-waaaa-aaaao-aal2a-cai").unwrap(),
+                is_nsfw: false,
+                status: PostStatus::ReadyToView,
+                created_at: Some(created_at_earlier),
+            },
+            PostScoreIndexItemV1 {
+                score: 5,
+                post_id: 5,
+                publisher_canister_id: Principal::from_text("w4nuc-waaaa-aaaao-aal2a-cai").unwrap(),
+                is_nsfw: false,
+                status: PostStatus::ReadyToView,
+                created_at: Some(created_at_earlier),
+            },
+        ];
+
+        for post in posts {
+            post_score_index.replace(&post);
+        }
+
+        let mut post_score_index_iter = post_score_index.iter();
+        assert_eq!(
+            post_score_index_iter.next(),
+            Some(&PostScoreIndexItemV1 {
+                score: 5,
+                post_id: 5,
+                publisher_canister_id: Principal::from_text("w4nuc-waaaa-aaaao-aal2a-cai").unwrap(),
+                is_nsfw: false,
+                status: PostStatus::ReadyToView,
+                created_at: Some(created_at_earlier),
+            })
+        );
+        assert_eq!(
+            post_score_index_iter.next(),
+            Some(&PostScoreIndexItemV1 {
+                score: 4,
+                post_id: 4,
+                publisher_canister_id: Principal::from_text("w4nuc-waaaa-aaaao-aal2a-cai").unwrap(),
+                is_nsfw: false,
+                status: PostStatus::ReadyToView,
+                created_at: Some(created_at_earlier),
+            })
+        );
+        assert_eq!(
+            post_score_index_iter.next(),
+            Some(&PostScoreIndexItemV1 {
+                score: 3,
+                post_id: 3,
+                publisher_canister_id: Principal::from_text("w4nuc-waaaa-aaaao-aal2a-cai").unwrap(),
+                is_nsfw: false,
+                status: PostStatus::ReadyToView,
+                created_at: Some(created_at_earlier),
+            })
+        );
+        assert_eq!(
+            post_score_index_iter.next(),
+            Some(&PostScoreIndexItemV1 {
+                score: 2,
+                post_id: 2,
+                publisher_canister_id: Principal::from_text("w4nuc-waaaa-aaaao-aal2a-cai").unwrap(),
+                is_nsfw: false,
+                status: PostStatus::ReadyToView,
+                created_at: Some(created_at_now),
+            })
+        );
+        assert_eq!(
+            post_score_index_iter.next(),
+            Some(&PostScoreIndexItemV1 {
+                score: 1,
+                post_id: 1,
+                publisher_canister_id: Principal::from_text("w4nuc-waaaa-aaaao-aal2a-cai").unwrap(),
+                is_nsfw: false,
+                status: PostStatus::ReadyToView,
+                created_at: Some(created_at_now),
+            })
+        );
+        assert_eq!(post_score_index_iter.next(), None);
+    }
+
+    #[test]
+    fn test_post_score_index_v1_replace() {
+        let mut post_score_index = PostScoreHomeIndex::default();
+        let created_at_now = SystemTime::now();
+
+        let posts = vec![
+            PostScoreIndexItemV1 {
+                score: 1,
+                post_id: 1,
+                publisher_canister_id: Principal::from_text("w4nuc-waaaa-aaaao-aal2a-cai").unwrap(),
+                is_nsfw: false,
+                status: PostStatus::Uploaded,
+                created_at: Some(created_at_now),
+            },
+            PostScoreIndexItemV1 {
+                score: 2,
+                post_id: 2,
+                publisher_canister_id: Principal::from_text("w4nuc-waaaa-aaaao-aal2a-cai").unwrap(),
+                is_nsfw: true,
+                status: PostStatus::ReadyToView,
+                created_at: Some(created_at_now),
+            },
+            PostScoreIndexItemV1 {
+                score: 3,
+                post_id: 1,
+                publisher_canister_id: Principal::from_text("w4nuc-waaaa-aaaao-aal2a-cai").unwrap(),
+                is_nsfw: true,
+                status: PostStatus::ReadyToView,
+                created_at: Some(created_at_now),
+            },
+        ];
+
+        for post in posts {
+            post_score_index.replace(&post);
+        }
+
+        let mut post_score_index_iter = post_score_index.iter();
+        assert_eq!(
+            post_score_index_iter.next(),
+            Some(&PostScoreIndexItemV1 {
+                score: 3,
+                post_id: 1,
+                publisher_canister_id: Principal::from_text("w4nuc-waaaa-aaaao-aal2a-cai").unwrap(),
+                is_nsfw: true,
+                status: PostStatus::ReadyToView,
+                created_at: Some(created_at_now),
+            })
+        );
+        assert_eq!(
+            post_score_index_iter.next(),
+            Some(&PostScoreIndexItemV1 {
+                score: 2,
+                post_id: 2,
+                publisher_canister_id: Principal::from_text("w4nuc-waaaa-aaaao-aal2a-cai").unwrap(),
+                is_nsfw: true,
+                status: PostStatus::ReadyToView,
+                created_at: Some(created_at_now),
+            })
+        );
+        assert_eq!(post_score_index_iter.next(), None);
+    }
+}

--- a/src/lib/shared_utils/src/common/types/top_posts/post_score_hot_or_not_index/mod.rs
+++ b/src/lib/shared_utils/src/common/types/top_posts/post_score_hot_or_not_index/mod.rs
@@ -1,0 +1,348 @@
+use candid::{CandidType, Deserialize};
+use serde::Serialize;
+use std::{
+    collections::{btree_map::Iter, BTreeMap, HashMap},
+    iter::{Chain, Rev},
+    slice,
+    time::{Duration, SystemTime},
+    vec,
+};
+
+use super::{post_score_index_item::PostScoreIndexItemV1, CreatedAt, GlobalPostId, Score};
+
+// Latest posts within 48 hrs
+pub const LATEST_POSTS_WINDOW: Duration = Duration::from_secs(48 * 60 * 60);
+
+#[derive(Default, Debug, Clone, CandidType, Deserialize, Serialize)]
+pub struct PostScoreHotOrNotIndex {
+    pub items_sorted_by_score: BTreeMap<Score, Vec<GlobalPostId>>,
+    pub items_latest_sorted_by_score: BTreeMap<Score, Vec<GlobalPostId>>,
+    pub item_presence_index: HashMap<GlobalPostId, PostScoreIndexItemV1>,
+    // TODO: Add below indexes
+    // pub item_nsfw_index: HashMap<IsNsfw, HashSet<GlobalPostId>>,
+    // pub item_status_index: HashMap<PostStatus, HashSet<GlobalPostId>>,
+    pub item_time_index: BTreeMap<CreatedAt, Vec<GlobalPostId>>,
+}
+
+impl PostScoreHotOrNotIndex {
+    pub fn replace(&mut self, item: &PostScoreIndexItemV1) {
+        // insert the item into the presence index accounting
+        //  for already present items
+        let item_presence_index_entry = (item.publisher_canister_id, item.post_id);
+        let item_score = item.score;
+
+        let _ = self.remove(item);
+        self.item_presence_index
+            .insert(item_presence_index_entry, item.clone());
+
+        // insert the item into the sorted index, nsfw, time and sorted and latest sorted indexes
+
+        // if item created within last 48 hrs, insert into latest sorted index
+        // else insert into sorted index
+        if let Some(created_at) = item.created_at {
+            if created_at > (SystemTime::now() - LATEST_POSTS_WINDOW) {
+                let latest_score_index_entry = self
+                    .items_latest_sorted_by_score
+                    .entry(item_score)
+                    .or_insert_with(Vec::new);
+                latest_score_index_entry.push(item_presence_index_entry);
+            } else {
+                let score_index_entry = self
+                    .items_sorted_by_score
+                    .entry(item_score)
+                    .or_insert_with(Vec::new);
+                score_index_entry.push(item_presence_index_entry);
+            }
+        } else {
+            let score_index_entry = self
+                .items_sorted_by_score
+                .entry(item_score)
+                .or_insert_with(Vec::new);
+            score_index_entry.push(item_presence_index_entry);
+        }
+
+        if let Some(created_at) = item.created_at {
+            let time_index_entry = self
+                .item_time_index
+                .entry(created_at)
+                .or_insert_with(Vec::new);
+            time_index_entry.push(item_presence_index_entry);
+        }
+    }
+
+    pub fn remove(&mut self, item: &PostScoreIndexItemV1) -> Option<PostScoreIndexItemV1> {
+        // remove the item from the presence index
+        let item_presence_index_entry = (item.publisher_canister_id, item.post_id);
+
+        let old_item = self.item_presence_index.remove(&item_presence_index_entry);
+
+        // if the item was already present, remove it from the sorted index, latest sorted, nsfw, status, time
+        if let Some(old_item) = old_item.clone() {
+            let old_score = old_item.score;
+            let old_created_at = old_item.created_at;
+
+            if let Some(old_score_index_entry) = self.items_sorted_by_score.get_mut(&old_score) {
+                old_score_index_entry.retain(|old_item| {
+                    old_item.0 != item.publisher_canister_id || old_item.1 != item.post_id
+                });
+            }
+
+            if let Some(old_latest_score_index_entry) =
+                self.items_latest_sorted_by_score.get_mut(&old_score)
+            {
+                old_latest_score_index_entry.retain(|old_item| {
+                    old_item.0 != item.publisher_canister_id || old_item.1 != item.post_id
+                });
+            }
+
+            if let Some(old_created_at) = old_created_at {
+                let old_time_index_entry = self.item_time_index.get_mut(&old_created_at).unwrap();
+                old_time_index_entry.retain(|old_item| {
+                    old_item.0 != item.publisher_canister_id || old_item.1 != item.post_id
+                });
+            }
+        }
+
+        old_item
+    }
+
+    pub fn iter(&self) -> PostScoreHotOrNotIndexIterator {
+        let latest_iter = self.items_latest_sorted_by_score.iter();
+        let old_iter = self.items_sorted_by_score.iter();
+
+        PostScoreHotOrNotIndexIterator {
+            id_to_item: &self.item_presence_index,
+            inner: latest_iter.rev().chain(old_iter.rev()),
+            current_vec: None,
+        }
+    }
+}
+
+pub struct PostScoreHotOrNotIndexIterator<'a> {
+    id_to_item: &'a HashMap<GlobalPostId, PostScoreIndexItemV1>,
+    inner: Chain<Rev<Iter<'a, Score, Vec<GlobalPostId>>>, Rev<Iter<'a, Score, Vec<GlobalPostId>>>>,
+    current_vec: Option<slice::Iter<'a, GlobalPostId>>,
+}
+
+impl<'a> Iterator for PostScoreHotOrNotIndexIterator<'a> {
+    type Item = &'a PostScoreIndexItemV1;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if let Some(current_vec) = &mut self.current_vec {
+            if let Some(item) = current_vec.next() {
+                return Some(self.id_to_item.get(item).unwrap());
+            }
+        }
+
+        if let Some((_, vec)) = self.inner.next() {
+            self.current_vec = Some(vec.iter());
+            return self.next();
+        }
+
+        None
+    }
+}
+
+impl<'a> IntoIterator for &'a PostScoreHotOrNotIndex {
+    type Item = &'a PostScoreIndexItemV1;
+    type IntoIter = PostScoreHotOrNotIndexIterator<'a>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.iter()
+    }
+}
+
+impl FromIterator<PostScoreIndexItemV1> for PostScoreHotOrNotIndex {
+    fn from_iter<T: IntoIterator<Item = PostScoreIndexItemV1>>(iter: T) -> Self {
+        let mut post_score_index_items = PostScoreHotOrNotIndex::default();
+
+        for item in iter {
+            post_score_index_items.replace(&item);
+        }
+
+        post_score_index_items
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use candid::Principal;
+
+    use crate::common::types::top_posts::post_score_index_item::PostStatus;
+
+    use super::*;
+
+    #[test]
+    fn test_post_score_index_v1_normal_functionality() {
+        let mut post_score_index = PostScoreHotOrNotIndex::default();
+        let created_at_now = SystemTime::now();
+        let creted_at_earlier = created_at_now - Duration::from_secs(60 * 60 * 48 + 1);
+
+        let posts = vec![
+            PostScoreIndexItemV1 {
+                score: 1,
+                post_id: 1,
+                publisher_canister_id: Principal::from_text("w4nuc-waaaa-aaaao-aal2a-cai").unwrap(),
+                is_nsfw: false,
+                status: PostStatus::ReadyToView,
+                created_at: Some(created_at_now),
+            },
+            PostScoreIndexItemV1 {
+                score: 2,
+                post_id: 2,
+                publisher_canister_id: Principal::from_text("w4nuc-waaaa-aaaao-aal2a-cai").unwrap(),
+                is_nsfw: false,
+                status: PostStatus::ReadyToView,
+                created_at: Some(created_at_now),
+            },
+            PostScoreIndexItemV1 {
+                score: 3,
+                post_id: 3,
+                publisher_canister_id: Principal::from_text("w4nuc-waaaa-aaaao-aal2a-cai").unwrap(),
+                is_nsfw: false,
+                status: PostStatus::ReadyToView,
+                created_at: Some(creted_at_earlier),
+            },
+            PostScoreIndexItemV1 {
+                score: 4,
+                post_id: 4,
+                publisher_canister_id: Principal::from_text("w4nuc-waaaa-aaaao-aal2a-cai").unwrap(),
+                is_nsfw: false,
+                status: PostStatus::ReadyToView,
+                created_at: Some(creted_at_earlier),
+            },
+            PostScoreIndexItemV1 {
+                score: 5,
+                post_id: 5,
+                publisher_canister_id: Principal::from_text("w4nuc-waaaa-aaaao-aal2a-cai").unwrap(),
+                is_nsfw: false,
+                status: PostStatus::ReadyToView,
+                created_at: Some(creted_at_earlier),
+            },
+        ];
+
+        for post in posts {
+            post_score_index.replace(&post);
+        }
+
+        let mut post_score_index_iter = post_score_index.iter();
+        assert_eq!(
+            post_score_index_iter.next(),
+            Some(&PostScoreIndexItemV1 {
+                score: 2,
+                post_id: 2,
+                publisher_canister_id: Principal::from_text("w4nuc-waaaa-aaaao-aal2a-cai").unwrap(),
+                is_nsfw: false,
+                status: PostStatus::ReadyToView,
+                created_at: Some(created_at_now),
+            })
+        );
+        assert_eq!(
+            post_score_index_iter.next(),
+            Some(&PostScoreIndexItemV1 {
+                score: 1,
+                post_id: 1,
+                publisher_canister_id: Principal::from_text("w4nuc-waaaa-aaaao-aal2a-cai").unwrap(),
+                is_nsfw: false,
+                status: PostStatus::ReadyToView,
+                created_at: Some(created_at_now),
+            })
+        );
+        assert_eq!(
+            post_score_index_iter.next(),
+            Some(&PostScoreIndexItemV1 {
+                score: 5,
+                post_id: 5,
+                publisher_canister_id: Principal::from_text("w4nuc-waaaa-aaaao-aal2a-cai").unwrap(),
+                is_nsfw: false,
+                status: PostStatus::ReadyToView,
+                created_at: Some(creted_at_earlier),
+            })
+        );
+        assert_eq!(
+            post_score_index_iter.next(),
+            Some(&PostScoreIndexItemV1 {
+                score: 4,
+                post_id: 4,
+                publisher_canister_id: Principal::from_text("w4nuc-waaaa-aaaao-aal2a-cai").unwrap(),
+                is_nsfw: false,
+                status: PostStatus::ReadyToView,
+                created_at: Some(creted_at_earlier),
+            })
+        );
+        assert_eq!(
+            post_score_index_iter.next(),
+            Some(&PostScoreIndexItemV1 {
+                score: 3,
+                post_id: 3,
+                publisher_canister_id: Principal::from_text("w4nuc-waaaa-aaaao-aal2a-cai").unwrap(),
+                is_nsfw: false,
+                status: PostStatus::ReadyToView,
+                created_at: Some(creted_at_earlier),
+            })
+        );
+        assert_eq!(post_score_index_iter.next(), None);
+    }
+
+    #[test]
+    fn test_post_score_index_v1_replace() {
+        let mut post_score_index = PostScoreHotOrNotIndex::default();
+        let created_at_now = SystemTime::now();
+
+        let posts = vec![
+            PostScoreIndexItemV1 {
+                score: 1,
+                post_id: 1,
+                publisher_canister_id: Principal::from_text("w4nuc-waaaa-aaaao-aal2a-cai").unwrap(),
+                is_nsfw: false,
+                status: PostStatus::Uploaded,
+                created_at: Some(created_at_now),
+            },
+            PostScoreIndexItemV1 {
+                score: 2,
+                post_id: 2,
+                publisher_canister_id: Principal::from_text("w4nuc-waaaa-aaaao-aal2a-cai").unwrap(),
+                is_nsfw: true,
+                status: PostStatus::ReadyToView,
+                created_at: Some(created_at_now),
+            },
+            PostScoreIndexItemV1 {
+                score: 3,
+                post_id: 1,
+                publisher_canister_id: Principal::from_text("w4nuc-waaaa-aaaao-aal2a-cai").unwrap(),
+                is_nsfw: true,
+                status: PostStatus::ReadyToView,
+                created_at: Some(created_at_now),
+            },
+        ];
+
+        for post in posts {
+            post_score_index.replace(&post);
+        }
+
+        let mut post_score_index_iter = post_score_index.iter();
+        assert_eq!(
+            post_score_index_iter.next(),
+            Some(&PostScoreIndexItemV1 {
+                score: 3,
+                post_id: 1,
+                publisher_canister_id: Principal::from_text("w4nuc-waaaa-aaaao-aal2a-cai").unwrap(),
+                is_nsfw: true,
+                status: PostStatus::ReadyToView,
+                created_at: Some(created_at_now),
+            })
+        );
+        assert_eq!(
+            post_score_index_iter.next(),
+            Some(&PostScoreIndexItemV1 {
+                score: 2,
+                post_id: 2,
+                publisher_canister_id: Principal::from_text("w4nuc-waaaa-aaaao-aal2a-cai").unwrap(),
+                is_nsfw: true,
+                status: PostStatus::ReadyToView,
+                created_at: Some(created_at_now),
+            })
+        );
+        assert_eq!(post_score_index_iter.next(), None);
+    }
+}

--- a/src/lib/shared_utils/src/common/types/top_posts/post_score_hot_or_not_index/mod.rs
+++ b/src/lib/shared_utils/src/common/types/top_posts/post_score_hot_or_not_index/mod.rs
@@ -8,6 +8,8 @@ use std::{
     vec,
 };
 
+use crate::common::utils::system_time::get_current_system_time;
+
 use super::{
     post_score_index_item::PostScoreIndexItemV1, CreatedAt, GlobalPostId, Score,
     LATEST_POSTS_WINDOW,
@@ -36,11 +38,12 @@ impl PostScoreHotOrNotIndex {
             .insert(item_presence_index_entry, item.clone());
 
         // insert the item into the sorted index, nsfw, time and sorted and latest sorted indexes
+        let now = get_current_system_time();
 
         // if item created within last 48 hrs, insert into latest sorted index
         // else insert into sorted index
         if let Some(created_at) = item.created_at {
-            if created_at > (SystemTime::now() - LATEST_POSTS_WINDOW) {
+            if created_at > (now - LATEST_POSTS_WINDOW) {
                 let latest_score_index_entry = self
                     .items_latest_sorted_by_score
                     .entry(item_score)
@@ -173,7 +176,7 @@ impl FromIterator<PostScoreIndexItemV1> for PostScoreHotOrNotIndex {
     }
 }
 
-#[cfg(test)]
+#[cfg(all(test, feature = "mockdata"))]
 mod tests {
     use candid::Principal;
 

--- a/src/lib/shared_utils/src/common/types/top_posts/post_score_hot_or_not_index/mod.rs
+++ b/src/lib/shared_utils/src/common/types/top_posts/post_score_hot_or_not_index/mod.rs
@@ -8,10 +8,10 @@ use std::{
     vec,
 };
 
-use super::{post_score_index_item::PostScoreIndexItemV1, CreatedAt, GlobalPostId, Score};
-
-// Latest posts within 48 hrs
-pub const LATEST_POSTS_WINDOW: Duration = Duration::from_secs(48 * 60 * 60);
+use super::{
+    post_score_index_item::PostScoreIndexItemV1, CreatedAt, GlobalPostId, Score,
+    LATEST_POSTS_WINDOW,
+};
 
 #[derive(Default, Debug, Clone, CandidType, Deserialize, Serialize)]
 pub struct PostScoreHotOrNotIndex {
@@ -185,7 +185,7 @@ mod tests {
     fn test_post_score_index_v1_normal_functionality() {
         let mut post_score_index = PostScoreHotOrNotIndex::default();
         let created_at_now = SystemTime::now();
-        let creted_at_earlier = created_at_now - Duration::from_secs(60 * 60 * 48 + 1);
+        let creted_at_earlier = created_at_now - (LATEST_POSTS_WINDOW + Duration::from_secs(1));
 
         let posts = vec![
             PostScoreIndexItemV1 {

--- a/src/lib/shared_utils/src/common/types/top_posts/post_score_hot_or_not_index/mod.rs
+++ b/src/lib/shared_utils/src/common/types/top_posts/post_score_hot_or_not_index/mod.rs
@@ -85,6 +85,9 @@ impl PostScoreHotOrNotIndex {
                 old_score_index_entry.retain(|old_item| {
                     old_item.0 != item.publisher_canister_id || old_item.1 != item.post_id
                 });
+                if old_score_index_entry.is_empty() {
+                    self.items_sorted_by_score.remove(&old_score);
+                }
             }
 
             if let Some(old_latest_score_index_entry) =
@@ -93,6 +96,9 @@ impl PostScoreHotOrNotIndex {
                 old_latest_score_index_entry.retain(|old_item| {
                     old_item.0 != item.publisher_canister_id || old_item.1 != item.post_id
                 });
+                if old_latest_score_index_entry.is_empty() {
+                    self.items_latest_sorted_by_score.remove(&old_score);
+                }
             }
 
             if let Some(old_created_at) = old_created_at {
@@ -100,6 +106,9 @@ impl PostScoreHotOrNotIndex {
                 old_time_index_entry.retain(|old_item| {
                     old_item.0 != item.publisher_canister_id || old_item.1 != item.post_id
                 });
+                if old_time_index_entry.is_empty() {
+                    self.item_time_index.remove(&old_created_at);
+                }
             }
         }
 

--- a/src/lib/shared_utils/src/common/types/top_posts/post_score_index/mod.rs
+++ b/src/lib/shared_utils/src/common/types/top_posts/post_score_index/mod.rs
@@ -1,16 +1,19 @@
 use candid::{CandidType, Deserialize, Principal};
 use serde::Serialize;
 use std::{
-    collections::{btree_map, BTreeMap, HashMap},
-    iter::Rev,
-    slice, vec,
+    collections::{
+        btree_map::{self, Iter},
+        BTreeMap, HashMap,
+    },
+    iter::{Chain, Rev},
+    slice,
+    time::{Duration, SystemTime},
+    vec,
 };
 
 use crate::common::types::top_posts::post_score_index_item::PostScoreIndexItem;
 
-type PublisherCanisterId = Principal;
-type PostId = u64;
-type Score = u64;
+use super::{PostId, PublisherCanisterId, Score};
 
 #[derive(Default, Debug, Clone, CandidType, Deserialize, Serialize)]
 pub struct PostScoreIndex {

--- a/src/lib/shared_utils/src/common/types/top_posts/post_score_index_item/mod.rs
+++ b/src/lib/shared_utils/src/common/types/top_posts/post_score_index_item/mod.rs
@@ -1,12 +1,37 @@
 use candid::{CandidType, Deserialize, Principal};
 use serde::Serialize;
-use std::cmp::Ordering;
+use std::{cmp::Ordering, time::SystemTime};
+
+#[derive(Serialize, Deserialize, CandidType, Clone, Default, Debug, PartialEq, Eq, Hash)]
+pub enum PostStatus {
+    #[default]
+    Uploaded,
+    Transcoding,
+    CheckingExplicitness,
+    BannedForExplicitness,
+    ReadyToView,
+    BannedDueToUserReporting,
+    Deleted,
+}
 
 #[derive(Clone, CandidType, Deserialize, Debug, Serialize)]
 pub struct PostScoreIndexItem {
     pub score: u64,
     pub post_id: u64,
     pub publisher_canister_id: Principal,
+}
+
+#[derive(Clone, CandidType, Deserialize, Debug, Serialize, PartialEq, Eq)]
+pub struct PostScoreIndexItemV1 {
+    pub score: u64,
+    pub post_id: u64,
+    pub publisher_canister_id: Principal,
+    #[serde(default)]
+    pub is_nsfw: bool,
+    #[serde(default)]
+    pub created_at: Option<SystemTime>,
+    #[serde(default)]
+    pub status: PostStatus,
 }
 
 // #[derive(Debug, PartialEq, Eq)]

--- a/src/lib/shared_utils/src/common/types/top_posts/post_score_index_item/mod.rs
+++ b/src/lib/shared_utils/src/common/types/top_posts/post_score_index_item/mod.rs
@@ -2,7 +2,7 @@ use candid::{CandidType, Deserialize, Principal};
 use serde::Serialize;
 use std::{cmp::Ordering, time::SystemTime};
 
-#[derive(Serialize, Deserialize, CandidType, Clone, Default, Debug, PartialEq, Eq, Hash)]
+#[derive(Serialize, Deserialize, CandidType, Clone, Default, Debug, PartialEq, Eq, Hash, Copy)]
 pub enum PostStatus {
     #[default]
     Uploaded,

--- a/src/lib/shared_utils/src/common/types/version_details.rs
+++ b/src/lib/shared_utils/src/common/types/version_details.rs
@@ -5,5 +5,5 @@ use serde::Serialize;
 pub struct VersionDetails {
     pub version_number: u64,
     #[serde(default)]
-    pub version: String
+    pub version: String,
 }

--- a/src/lib/shared_utils/src/pagination.rs
+++ b/src/lib/shared_utils/src/pagination.rs
@@ -33,6 +33,27 @@ pub fn get_pagination_bounds(
     Ok((from_inclusive_id, upper_bound_exclusive))
 }
 
+pub fn get_pagination_bounds_cursor(
+    from_inclusive_id: u64,
+    limit: u64,
+    total_items: u64,
+) -> Result<(u64, u64), PaginationError> {
+    if from_inclusive_id >= total_items {
+        return Err(PaginationError::ReachedEndOfItemsList);
+    }
+
+    let mut adjusted_limit = limit;
+    if adjusted_limit > total_items - from_inclusive_id {
+        adjusted_limit = total_items - from_inclusive_id;
+    }
+
+    if adjusted_limit > MAX_POSTS_IN_ONE_REQUEST {
+        return Err(PaginationError::ExceededMaxNumberOfItemsAllowedInOneRequest);
+    }
+
+    Ok((from_inclusive_id, adjusted_limit))
+}
+
 #[cfg(test)]
 mod test {
     use super::*;
@@ -69,6 +90,36 @@ mod test {
         // number of items fetched exceeds max allowed
         assert_eq!(
             get_pagination_bounds(0, 110, 250),
+            Err(PaginationError::ExceededMaxNumberOfItemsAllowedInOneRequest)
+        );
+    }
+
+    #[test]
+    fn test_get_pagination_bounds_cursor() {
+        // exact number of items as limit
+        assert_eq!(get_pagination_bounds_cursor(0, 10, 10), Ok((0, 10)));
+
+        // limit exceeds total items
+        assert_eq!(get_pagination_bounds_cursor(0, 10, 5), Ok((0, 5)));
+
+        // total items exceeds limit
+        assert_eq!(get_pagination_bounds_cursor(0, 10, 15), Ok((0, 10)));
+
+        // number of items is zero
+        assert_eq!(
+            get_pagination_bounds_cursor(0, 10, 0),
+            Err(PaginationError::ReachedEndOfItemsList)
+        );
+
+        // lower bound exceeds total items
+        assert_eq!(
+            get_pagination_bounds_cursor(10, 10, 5),
+            Err(PaginationError::ReachedEndOfItemsList)
+        );
+
+        // number of items fetched exceeds max allowed
+        assert_eq!(
+            get_pagination_bounds_cursor(0, 110, 250),
             Err(PaginationError::ExceededMaxNumberOfItemsAllowedInOneRequest)
         );
     }

--- a/src/lib/test_utils/src/setup/env/v1.rs
+++ b/src/lib/test_utils/src/setup/env/v1.rs
@@ -13,11 +13,11 @@ use shared_utils::{
 };
 
 use crate::setup::test_constants::{
-    get_canister_wasm, get_global_super_admin_principal_id,
+    get_canister_wasm, get_global_super_admin_principal_id, get_mock_canister_id_sns,
     v1::{
         CANISTER_INITIAL_CYCLES_FOR_NON_SPAWNING_CANISTERS,
         CANISTER_INITIAL_CYCLES_FOR_SPAWNING_CANISTERS,
-    }, get_mock_canister_id_sns,
+    },
 };
 
 /// The path to the state machine binary to run the tests with
@@ -88,7 +88,7 @@ pub fn get_initialized_env_with_provisioned_known_canisters(
 
     known_principal_map_with_all_canisters.insert(
         KnownPrincipalType::CanisterIdSnsGovernance,
-        get_mock_canister_id_sns()
+        get_mock_canister_id_sns(),
     );
 
     // * Install canisters
@@ -130,6 +130,7 @@ pub fn get_initialized_env_with_provisioned_known_canisters(
         get_canister_wasm(KnownPrincipalType::CanisterIdPostCache),
         candid::encode_one(PostCacheInitArgs {
             known_principal_ids: Some(known_principal_map_with_all_canisters.clone()),
+            ..Default::default()
         })
         .unwrap(),
     );
@@ -151,7 +152,7 @@ pub fn get_initialized_env_with_provisioned_known_canisters(
         candid::encode_one(UserIndexInitArgs {
             known_principal_ids: Some(known_principal_map_with_all_canisters.clone()),
             access_control_map: Some(user_index_access_control_map),
-            version: String::from("v1.0.0")
+            version: String::from("v1.0.0"),
         })
         .unwrap(),
     );


### PR DESCRIPTION
Fixes #228 

- [x] Add new fields to PostScoreIndexItem
	- [x] new struct
	- [x] New BTreeMap indexes for filters
		- [x] methods
	- [x] tests
	- [x] periodically update latest index
- [x] New feed filter APIs
- [x] Update API on PostCache side
	- [x] Call from individual template canister on update
	- [x] update receive methods
	- [x] update existing reconcile score methods
	- [x] integration testing
- [x] post_upgrade
	- [x] migration script
		- [x] versioning
		- [x] Call individual template canisters for values. nanosec timer
	- [x] testing
- [x] testing
	- [x] mock timing
	- [x] trigger calls 
		- [ ] stuck
		- [x] hotornot feed time update
	- [x] upgrade testing
- [x] check backward compatibility - to not break existing flows

- [x] reconcile scores from PostCache