### PR TITLE
update guard from global admin to profile owner for last access time

### DIFF
--- a/src/canister/individual_user_template/src/api/canister_management/update_last_access_time.rs
+++ b/src/canister/individual_user_template/src/api/canister_management/update_last_access_time.rs
@@ -1,12 +1,18 @@
 
+use ic_cdk::caller;
 use ic_cdk_macros::update;
 use shared_utils::{canister_specific::individual_user_template::types::session::SessionType, common::utils::permissions::is_caller_global_admin};
 use shared_utils::common::utils::system_time::get_current_system_time_from_ic;
 
 use crate::CANISTER_DATA;
 
-#[update(guard="is_caller_global_admin")]
+#[update]
 fn update_last_access_time() -> Result<String, String> {
+
+    let profile_owner = CANISTER_DATA.with_borrow(|canister_data| canister_data.profile.principal_id.unwrap());
+    if profile_owner != caller() {
+        return Err("Unauthorized".into())
+    }
     
     CANISTER_DATA.with_borrow_mut(|canister_data| {
         let session_type = canister_data.session_type.ok_or(String::from("User is not yet registered"))?;

--- a/src/canister/individual_user_template/src/api/canister_management/update_last_access_time.rs
+++ b/src/canister/individual_user_template/src/api/canister_management/update_last_access_time.rs
@@ -1,7 +1,6 @@
 
 use ic_cdk::caller;
 use ic_cdk_macros::update;
-use shared_utils::{canister_specific::individual_user_template::types::session::SessionType, common::utils::permissions::is_caller_global_admin};
 use shared_utils::common::utils::system_time::get_current_system_time_from_ic;
 
 use crate::CANISTER_DATA;
@@ -15,15 +14,8 @@ fn update_last_access_time() -> Result<String, String> {
     }
     
     CANISTER_DATA.with_borrow_mut(|canister_data| {
-        let session_type = canister_data.session_type.ok_or(String::from("User is not yet registered"))?;
-        match session_type {
-            SessionType::RegisteredSession => {
-                canister_data.last_access_time = Some(get_current_system_time_from_ic());
-                Ok("Success".into())
-            },
-            SessionType::AnonymousSession => {
-                Err(String::from("User is not yet registered"))
-            }
-        }
+        canister_data.session_type.ok_or(String::from("Canister not yet assigned"))?;
+        canister_data.last_access_time = Some(get_current_system_time_from_ic());
+        Ok("Success".into())
     })
 }

--- a/src/lib/integration_tests/tests/profile/main.rs
+++ b/src/lib/integration_tests/tests/profile/main.rs
@@ -2,3 +2,4 @@ pub mod when_setting_unique_username_then_new_username_persisted_in_personal_can
 pub mod when_a_new_user_signup_canister_is_marked_as_anonymous_login;
 pub mod requesting_new_canister_for_a_user_sets_the_profile_owner;
 pub mod update_session_type_tests;
+pub mod update_last_access_time_test;

--- a/src/lib/integration_tests/tests/profile/update_last_access_time_test.rs
+++ b/src/lib/integration_tests/tests/profile/update_last_access_time_test.rs
@@ -1,0 +1,74 @@
+use candid::Principal;
+use ic_test_state_machine_client::WasmResult;
+use shared_utils::{
+    canister_specific::individual_user_template::types::{profile::UserProfileDetailsForFrontend, session::SessionType},
+    common::types::known_principal::KnownPrincipalType, constant::GLOBAL_SUPER_ADMIN_USER_ID,
+};
+use test_utils::setup::{
+    env::v1::{get_initialized_env_with_provisioned_known_canisters, get_new_state_machine},
+    test_constants::get_mock_user_alice_principal_id,
+};
+
+#[test]
+fn update_last_access_time_test(
+) {
+    let state_machine = get_new_state_machine();
+    let known_principal_map = get_initialized_env_with_provisioned_known_canisters(&state_machine);
+    let user_index_canister_id = known_principal_map
+        .get(&KnownPrincipalType::CanisterIdUserIndex)
+        .unwrap();
+    let alice_principal_id = get_mock_user_alice_principal_id();
+
+    let alice_canister_id = state_machine.update_call(
+        *user_index_canister_id,
+        alice_principal_id,
+        "get_requester_principals_canister_id_create_if_not_exists_and_optionally_allow_referrer",
+        candid::encode_one(()).unwrap(),
+    ).map(|reply_payload| {
+        let alice_canister_id: Principal = match reply_payload {
+            WasmResult::Reply(payload) => candid::decode_one(&payload).unwrap(),
+            _ => panic!("\n🛑 get_requester_principals_canister_id_create_if_not_exists_and_optionally_allow_referrer failed\n"),
+        };
+        alice_canister_id
+    }).unwrap();
+
+
+    let update_last_access_time_result = state_machine.update_call(
+        alice_canister_id, 
+        Principal::anonymous(), 
+        "update_last_access_time", 
+        candid::encode_one(SessionType::RegisteredSession).unwrap()
+    )
+    .map(|reply_payload| {
+        let update_last_access_time_res: Result<String, String> = match reply_payload {
+            WasmResult::Reply(payload) => candid::decode_one(&payload).unwrap(),
+            _ => panic!("\n🛑 update_last_access_time failed\n"),
+        };
+        update_last_access_time_res 
+    })
+    .unwrap(); 
+
+    assert!(update_last_access_time_result.is_err());
+
+   
+    let update_last_access_time_result = state_machine.update_call(
+        alice_canister_id,
+        alice_principal_id, 
+        "update_last_access_time", 
+        candid::encode_one(SessionType::RegisteredSession).unwrap()
+    )
+    .map(|reply_payload| {
+        let update_last_access_time_res: Result<String, String> = match reply_payload {
+            WasmResult::Reply(payload) => candid::decode_one(&payload).unwrap(),
+            _ => panic!("\n🛑 update_last_access_time failed\n"),
+        };
+        update_last_access_time_res 
+    })
+    .unwrap(); 
+
+    update_last_access_time_result.unwrap();
+
+
+
+   
+}


### PR DESCRIPTION
## Changes
- modify guard for endpoint `update_last_access_time` from global admin to profile owner.