### PR TITLE
set known principal map in post upgrade in post cache

### DIFF
--- a/src/canister/post_cache/src/api/canister_lifecycle/post_upgrade.rs
+++ b/src/canister/post_cache/src/api/canister_lifecycle/post_upgrade.rs
@@ -57,6 +57,10 @@ fn save_upgrade_args_to_memory() {
             canister_data_ref_cell.version_details.version_number = upgrade_version_number;
         }
 
+        if let Some(known_principal_map) = upgrade_args.known_principal_ids {
+            canister_data_ref_cell.known_principal_ids = known_principal_map;
+        }
+
         canister_data_ref_cell.version_details.version = upgrade_args.version;
     });
 }


### PR DESCRIPTION
## Changes
- set known principal ids if found in post upgrade hook.
- This will be required to flush the data in post cache without removing reference to known principal ids.