### PR TITLE
stop subnet canister before upgrading

### DIFF
--- a/src/canister/platform_orchestrator/src/api/canister_lifecycle/init.rs
+++ b/src/canister/platform_orchestrator/src/api/canister_lifecycle/init.rs
@@ -1,4 +1,3 @@
-use candid::Principal;
 use ic_cdk_macros::init;
 use shared_utils::canister_specific::platform_orchestrator::types::args::PlatformOrchestratorInitArgs;
 use crate::CANISTER_DATA;
@@ -10,12 +9,5 @@ use crate::CANISTER_DATA;
 fn init(init_args: PlatformOrchestratorInitArgs) {
     CANISTER_DATA.with_borrow_mut(|canister_data| {
         canister_data.version_detail.version = init_args.version;
-        canister_data.all_subnet_orchestrator_canisters_list.insert(Principal::from_text("rimrc-piaaa-aaaao-aaljq-cai").unwrap());
-        canister_data.subet_orchestrator_with_capacity_left.insert(Principal::from_text("rimrc-piaaa-aaaao-aaljq-cai").unwrap());
-        canister_data.all_post_cache_orchestrator_list.insert(Principal::from_text("y6yjf-jyaaa-aaaal-qbd6q-cai").unwrap());
-
-        canister_data.all_subnet_orchestrator_canisters_list.insert(Principal::from_text("znhy2-2qaaa-aaaag-acofq-cai").unwrap());
-        canister_data.subet_orchestrator_with_capacity_left.insert(Principal::from_text("znhy2-2qaaa-aaaag-acofq-cai").unwrap());
-        canister_data.all_post_cache_orchestrator_list.insert(Principal::from_text("zyajx-3yaaa-aaaag-acoga-cai").unwrap());
     })
 }

--- a/src/canister/platform_orchestrator/src/api/canister_lifecycle/post_upgrade.rs
+++ b/src/canister/platform_orchestrator/src/api/canister_lifecycle/post_upgrade.rs
@@ -1,6 +1,7 @@
 use ciborium::de;
 use ic_cdk_macros::post_upgrade;
 use ic_stable_structures::Memory;
+use shared_utils::{canister_specific::platform_orchestrator::types::args::PlatformOrchestratorInitArgs, common::utils::system_time};
 
 use crate::{data_model::memory, CANISTER_DATA};
 
