### PR TITLE
fix upgrade process for individual canister and update profile owner

### DIFF
--- a/src/canister/individual_user_template/src/api/canister_lifecycle/post_upgrade.rs
+++ b/src/canister/individual_user_template/src/api/canister_lifecycle/post_upgrade.rs
@@ -1,3 +1,4 @@
+use candid::Principal;
 use ciborium::de;
 use ic_cdk_macros::post_upgrade;
 use ic_stable_structures::Memory;
@@ -27,8 +28,20 @@ fn post_upgrade() {
     save_upgrade_args_to_memory();
     refetch_well_known_principals();
     reenqueue_timers_for_pending_bet_outcomes();
+    reset_profile_owner();
 }
 
+
+fn reset_profile_owner() {
+    CANISTER_DATA.with_borrow_mut(|canister_data| {
+        if let Some(profile_owner) = canister_data.profile.principal_id {
+            if profile_owner.eq(&Principal::anonymous()){
+                canister_data.profile.principal_id = None;
+            }
+        }
+    })
+}
+ 
 fn restore_data_from_stable_memory() {
     let heap_data = memory::get_upgrades_memory();
     let mut heap_data_len_bytes = [0; 4];

--- a/src/canister/individual_user_template/src/api/canister_management/update_profile_owner.rs
+++ b/src/canister/individual_user_template/src/api/canister_management/update_profile_owner.rs
@@ -6,10 +6,10 @@ use crate::CANISTER_DATA;
 
 
 #[update]
-pub async fn update_profile_owner(user_id: Option<Principal>) -> Result<(), String>{
+pub async fn update_profile_owner(user_id: Option<Principal>) -> Result<(), String> {
 
     if !is_controller(&api::caller()) {
-        return Err("UnAuthorised Access".into());
+        return Err("Unauthorised".into());
     }
 
     CANISTER_DATA.with_borrow_mut(|canister_data| {

--- a/src/canister/platform_orchestrator/can.did
+++ b/src/canister/platform_orchestrator/can.did
@@ -27,6 +27,7 @@ service : (PlatformOrchestratorInitArgs) -> {
   start_reclaiming_cycles_from_subnet_orchestrator_canister : () -> (text);
   stop_upgrades_for_individual_user_canisters : () -> (Result);
   subnet_orchestrator_maxed_out : () -> ();
+  update_profile_owner_for_individual_canisters : () -> ();
   upgrade_canister : (UpgradeCanisterArg) -> (Result);
   upgrade_specific_individual_canister : (principal) -> ();
   upload_wasms : (WasmType, vec nat8) -> (Result);

--- a/src/canister/platform_orchestrator/src/api/canister_management/mod.rs
+++ b/src/canister/platform_orchestrator/src/api/canister_management/mod.rs
@@ -12,6 +12,7 @@ mod get_all_available_subnet_orchestrators;
 mod get_all_subnet_orchestrators;
 mod stop_upgrades_for_individual_user_canisters;
 mod upgrade_specific_individual_canister;
+mod update_profile_owner_for_individual_users;
 
 #[query]
 pub fn get_version() -> String {

--- a/src/canister/platform_orchestrator/src/api/canister_management/update_profile_owner_for_individual_users.rs
+++ b/src/canister/platform_orchestrator/src/api/canister_management/update_profile_owner_for_individual_users.rs
@@ -1,0 +1,12 @@
+use ic_cdk_macros::update;
+
+use crate::CANISTER_DATA;
+
+#[update]
+fn update_profile_owner_for_individual_canisters() {
+    CANISTER_DATA.with_borrow(|canister_data| {
+        canister_data.all_subnet_orchestrator_canisters_list.iter().for_each(|subnet_canster_id| {
+            let _ = ic_cdk::notify(*subnet_canster_id, "update_profile_owner_for_individual_canisters", ());
+        })
+    })
+}

--- a/src/canister/user_index/can.did
+++ b/src/canister/user_index/can.did
@@ -120,6 +120,7 @@ service : (UserIndexInitArgs) -> {
       text,
       principal,
     ) -> (Result_3);
+  update_profile_owner_for_individual_canisters : () -> ();
   upgrade_specific_individual_user_canister_with_latest_wasm : (
       principal,
       opt principal,

--- a/src/canister/user_index/src/api/canister_management/mod.rs
+++ b/src/canister/user_index/src/api/canister_management/mod.rs
@@ -5,11 +5,11 @@ use shared_utils::{canister_specific::individual_user_template::types::arg::Indi
 
 use crate::{CANISTER_DATA, util::canister_management};
 
-use super::upgrade_individual_user_template::update_user_index_upgrade_user_canisters_with_latest_wasm;
 
 pub mod create_pool_of_available_canisters;
 pub mod get_subnet_available_capacity;
 pub mod get_subnet_backup_capacity;
+pub mod start_upgrades_for_individual_canisters;
 
 
 #[update]
@@ -29,26 +29,6 @@ pub async fn set_permission_to_upgrade_individual_canisters(flag: bool) -> Strin
        canister_data_ref.borrow_mut().allow_upgrades_for_individual_canisters = flag;
     });
     return "Success".to_string()
-}
-
-#[update]
-async fn start_upgrades_for_individual_canisters(version: String, individual_user_wasm: Vec<u8>) -> String {
-    
-    if !is_controller(&caller()) {
-        panic!("Unauthorized caller");
-    }
-
-    CANISTER_DATA.with_borrow_mut(|canister_data| {
-        canister_data.allow_upgrades_for_individual_canisters = true;
-        canister_data.last_run_upgrade_status.version = version.clone();
-        let canister_wasm = CanisterWasm {
-            version: version.clone(),
-            wasm_blob: individual_user_wasm.clone()
-        };
-        canister_data.wasms.insert(WasmType::IndividualUserWasm, canister_wasm);
-    });
-    ic_cdk::spawn(update_user_index_upgrade_user_canisters_with_latest_wasm::upgrade_user_canisters_with_latest_wasm(version, individual_user_wasm));
-    "Success".to_string()
 }
 
 #[query]

--- a/src/canister/user_index/src/api/canister_management/start_upgrades_for_individual_canisters.rs
+++ b/src/canister/user_index/src/api/canister_management/start_upgrades_for_individual_canisters.rs
@@ -1,0 +1,20 @@
+use ic_cdk_macros::update;
+
+use shared_utils::common::{types::wasm::{CanisterWasm, WasmType}, utils::permissions::is_caller_controller};
+use crate::{api::upgrade_individual_user_template::update_user_index_upgrade_user_canisters_with_latest_wasm, CANISTER_DATA};
+
+#[update(guard = "is_caller_controller")]
+async fn start_upgrades_for_individual_canisters(version: String, individual_user_wasm: Vec<u8>) -> String {
+
+    CANISTER_DATA.with_borrow_mut(|canister_data| {
+        canister_data.allow_upgrades_for_individual_canisters = true;
+        canister_data.last_run_upgrade_status.version = version.clone();
+        let canister_wasm = CanisterWasm {
+            version: version.clone(),
+            wasm_blob: individual_user_wasm.clone()
+        };
+        canister_data.wasms.insert(WasmType::IndividualUserWasm, canister_wasm);
+    });
+    ic_cdk::spawn(update_user_index_upgrade_user_canisters_with_latest_wasm::upgrade_user_canisters_with_latest_wasm(version, individual_user_wasm));
+    "Success".to_string()
+}

--- a/src/canister/user_index/src/api/upgrade_individual_user_template/update_user_index_upgrade_user_canisters_with_latest_wasm.rs
+++ b/src/canister/user_index/src/api/upgrade_individual_user_template/update_user_index_upgrade_user_canisters_with_latest_wasm.rs
@@ -96,29 +96,25 @@ pub async fn upgrade_user_canisters_with_latest_wasm(_version: String, individua
 async fn recharge_and_upgrade(user_canister_id: Principal, user_principal_id: Principal, version_number: u64, configuration: Configuration, version: String, individual_user_wasm: Vec<u8>) -> Result<(Principal, Principal), ((Principal, Principal), String)> {
     recharge_canister_if_below_threshold(&user_canister_id).await.map_err(|e| ((user_principal_id, user_canister_id), e))?;
     
-    upgrade_user_canister(&user_principal_id, &user_canister_id, version_number, &configuration, version, individual_user_wasm).await.map_err(|s| ((user_principal_id, user_canister_id), s))?;
+    upgrade_user_canister(user_canister_id, &configuration, version, individual_user_wasm).await.map_err(|s| ((user_principal_id, user_canister_id), s))?;
 
     Ok((user_principal_id, user_canister_id))
 }
 
 async fn upgrade_user_canister(
-    user_principal_id: &Principal,
-    canister_id: &Principal,
-    version_number: u64,
+    canister_id: Principal,
     configuration: &Configuration,
     version: String,
     individual_user_wasm: Vec<u8>
 ) -> Result<(), String> {
     canister_management::upgrade_individual_user_canister(
-        *canister_id,
+        canister_id,
         CanisterInstallMode::Upgrade,
         IndividualUserTemplateInitArgs {
             known_principal_ids: Some(configuration.known_principal_ids.clone()),
-            profile_owner: Some(*user_principal_id),
-            upgrade_version_number: Some(version_number + 1),
-            url_to_send_canister_metrics_to: Some(
-                configuration.url_to_send_canister_metrics_to.clone(),
-            ),
+            profile_owner: None,
+            upgrade_version_number: None,
+            url_to_send_canister_metrics_to: None,
             version,
         },
         individual_user_wasm

--- a/src/canister/user_index/src/api/user_record/mod.rs
+++ b/src/canister/user_index/src/api/user_record/mod.rs
@@ -5,3 +5,4 @@ pub mod get_user_canister_id_from_user_principal_id;
 pub mod get_user_canister_list;
 pub mod get_user_index_canister_count;
 pub mod update_index_with_unique_user_name_corresponding_to_user_principal_id;
+pub mod update_profile_owner_for_individual_canisters;

--- a/src/canister/user_index/src/api/user_record/update_profile_owner_for_individual_canisters.rs
+++ b/src/canister/user_index/src/api/user_record/update_profile_owner_for_individual_canisters.rs
@@ -1,0 +1,13 @@
+use ic_cdk_macros::update;
+use shared_utils::common::utils::permissions::is_caller_controller;
+
+use crate::CANISTER_DATA;
+
+#[update(guard = "is_caller_controller")]
+async fn update_profile_owner_for_individual_canisters() {
+    CANISTER_DATA.with_borrow(|canister_data| {
+        canister_data.user_principal_id_to_canister_id_map.iter().for_each(|(user_principal, user_canister_id)| {
+            let _ = ic_cdk::notify(*user_canister_id, "update_profile_owner", (Some(*user_principal),));
+        })
+    });
+}

--- a/src/lib/integration_tests/tests/profile/main.rs
+++ b/src/lib/integration_tests/tests/profile/main.rs
@@ -1,1 +1,2 @@
 pub mod when_setting_unique_username_then_new_username_persisted_in_personal_canister_and_updated_in_user_index;
+pub mod requesting_new_canister_for_a_user_sets_the_profile_owner;

--- a/src/lib/integration_tests/tests/profile/requesting_new_canister_for_a_user_sets_the_profile_owner.rs
+++ b/src/lib/integration_tests/tests/profile/requesting_new_canister_for_a_user_sets_the_profile_owner.rs
@@ -1,0 +1,58 @@
+use candid::Principal;
+use ic_test_state_machine_client::WasmResult;
+use shared_utils::{
+    canister_specific::individual_user_template::types::profile::UserProfileDetailsForFrontend,
+    common::types::known_principal::KnownPrincipalType,
+};
+use test_utils::setup::{
+    env::v1::{get_initialized_env_with_provisioned_known_canisters, get_new_state_machine},
+    test_constants::get_mock_user_alice_principal_id,
+};
+
+#[test]
+fn requesting_new_canister_for_a_user_sets_the_profile_owner(
+) {
+    let state_machine = get_new_state_machine();
+    let known_principal_map = get_initialized_env_with_provisioned_known_canisters(&state_machine);
+    let user_index_canister_id = known_principal_map
+        .get(&KnownPrincipalType::CanisterIdUserIndex)
+        .unwrap();
+    let alice_principal_id = get_mock_user_alice_principal_id();
+
+    let alice_canister_id = state_machine.update_call(
+        *user_index_canister_id,
+        alice_principal_id,
+        "get_requester_principals_canister_id_create_if_not_exists_and_optionally_allow_referrer",
+        candid::encode_one(()).unwrap(),
+    ).map(|reply_payload| {
+        let alice_canister_id: Principal = match reply_payload {
+            WasmResult::Reply(payload) => candid::decode_one(&payload).unwrap(),
+            _ => panic!("\n🛑 get_requester_principals_canister_id_create_if_not_exists_and_optionally_allow_referrer failed\n"),
+        };
+        alice_canister_id
+    }).unwrap();
+
+
+    let profile_details_from_user_canister = state_machine
+        .query_call(
+            alice_canister_id,
+            Principal::anonymous(),
+            "get_profile_details",
+            candid::encode_args(()).unwrap(),
+        )
+        .map(|reply_payload| {
+            let profile_details_from_user_canister: UserProfileDetailsForFrontend =
+                match reply_payload {
+                    WasmResult::Reply(payload) => candid::decode_one(&payload).unwrap(),
+                    _ => panic!("\n🛑 get_profile_details failed\n"),
+                };
+            profile_details_from_user_canister
+        })
+        .unwrap();
+
+    assert_eq!(
+        profile_details_from_user_canister.principal_id,
+        alice_principal_id
+    );
+
+}


### PR DESCRIPTION
## Changes
- Avoid sending profile owner while upgrading individual canisters
- added test to check the profile owner when requesting a new canister

## Impacts
- fixes #280
- fixes #281 