### PR TITLE
feat: Add API to return cycle to platform_orchestrator

### DIFF
--- a/src/canister/configuration/can.did
+++ b/src/canister/configuration/can.did
@@ -26,6 +26,7 @@ service : (ConfigurationInitArgs) -> {
   get_well_known_principal_value : (KnownPrincipalType) -> (
       opt principal,
     ) query;
+  return_cycles_to_platform_orchestrator_canister : () -> ();
   toggle_signups_enabled : () -> (Result);
   update_list_of_well_known_principals : (KnownPrincipalType, principal) -> (
       Result,

--- a/src/canister/configuration/src/api/cycle_management/mod.rs
+++ b/src/canister/configuration/src/api/cycle_management/mod.rs
@@ -1,0 +1,1 @@
+pub mod return_cycle_to_platform_orchestrator;

--- a/src/canister/configuration/src/api/cycle_management/return_cycle_to_platform_orchestrator.rs
+++ b/src/canister/configuration/src/api/cycle_management/return_cycle_to_platform_orchestrator.rs
@@ -1,0 +1,31 @@
+use ic_cdk::api::{
+    canister_balance128,
+    management_canister::{main, provisional::CanisterIdRecord},
+};
+use shared_utils::common::types::known_principal::KnownPrincipalType;
+
+use crate::CANISTER_DATA;
+
+#[ic_cdk::update]
+async fn return_cycles_to_platform_orchestrator_canister() {
+    let platform_orchestrator_canister_id = CANISTER_DATA.with(|canister_data_ref_cell| {
+        canister_data_ref_cell
+            .borrow()
+            .known_principal_ids
+            .get(&KnownPrincipalType::CanisterIdPlatformOrchestrator)
+            .cloned()
+            .unwrap()
+    });
+
+    if canister_balance128() > 200_000_000_000 {
+        let cycle_amount_to_transfer = canister_balance128() - 200_000_000_000;
+        main::deposit_cycles(
+            CanisterIdRecord {
+                canister_id: platform_orchestrator_canister_id,
+            },
+            cycle_amount_to_transfer,
+        )
+        .await
+        .unwrap();
+    }
+}

--- a/src/canister/configuration/src/api/cycle_management/return_cycle_to_platform_orchestrator.rs
+++ b/src/canister/configuration/src/api/cycle_management/return_cycle_to_platform_orchestrator.rs
@@ -1,21 +1,13 @@
+use candid::Principal;
 use ic_cdk::api::{
     canister_balance128,
     management_canister::{main, provisional::CanisterIdRecord},
 };
-use shared_utils::common::types::known_principal::KnownPrincipalType;
-
-use crate::CANISTER_DATA;
+use std::str::FromStr;
 
 #[ic_cdk::update]
 async fn return_cycles_to_platform_orchestrator_canister() {
-    let platform_orchestrator_canister_id = CANISTER_DATA.with(|canister_data_ref_cell| {
-        canister_data_ref_cell
-            .borrow()
-            .known_principal_ids
-            .get(&KnownPrincipalType::CanisterIdPlatformOrchestrator)
-            .cloned()
-            .unwrap()
-    });
+    let platform_orchestrator_canister_id = Principal::from_str("74zq4-iqaaa-aaaam-ab53a-cai").unwrap();
 
     if canister_balance128() > 200_000_000_000 {
         let cycle_amount_to_transfer = canister_balance128() - 200_000_000_000;

--- a/src/canister/configuration/src/api/mod.rs
+++ b/src/canister/configuration/src/api/mod.rs
@@ -1,3 +1,4 @@
 pub mod canister_lifecycle;
 pub mod user_signup;
 pub mod well_known_principal;
+pub mod cycle_management;

--- a/src/canister/data_backup/can.did
+++ b/src/canister/data_backup/can.did
@@ -219,6 +219,7 @@ service : (DataBackupInitArgs) -> {
       principal,
     ) -> ();
   restore_backed_up_data_to_individual_users_canister : (principal) -> (text);
+  return_cycles_to_platform_orchestrator_canister : () -> ();
   send_restore_data_back_to_user_index_canister : () -> ();
   update_user_add_role : (UserAccessRole, principal) -> ();
   update_user_remove_role : (UserAccessRole, principal) -> ();

--- a/src/canister/data_backup/src/api/cycle_management/mod.rs
+++ b/src/canister/data_backup/src/api/cycle_management/mod.rs
@@ -1,0 +1,1 @@
+pub mod return_cycle_to_platform_orchestrator;

--- a/src/canister/data_backup/src/api/cycle_management/return_cycle_to_platform_orchestrator.rs
+++ b/src/canister/data_backup/src/api/cycle_management/return_cycle_to_platform_orchestrator.rs
@@ -1,22 +1,13 @@
+use candid::Principal;
 use ic_cdk::api::{
     canister_balance128,
     management_canister::{main, provisional::CanisterIdRecord},
 };
-use shared_utils::common::types::known_principal::KnownPrincipalType;
-
-use crate::CANISTER_DATA;
+use std::str::FromStr;
 
 #[ic_cdk::update]
 async fn return_cycles_to_platform_orchestrator_canister() {
-    let platform_orchestrator_canister_id = CANISTER_DATA.with(|canister_data_ref_cell| {
-        canister_data_ref_cell
-            .borrow()
-            .heap_data
-            .known_principal_ids
-            .get(&KnownPrincipalType::CanisterIdPlatformOrchestrator)
-            .cloned()
-            .unwrap()
-    });
+    let platform_orchestrator_canister_id = Principal::from_str("74zq4-iqaaa-aaaam-ab53a-cai").unwrap();
 
     if canister_balance128() > 200_000_000_000 {
         let cycle_amount_to_transfer = canister_balance128() - 200_000_000_000;

--- a/src/canister/data_backup/src/api/cycle_management/return_cycle_to_platform_orchestrator.rs
+++ b/src/canister/data_backup/src/api/cycle_management/return_cycle_to_platform_orchestrator.rs
@@ -1,0 +1,32 @@
+use ic_cdk::api::{
+    canister_balance128,
+    management_canister::{main, provisional::CanisterIdRecord},
+};
+use shared_utils::common::types::known_principal::KnownPrincipalType;
+
+use crate::CANISTER_DATA;
+
+#[ic_cdk::update]
+async fn return_cycles_to_platform_orchestrator_canister() {
+    let platform_orchestrator_canister_id = CANISTER_DATA.with(|canister_data_ref_cell| {
+        canister_data_ref_cell
+            .borrow()
+            .heap_data
+            .known_principal_ids
+            .get(&KnownPrincipalType::CanisterIdPlatformOrchestrator)
+            .cloned()
+            .unwrap()
+    });
+
+    if canister_balance128() > 200_000_000_000 {
+        let cycle_amount_to_transfer = canister_balance128() - 200_000_000_000;
+        main::deposit_cycles(
+            CanisterIdRecord {
+                canister_id: platform_orchestrator_canister_id,
+            },
+            cycle_amount_to_transfer,
+        )
+        .await
+        .unwrap();
+    }
+}

--- a/src/canister/data_backup/src/api/mod.rs
+++ b/src/canister/data_backup/src/api/mod.rs
@@ -4,3 +4,4 @@ pub mod canister_lifecycle;
 pub mod individual_user_backup;
 pub mod user_index_backup;
 pub mod well_known_principal;
+pub mod cycle_management;


### PR DESCRIPTION
Closes: #364 

- Added API in configuratiion and data_backup canister which returns remaining cycles to platform canister leaving 200_000_000_000 cycles