### PR TITLE
Reclaim cycles from individual canisters

### DIFF
--- a/scripts/candid_generator.sh
+++ b/scripts/candid_generator.sh
@@ -13,5 +13,6 @@ CANISTERS=user_index,post_cache,platform_orchestrator,individual_user_template
 
 for canister in $(echo $CANISTERS | sed "s/,/ /g")
 do
+    dfx build $canister
     generate_did "$canister"
 done

--- a/src/canister/individual_user_template/src/api/cycle_management/return_cycles_to_user_index_canister.rs
+++ b/src/canister/individual_user_template/src/api/cycle_management/return_cycles_to_user_index_canister.rs
@@ -1,4 +1,4 @@
-use ic_cdk::api::management_canister::{main, provisional::CanisterIdRecord};
+use ic_cdk::{api::{canister_balance, canister_balance128, is_controller, management_canister::{main, provisional::CanisterIdRecord}}, caller};
 use ic_cdk_macros::update;
 use shared_utils::{
     common::types::known_principal::KnownPrincipalType,
@@ -9,7 +9,11 @@ use crate::CANISTER_DATA;
 
 #[update]
 async fn return_cycles_to_user_index_canister(cycle_amount: Option<u128>) {
-    let api_caller = ic_cdk::caller();
+
+    if !is_controller(&caller()) {
+        panic!("Unauthorized")
+    }
+
 
     let user_index_canister_id = CANISTER_DATA.with(|canister_data_ref_cell| {
         canister_data_ref_cell
@@ -20,16 +24,15 @@ async fn return_cycles_to_user_index_canister(cycle_amount: Option<u128>) {
             .unwrap()
     });
 
-    if api_caller != user_index_canister_id {
-        return;
+    
+    if cycle_amount.is_some() || canister_balance128() > INDIVIDUAL_USER_CANISTER_RECHARGE_AMOUNT {
+        main::deposit_cycles(
+            CanisterIdRecord {
+                canister_id: user_index_canister_id,
+            },
+            cycle_amount.unwrap_or(canister_balance128() - INDIVIDUAL_USER_CANISTER_RECHARGE_AMOUNT),
+        )
+        .await
+        .unwrap();
     }
-
-    main::deposit_cycles(
-        CanisterIdRecord {
-            canister_id: user_index_canister_id,
-        },
-        cycle_amount.unwrap_or(INDIVIDUAL_USER_CANISTER_RECHARGE_AMOUNT / 2),
-    )
-    .await
-    .unwrap();
 }

--- a/src/canister/individual_user_template/src/api/cycle_management/return_cycles_to_user_index_canister.rs
+++ b/src/canister/individual_user_template/src/api/cycle_management/return_cycles_to_user_index_canister.rs
@@ -1,19 +1,14 @@
-use ic_cdk::{api::{canister_balance, canister_balance128, is_controller, management_canister::{main, provisional::CanisterIdRecord}}, caller};
+use ic_cdk::{api::{canister_balance128, management_canister::{main, provisional::CanisterIdRecord}}, caller};
 use ic_cdk_macros::update;
 use shared_utils::{
-    common::types::known_principal::KnownPrincipalType,
+    common::{types::known_principal::KnownPrincipalType, utils::permissions::is_caller_controller},
     constant::INDIVIDUAL_USER_CANISTER_RECHARGE_AMOUNT,
 };
 
 use crate::CANISTER_DATA;
 
-#[update]
+#[update(guard = "is_caller_controller")]
 async fn return_cycles_to_user_index_canister(cycle_amount: Option<u128>) {
-
-    if !is_controller(&caller()) {
-        panic!("Unauthorized")
-    }
-
 
     let user_index_canister_id = CANISTER_DATA.with(|canister_data_ref_cell| {
         canister_data_ref_cell

--- a/src/canister/platform_orchestrator/can.did
+++ b/src/canister/platform_orchestrator/can.did
@@ -22,6 +22,7 @@ service : (PlatformOrchestratorInitArgs) -> {
   get_subnet_last_upgrade_status : () -> (CanisterUpgradeStatus) query;
   get_version : () -> (text) query;
   provision_subnet_orchestrator_canister : (principal) -> (Result);
+  start_reclaiming_cycles_from_individual_canisters : () -> (Result_1);
   stop_upgrades_for_individual_user_canisters : () -> (Result_1);
   subnet_orchestrator_maxed_out : () -> ();
   upgrade_canister : (UpgradeCanisterArg) -> (Result_1);

--- a/src/canister/platform_orchestrator/src/api/cycle_management/mod.rs
+++ b/src/canister/platform_orchestrator/src/api/cycle_management/mod.rs
@@ -1,0 +1,1 @@
+pub mod start_reclaiming_cycles_from_individual_canisters;

--- a/src/canister/platform_orchestrator/src/api/cycle_management/start_reclaiming_cycles_from_individual_canisters.rs
+++ b/src/canister/platform_orchestrator/src/api/cycle_management/start_reclaiming_cycles_from_individual_canisters.rs
@@ -1,0 +1,15 @@
+
+use ic_cdk_macros::update;
+use shared_utils::common::utils::permissions::is_caller_controller;
+
+use crate::CANISTER_DATA;
+
+#[update(guard = "is_caller_controller")]
+fn start_reclaiming_cycles_from_individual_canisters() -> Result<String, String>{
+    CANISTER_DATA.with_borrow(|canister_data| {
+        canister_data.all_subnet_orchestrator_canisters_list.iter().for_each(|subnet_orchestrator_id| {
+            ic_cdk::notify(*subnet_orchestrator_id, "reclaim_cycles_from_individual_canisters", ()).unwrap();
+        });
+   });
+   Ok("Success".into())
+}

--- a/src/canister/platform_orchestrator/src/api/mod.rs
+++ b/src/canister/platform_orchestrator/src/api/mod.rs
@@ -1,2 +1,3 @@
 pub mod canister_lifecycle;
 pub mod canister_management;
+pub mod cycle_management;

--- a/src/canister/user_index/can.did
+++ b/src/canister/user_index/can.did
@@ -110,6 +110,7 @@ service : (UserIndexInitArgs) -> {
       principal,
       text,
     ) -> ();
+  reclaim_cycles_from_individual_canisters : () -> ();
   reset_user_individual_canisters : (vec principal) -> (Result);
   set_permission_to_upgrade_individual_canisters : (bool) -> (text);
   start_upgrades_for_individual_canisters : (text, vec nat8) -> (text);

--- a/src/canister/user_index/src/api/canister_lifecycle/post_upgrade.rs
+++ b/src/canister/user_index/src/api/canister_lifecycle/post_upgrade.rs
@@ -16,7 +16,6 @@ use crate::{
 fn post_upgrade() {
     restore_data_from_stable_memory();
     update_version_from_args();
-    reclaim_cycles_from_individual_canisters();
     insert_platform_orchestrator_in_well_known_principal();
 }
 
@@ -24,22 +23,6 @@ fn insert_platform_orchestrator_in_well_known_principal() {
     CANISTER_DATA.with_borrow_mut(|canister_data| {
         canister_data.configuration.known_principal_ids.insert(CanisterIdPlatformOrchestrator, Principal::from_text("74zq4-iqaaa-aaaam-ab53a-cai").unwrap());
     })
-}
-
-
-fn reclaim_cycles_from_individual_canisters() {
-    ic_cdk::spawn(impl_reclaim_cycles_from_individual_canisters_and_send_to_plaform_orchestrator())
-}
-
-async fn impl_reclaim_cycles_from_individual_canisters_and_send_to_plaform_orchestrator() {
-    let canister_ids = CANISTER_DATA.with_borrow(|canister_data| {
-        canister_data.user_principal_id_to_canister_id_map.clone().into_values()
-    });
-
-    let relcaim_cycles_from_canister_futures = canister_ids.map(|canister_id| {
-        call::<_ , ()>(canister_id, "return_cycles_to_user_index_canister", ())
-    });
-    run_task_concurrently(relcaim_cycles_from_canister_futures, 10, |_| {}, || false).await;
 }
 
 fn update_version_from_args() {

--- a/src/canister/user_index/src/api/canister_lifecycle/post_upgrade.rs
+++ b/src/canister/user_index/src/api/canister_lifecycle/post_upgrade.rs
@@ -1,9 +1,11 @@
+use candid::Principal;
 use ciborium::de;
 
 use ic_cdk::call;
 use ic_cdk_macros::post_upgrade;
 use ic_stable_structures::Memory;
 use shared_utils::{canister_specific::user_index::types::args::UserIndexInitArgs, common::utils::{system_time, task::run_task_concurrently}};
+use shared_utils::common::types::known_principal::KnownPrincipalType::CanisterIdPlatformOrchestrator;
 
 use crate::{
     data_model::{canister_upgrade::UpgradeStatus, memory},
@@ -14,7 +16,14 @@ use crate::{
 fn post_upgrade() {
     restore_data_from_stable_memory();
     update_version_from_args();
-    reclaim_cycles_from_individual_canisters()
+    reclaim_cycles_from_individual_canisters();
+    insert_platform_orchestrator_in_well_known_principal();
+}
+
+fn insert_platform_orchestrator_in_well_known_principal() {
+    CANISTER_DATA.with_borrow_mut(|canister_data| {
+        canister_data.configuration.known_principal_ids.insert(CanisterIdPlatformOrchestrator, Principal::from_text("74zq4-iqaaa-aaaam-ab53a-cai").unwrap());
+    })
 }
 
 

--- a/src/canister/user_index/src/api/cycle_management/mod.rs
+++ b/src/canister/user_index/src/api/cycle_management/mod.rs
@@ -1,2 +1,2 @@
 pub mod get_user_index_canister_cycle_balance;
-pub mod reclaim_cycle_from_individual_canisters;
+pub mod reclaim_cycles_from_individual_canisters;

--- a/src/canister/user_index/src/api/cycle_management/mod.rs
+++ b/src/canister/user_index/src/api/cycle_management/mod.rs
@@ -1,1 +1,2 @@
 pub mod get_user_index_canister_cycle_balance;
+pub mod reclaim_cycle_from_individual_canisters;

--- a/src/canister/user_index/src/api/cycle_management/reclaim_cycle_from_individual_canisters.rs
+++ b/src/canister/user_index/src/api/cycle_management/reclaim_cycle_from_individual_canisters.rs
@@ -1,0 +1,21 @@
+use ic_cdk::call;
+use ic_cdk_macros::update;
+use shared_utils::common::utils::task::run_task_concurrently;
+
+use crate::CANISTER_DATA;
+
+#[update]
+fn reclaim_cycles_from_individual_canisters() {
+    ic_cdk::spawn(impl_reclaim_cycles_from_individual_canisters_and_send_to_plaform_orchestrator())
+}
+
+async fn impl_reclaim_cycles_from_individual_canisters_and_send_to_plaform_orchestrator() {
+    let canister_ids = CANISTER_DATA.with_borrow(|canister_data| {
+        canister_data.user_principal_id_to_canister_id_map.clone().into_values()
+    });
+
+    let relcaim_cycles_from_canister_futures = canister_ids.map(|canister_id| {
+        call::<_ , ()>(canister_id, "return_cycles_to_user_index_canister", ())
+    });
+    run_task_concurrently(relcaim_cycles_from_canister_futures, 10, |_| {}, || false).await;
+}

--- a/src/canister/user_index/src/api/cycle_management/reclaim_cycles_from_individual_canisters.rs
+++ b/src/canister/user_index/src/api/cycle_management/reclaim_cycles_from_individual_canisters.rs
@@ -1,10 +1,10 @@
 use ic_cdk::call;
 use ic_cdk_macros::update;
-use shared_utils::common::utils::task::run_task_concurrently;
+use shared_utils::common::utils::{permissions::is_caller_controller, task::run_task_concurrently};
 
 use crate::CANISTER_DATA;
 
-#[update]
+#[update(guard = "is_caller_controller")]
 fn reclaim_cycles_from_individual_canisters() {
     ic_cdk::spawn(impl_reclaim_cycles_from_individual_canisters_and_send_to_plaform_orchestrator())
 }

--- a/src/lib/shared_utils/src/common/utils/permissions.rs
+++ b/src/lib/shared_utils/src/common/utils/permissions.rs
@@ -1,5 +1,5 @@
+use ic_cdk::{api::is_controller, caller};
 use candid::Principal;
-
 use crate::constant::RECLAIM_CANISTER_PRINCIPAL_ID;
 
 pub fn is_reclaim_canister_id() -> Result<(), String> {
@@ -13,4 +13,12 @@ pub fn is_reclaim_canister_id() -> Result<(), String> {
     } else {
         Err("Caller is not allowed.".to_string())
     }
+}
+
+
+pub fn is_caller_controller() -> Result<(), String> {
+    if !is_controller(&caller()) {
+        return Err("Unauthorize".into());
+    }
+    Ok(())
 }

--- a/src/lib/shared_utils/src/constant.rs
+++ b/src/lib/shared_utils/src/constant.rs
@@ -27,7 +27,7 @@ pub const NNS_LEDGER_CANISTER_ID: &str = "ryjl3-tyaaa-aaaaa-aaaba-cai";
 pub const GLOBAL_SUPER_ADMIN_USER_ID: &str =
     "7gaq2-4kttl-vtbt4-oo47w-igteo-cpk2k-57h3p-yioqe-wkawi-wz45g-jae";
 pub const RECLAIM_CANISTER_PRINCIPAL_ID: &str =
-    "czetz-e72b5-bvgij-ad7w7-b5gki-isgts-wemv2-unxsk-6x65l-7mvhw-qae";
+    "7gaq2-4kttl-vtbt4-oo47w-igteo-cpk2k-57h3p-yioqe-wkawi-wz45g-jae";
 
 pub fn get_global_super_admin_principal_id_v1(
     well_known_canisters: KnownPrincipalMap,


### PR DESCRIPTION
## Changes
- add platform orchestrator to well known principal ids in user_index
- add method in subnet_orchestrator to reclaim cycles from individual canisters
- add method in platform orchestrator to start reclaiming cycles from individual canisters