@@ -9,6 +10,11 @@ use crate::{data_model::memory, CANISTER_DATA};
 
 #[post_upgrade]
 pub fn post_upgrade() {
+   restore_data_from_stable_memory();
+   update_version_from_args();
+}
+
+fn restore_data_from_stable_memory() {
    let heap_data = memory::get_upgrades_memory();
    let mut heap_data_len_bytes = [0; 4];
    heap_data.read(0, &mut heap_data_len_bytes);
@@ -19,5 +25,13 @@ pub fn post_upgrade() {
    let canister_data = de::from_reader(&*canister_data_bytes).expect("Failed to deserialize heap data");
    CANISTER_DATA.with_borrow_mut(|cd| {
         *cd = canister_data;
+   })
+}
+
+fn update_version_from_args() {
+   let (upgrade_args,) = ic_cdk::api::call::arg_data::<(PlatformOrchestratorInitArgs,)>();
+   CANISTER_DATA.with_borrow_mut(|canister_data| {
+      canister_data.version_detail.version = upgrade_args.version;
+      canister_data.version_detail.last_update_on = system_time::get_current_system_time();
    })
 }

--- a/src/canister/platform_orchestrator/src/api/canister_management/upgrade_canister.rs
+++ b/src/canister/platform_orchestrator/src/api/canister_management/upgrade_canister.rs
@@ -1,6 +1,6 @@
 
 use candid::Principal;
-use ic_cdk::{api::{is_controller, management_canister::{main::{deposit_cycles, install_code, CanisterInstallMode, InstallCodeArgument}, provisional::CanisterIdRecord}}, caller};
+use ic_cdk::{api::{is_controller, management_canister::{main::{deposit_cycles, CanisterInstallMode, InstallCodeArgument}, provisional::CanisterIdRecord}}, caller};
 use ic_cdk_macros::update;
 use shared_utils::{
     canister_specific::{
@@ -9,7 +9,7 @@ use shared_utils::{
     },
     common::{
         types::wasm::{CanisterWasm, WasmType},
-        utils::task::run_task_concurrently
+        utils::{task::run_task_concurrently, upgrade_canister::upgrade_canister_util}
     },
     constant::{
         POST_CACHE_CANISTER_CYCLES_RECHARGE_AMOUMT, 
@@ -211,38 +211,38 @@ async fn recharge_post_cache_canister_if_needed(canister_id: Principal) -> Resul
 
 
 async fn upgrade_subnet_post_cache_canister(canister_id: Principal, wasm: Vec<u8>, version: String) -> Result<(), String> {
-    install_code(
-        InstallCodeArgument {
-            mode: CanisterInstallMode::Upgrade,
-            canister_id,
-            wasm_module: wasm,
-            arg: candid::encode_one( PostCacheInitArgs {
-                version,
-                upgrade_version_number: None,
-                known_principal_ids: None,
-            })
-            .unwrap()
-        }
-    )
+    let install_code_arg = InstallCodeArgument {
+        mode: CanisterInstallMode::Upgrade,
+        canister_id,
+        wasm_module: wasm,
+        arg: candid::encode_one( PostCacheInitArgs {
+            version,
+            upgrade_version_number: None,
+            known_principal_ids: None,
+        })
+        .unwrap()
+    };
+
+    upgrade_canister_util(install_code_arg)
     .await
     .map_err(|e| e.1)
 }
 
 
 async fn upgrade_subnet_orchestrator_canister(canister_id: Principal, wasm: Vec<u8>, version: String) -> Result<(), String> {
-    install_code(
-        InstallCodeArgument {
-            mode: CanisterInstallMode::Upgrade,
-            canister_id,
-            wasm_module: wasm,
-            arg: candid::encode_one(UserIndexInitArgs {
-                known_principal_ids: None,
-                access_control_map: None,
-                version
-            })
-            .unwrap()
-        }
-    )
+    let install_code_arg = InstallCodeArgument {
+        mode: CanisterInstallMode::Upgrade,
+        canister_id,
+        wasm_module: wasm,
+        arg: candid::encode_one(UserIndexInitArgs {
+            known_principal_ids: None,
+            access_control_map: None,
+            version
+        })
+        .unwrap()
+    };
+    
+    upgrade_canister_util(install_code_arg)
     .await
     .map_err(|e| e.1)
 }

--- a/src/lib/shared_utils/src/common/types/wasm.rs
+++ b/src/lib/shared_utils/src/common/types/wasm.rs
@@ -47,8 +47,5 @@ impl Storable for CanisterWasm {
         canister_wasm
     }
 
-    const BOUND: Bound = Bound::Bounded { 
-        max_size: 200_000_000, // 2 MB 
-        is_fixed_size: false
-    };
+    const BOUND: Bound = Bound::Unbounded;
 }

--- a/src/lib/shared_utils/src/common/types/wasm.rs
+++ b/src/lib/shared_utils/src/common/types/wasm.rs
@@ -25,7 +25,7 @@ impl Storable for WasmType {
         wasm_type
     }
 
-    const BOUND: Bound = Bound::Bounded { max_size: 19, is_fixed_size: true };
+    const BOUND: Bound = Bound::Bounded { max_size: 25, is_fixed_size: false };
 }
 
 

--- a/src/lib/shared_utils/src/common/utils/mod.rs
+++ b/src/lib/shared_utils/src/common/utils/mod.rs
@@ -1,3 +1,4 @@
 pub mod stable_memory_serializer_deserializer;
 pub mod task;
 pub mod system_time;
+pub mod upgrade_canister;

--- a/src/lib/shared_utils/src/common/utils/upgrade_canister.rs
+++ b/src/lib/shared_utils/src/common/utils/upgrade_canister.rs
@@ -1,0 +1,10 @@
+use ic_cdk::api::{call::CallResult, management_canister::{main::{self, start_canister, stop_canister, InstallCodeArgument}, provisional::CanisterIdRecord}};
+
+
+pub async fn upgrade_canister_util (arg: InstallCodeArgument) -> CallResult<()>{
+    let canister_id = arg.canister_id;
+    stop_canister(CanisterIdRecord {canister_id}).await?;
+    main::install_code(arg).await?;
+    start_canister(CanisterIdRecord {canister_id}).await
+}
+


### PR DESCRIPTION
## Changes
- stop subnet orchestrator and post cache canisters before upgrading them

## Impact
- fixes #256 