### PR TITLE
fix: data_backup canister removal - local updates

### DIFF
--- a/ic_repl_tests/individual_user_template/post/bulk_posts.test.sh
+++ b/ic_repl_tests/individual_user_template/post/bulk_posts.test.sh
@@ -1,4 +1,5 @@
-import user_index_canister = "br5f7-7uaaa-aaaaa-qaaca-cai";
+import user_index_canister = "be2us-64aaa-aaaaa-qaabq-cai";
+
 identity default;
 
 let my_canister = call user_index_canister.get_requester_principals_canister_id_create_if_not_exists_and_optionally_allow_referrer(null);

--- a/ic_repl_tests/individual_user_template/post/post.test.sh
+++ b/ic_repl_tests/individual_user_template/post/post.test.sh
@@ -1,4 +1,5 @@
-import user_index_canister = "br5f7-7uaaa-aaaaa-qaaca-cai";
+import user_index_canister = "be2us-64aaa-aaaaa-qaabq-cai";
+
 identity default;
 
 let my_canister = call user_index_canister.get_requester_principals_canister_id_create_if_not_exists_and_optionally_allow_referrer(null);

--- a/ic_repl_tests/individual_user_template/post/post_toggle_like_check_liked_by_me.test.sh
+++ b/ic_repl_tests/individual_user_template/post/post_toggle_like_check_liked_by_me.test.sh
@@ -1,4 +1,4 @@
-import user_index_canister = "br5f7-7uaaa-aaaaa-qaaca-cai";
+import user_index_canister = "be2us-64aaa-aaaaa-qaabq-cai";
 
 identity default;
 

--- a/ic_repl_tests/individual_user_template/profile/alice_follows_bob.test.sh
+++ b/ic_repl_tests/individual_user_template/profile/alice_follows_bob.test.sh
@@ -1,6 +1,7 @@
 
 
-import user_index_canister = "br5f7-7uaaa-aaaaa-qaaca-cai";
+import user_index_canister = "be2us-64aaa-aaaaa-qaabq-cai";
+
 
 identity bob;
 

--- a/ic_repl_tests/post_cache/newly_created_post.test.sh
+++ b/ic_repl_tests/post_cache/newly_created_post.test.sh
@@ -1,6 +1,7 @@
 
 
-import user_index_canister = "br5f7-7uaaa-aaaaa-qaaca-cai";
+import user_index_canister = "be2us-64aaa-aaaaa-qaabq-cai";
+
 identity default;
 
 let my_canister = call user_index_canister.get_requester_principals_canister_id_create_if_not_exists_and_optionally_allow_referrer(null);

--- a/ic_repl_tests/post_cache/post_with_likes_and_shares.test.sh
+++ b/ic_repl_tests/post_cache/post_with_likes_and_shares.test.sh
@@ -1,6 +1,7 @@
 
 
-import user_index_canister = "br5f7-7uaaa-aaaaa-qaaca-cai";
+import user_index_canister = "be2us-64aaa-aaaaa-qaabq-cai";
+
 identity default;
 let my_canister = call user_index_canister.get_requester_principals_canister_id_create_if_not_exists_and_optionally_allow_referrer(null);
 

--- a/ic_repl_tests/user_index/create_new_users.test.sh
+++ b/ic_repl_tests/user_index/create_new_users.test.sh
@@ -1,6 +1,7 @@
 
 
-import user_index_canister = "br5f7-7uaaa-aaaaa-qaaca-cai";
+import user_index_canister = "be2us-64aaa-aaaaa-qaabq-cai";
+
 
 identity alice;
 

--- a/scripts/canisters/local_deploy/upgrade_all_canisters.sh
+++ b/scripts/canisters/local_deploy/upgrade_all_canisters.sh
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+scripts/candid_generator.sh
+
 usage() {
   printf "Usage: \n[-s Skip test] \n[-h Display help] \n";
   exit 0;


### PR DESCRIPTION
- update the ic_repl tests to work locally.
- include the candid_generator script on top of upgrade_all_canisters script so that it is run every time.