### PR TITLE
Hung timers

### DIFF
--- a/src/canister/individual_user_template/can.did
+++ b/src/canister/individual_user_template/can.did
@@ -245,18 +245,19 @@ type Result_12 = variant {
 };
 type Result_13 = variant { Ok : vec WatchHistoryItem; Err : text };
 type Result_14 = variant { Ok : vec text; Err : NamespaceErrors };
-type Result_15 = variant { Ok; Err : MigrationErrors };
-type Result_16 = variant { Ok : text; Err : text };
-type Result_17 = variant {
+type Result_15 = variant { Ok : vec record { nat64; nat8 }; Err : text };
+type Result_16 = variant { Ok; Err : MigrationErrors };
+type Result_17 = variant { Ok : text; Err : text };
+type Result_18 = variant {
   Ok : UserProfileDetailsForFrontend;
   Err : UpdateProfileDetailsError;
 };
-type Result_18 = variant { Ok; Err : text };
-type Result_19 = variant { Ok; Err : UpdateProfileSetUniqueUsernameError };
+type Result_19 = variant { Ok; Err : text };
 type Result_2 = variant {
   Ok : BettingStatus;
   Err : BetOnCurrentlyViewingPostError;
 };
+type Result_20 = variant { Ok; Err : UpdateProfileSetUniqueUsernameError };
 type Result_3 = variant { Ok : NamespaceForFrontend; Err : NamespaceErrors };
 type Result_4 = variant { Ok : opt text; Err : NamespaceErrors };
 type Result_5 = variant { Ok; Err : NamespaceErrors };
@@ -424,15 +425,16 @@ service : (IndividualUserTemplateInitArgs) -> {
   list_namespace_keys : (nat64) -> (Result_14) query;
   list_namespaces : (nat64, nat64) -> (vec NamespaceForFrontend) query;
   load_snapshot : (nat64) -> ();
+  once_reenqueue_timers_for_pending_bet_outcomes : () -> (Result_15);
   read_key_value_pair : (nat64, text) -> (Result_4) query;
   receive_and_save_snaphot : (nat64, blob) -> ();
   receive_bet_from_bet_makers_canister : (PlaceBetArg, principal) -> (Result_2);
   receive_bet_winnings_when_distributed : (nat64, BetOutcomeForBetMaker) -> ();
-  receive_data_from_hotornot : (principal, nat64, vec Post) -> (Result_15);
+  receive_data_from_hotornot : (principal, nat64, vec Post) -> (Result_16);
   return_cycles_to_user_index_canister : (opt nat) -> ();
   save_snapshot_json : () -> (nat32);
-  transfer_tokens_and_posts : (principal, principal) -> (Result_15);
-  update_last_access_time : () -> (Result_16);
+  transfer_tokens_and_posts : (principal, principal) -> (Result_16);
+  update_last_access_time : () -> (Result_17);
   update_last_canister_functionality_access_time : () -> ();
   update_post_add_view_details : (nat64, PostViewDetailsFromFrontend) -> ();
   update_post_as_ready_to_view : (nat64) -> ();
@@ -440,20 +442,20 @@ service : (IndividualUserTemplateInitArgs) -> {
   update_post_status : (nat64, PostStatus) -> ();
   update_post_toggle_like_status_by_caller : (nat64) -> (bool);
   update_profile_display_details : (UserProfileUpdateDetailsFromFrontend) -> (
-      Result_17,
+      Result_18,
     );
-  update_profile_owner : (opt principal) -> (Result_18);
-  update_profile_set_unique_username_once : (text) -> (Result_19);
+  update_profile_owner : (opt principal) -> (Result_19);
+  update_profile_set_unique_username_once : (text) -> (Result_20);
   update_profiles_i_follow_toggle_list_with_specified_profile : (
       FolloweeArg,
     ) -> (Result_6);
   update_profiles_that_follow_me_toggle_list_with_specified_profile : (
       FollowerArg,
     ) -> (Result_6);
-  update_referrer_details : (UserCanisterDetails) -> (Result_16);
-  update_session_type : (SessionType) -> (Result_16);
-  update_success_history : (SuccessHistoryItemV1) -> (Result_16);
-  update_watch_history : (WatchHistoryItem) -> (Result_16);
+  update_referrer_details : (UserCanisterDetails) -> (Result_17);
+  update_session_type : (SessionType) -> (Result_17);
+  update_success_history : (SuccessHistoryItemV1) -> (Result_17);
+  update_watch_history : (WatchHistoryItem) -> (Result_17);
   update_well_known_principal : (KnownPrincipalType, principal) -> ();
   write_key_value_pair : (nat64, text, text) -> (Result_4);
   write_multiple_key_value_pairs : (nat64, vec record { text; text }) -> (

--- a/src/canister/individual_user_template/src/api/canister_lifecycle/post_upgrade.rs
+++ b/src/canister/individual_user_template/src/api/canister_lifecycle/post_upgrade.rs
@@ -8,7 +8,7 @@ use crate::data_model::memory;
 use shared_utils::canister_specific::individual_user_template::types::arg::IndividualUserTemplateInitArgs;
 
 use crate::{
-    api::hot_or_not_bet::reenqueue_timers_for_pending_bet_outcomes::reenqueue_timers_for_pending_bet_outcomes,
+    api::hot_or_not_bet::reenqueue_timers_for_pending_bet_outcomes::{reenqueue_timers_for_pending_bet_outcomes,once_reenqueue_timers_for_pending_bet_outcomes},
     CANISTER_DATA,
 };
 
@@ -18,6 +18,7 @@ fn post_upgrade() {
     save_upgrade_args_to_memory();
     migrate_excessive_tokens();
     reenqueue_timers_for_pending_bet_outcomes();
+    once_reenqueue_timers_for_pending_bet_outcomes(); 
 }
 
 fn restore_data_from_stable_memory() {

--- a/src/canister/individual_user_template/src/api/canister_lifecycle/post_upgrade.rs
+++ b/src/canister/individual_user_template/src/api/canister_lifecycle/post_upgrade.rs
@@ -8,7 +8,7 @@ use crate::data_model::memory;
 use shared_utils::canister_specific::individual_user_template::types::arg::IndividualUserTemplateInitArgs;
 
 use crate::{
-    api::hot_or_not_bet::reenqueue_timers_for_pending_bet_outcomes::{reenqueue_timers_for_pending_bet_outcomes,once_reenqueue_timers_for_pending_bet_outcomes},
+    api::hot_or_not_bet::reenqueue_timers_for_pending_bet_outcomes::reenqueue_timers_for_pending_bet_outcomes,
     CANISTER_DATA,
 };
 
@@ -18,7 +18,6 @@ fn post_upgrade() {
     save_upgrade_args_to_memory();
     migrate_excessive_tokens();
     reenqueue_timers_for_pending_bet_outcomes();
-    once_reenqueue_timers_for_pending_bet_outcomes(); 
 }
 
 fn restore_data_from_stable_memory() {

--- a/src/canister/individual_user_template/src/api/hot_or_not_bet/reenqueue_timers_for_pending_bet_outcomes.rs
+++ b/src/canister/individual_user_template/src/api/hot_or_not_bet/reenqueue_timers_for_pending_bet_outcomes.rs
@@ -3,6 +3,7 @@ use std::time::{Duration, SystemTime};
 use ic_cdk_macros::update;
 // use rand::Rng;
 use shared_utils::{
+    utils::permissions::is_caller_controller,
     canister_specific::individual_user_template::types::hot_or_not::{
         GlobalRoomId, RoomBetPossibleOutcomes, SlotId, DURATION_OF_EACH_SLOT_IN_SECONDS,
     },
@@ -25,7 +26,7 @@ pub fn reenqueue_timers_for_pending_bet_outcomes() {
     });
 }
 
-#[update(guard = "is_caller_global_admin_or_controller")]
+#[update(guard = "is_caller_controller")]
 async fn once_reenqueue_timers_for_pending_bet_outcomes() -> Result<Vec<(u64, u8)>, String> {
     let current_time = system_time::get_current_system_time_from_ic();
 

--- a/src/canister/individual_user_template/src/api/hot_or_not_bet/reenqueue_timers_for_pending_bet_outcomes.rs
+++ b/src/canister/individual_user_template/src/api/hot_or_not_bet/reenqueue_timers_for_pending_bet_outcomes.rs
@@ -26,13 +26,15 @@ pub fn reenqueue_timers_for_pending_bet_outcomes() {
 }
 
 #[update]
+// #[update(guard = "is_caller_global_admin_or_controller")]
 async fn once_reenqueue_timers_for_pending_bet_outcomes() -> Result<Vec<(u64, u8)>, String> {
     let current_time = system_time::get_current_system_time_from_ic();
 
     let post_w_slot = CANISTER_DATA.with(|canister_data_ref_cell| {
         let canister_data = canister_data_ref_cell.borrow_mut();
 
-        let posts_with_slots = once_get_posts_that_have_pending_outcomes(&canister_data, &current_time);
+        let posts_with_slots =
+            once_get_posts_that_have_pending_outcomes(&canister_data, &current_time);
 
         // once_reenqueue_timers_for_these_posts(&mut canister_data, posts_with_slots, &current_time);
         once_reenqueue_timers_for_these_posts(posts_with_slots.clone());
@@ -169,7 +171,7 @@ mod test {
 
     use shared_utils::{
         canister_specific::individual_user_template::types::{
-            hot_or_not::HotOrNotDetails,
+            hot_or_not::{HotOrNotDetails, RoomDetailsV1},
             post::{FeedScore, Post, PostViewStatistics},
         },
         common::types::top_posts::post_score_index_item::PostStatus,
@@ -315,5 +317,76 @@ mod test {
         assert_eq!(posts_that_have_pending_outcomes[0], 2);
         assert_eq!(posts_that_have_pending_outcomes[1], 1);
         assert_eq!(posts_that_have_pending_outcomes[2], 0);
+    }
+
+    #[test]
+    fn test_once_get_posts_that_have_pending_outcomes() {
+        let mut canister_data = CanisterData::default();
+
+        let current_time = SystemTime::now();
+        let old_time = current_time - Duration::from_secs(49 * 60 * 60);
+
+        // Create posts
+        for i in 0..5 {
+            let post = Post {
+                id: i,
+                created_at: if i % 2 != 0 {
+                    old_time.checked_sub(Duration::from_secs(i * 60)).unwrap()
+                } else {
+                    current_time
+                        .checked_sub(Duration::from_secs(3 * 60 * 60))
+                        .unwrap()
+                },
+                // only those posts which have hot_or_not_details !=None and create_at > 48 hrs should filter through
+                hot_or_not_details: if i % 2 != 0 {
+                    Some(HotOrNotDetails::default())
+                } else {
+                    None
+                },
+                is_nsfw: false,
+                description: "Singing and dancing".to_string(),
+                hashtags: vec!["sing".to_string(), "dance".to_string()],
+                video_uid: "video#0001".to_string(),
+                status: PostStatus::ReadyToView,
+                likes: HashSet::new(),
+                share_count: 0,
+                view_stats: PostViewStatistics::default(),
+                home_feed_score: FeedScore::default(),
+                creator_consent_for_inclusion_in_hot_or_not: true,
+            };
+            canister_data.all_created_posts.insert(i, post);
+        }
+
+        // Populate room_details_map
+        let room_details_map = &mut canister_data.room_details_map;
+        for post_id in 0..5 {
+            for slot in 1..=48 {
+                // just to ensure that some slot ids are empty.
+                // i.e. in some slots, there wasn't a single bet placed
+                if slot % 3 == 0 {
+                    continue;
+                }
+
+                for room in 1..=3 {
+                    let global_room_id = GlobalRoomId(post_id, slot, room);
+                    let outcome = if room == 2 {
+                        RoomBetPossibleOutcomes::BetOngoing
+                    } else {
+                        RoomBetPossibleOutcomes::HotWon
+                    };
+                    room_details_map.insert(
+                        global_room_id,
+                        RoomDetailsV1 {
+                            bet_outcome: outcome,
+                            ..Default::default()
+                        },
+                    );
+                }
+            }
+        }
+
+        let result = once_get_posts_that_have_pending_outcomes(&canister_data, &current_time);
+
+        assert!(result.iter().all(|(post_id, _)| post_id % 2 != 0));
     }
 }

--- a/src/canister/individual_user_template/src/api/hot_or_not_bet/reenqueue_timers_for_pending_bet_outcomes.rs
+++ b/src/canister/individual_user_template/src/api/hot_or_not_bet/reenqueue_timers_for_pending_bet_outcomes.rs
@@ -25,8 +25,7 @@ pub fn reenqueue_timers_for_pending_bet_outcomes() {
     });
 }
 
-#[update]
-// #[update(guard = "is_caller_global_admin_or_controller")]
+#[update(guard = "is_caller_global_admin_or_controller")]
 async fn once_reenqueue_timers_for_pending_bet_outcomes() -> Result<Vec<(u64, u8)>, String> {
     let current_time = system_time::get_current_system_time_from_ic();
 

--- a/src/canister/individual_user_template/src/api/hot_or_not_bet/reenqueue_timers_for_pending_bet_outcomes.rs
+++ b/src/canister/individual_user_template/src/api/hot_or_not_bet/reenqueue_timers_for_pending_bet_outcomes.rs
@@ -3,7 +3,7 @@ use std::time::{Duration, SystemTime};
 use ic_cdk_macros::update;
 // use rand::Rng;
 use shared_utils::{
-    common::utils::permissions::is_caller_controller,
+    common::utils::permissions::is_caller_controller_or_global_admin,
     canister_specific::individual_user_template::types::hot_or_not::{
         GlobalRoomId, RoomBetPossibleOutcomes, SlotId, DURATION_OF_EACH_SLOT_IN_SECONDS,
     },
@@ -26,7 +26,7 @@ pub fn reenqueue_timers_for_pending_bet_outcomes() {
     });
 }
 
-#[update(guard = "is_caller_controller")]
+#[update(guard = "is_caller_controller_or_global_admin")]
 async fn once_reenqueue_timers_for_pending_bet_outcomes() -> Result<Vec<(u64, u8)>, String> {
     let current_time = system_time::get_current_system_time_from_ic();
 

--- a/src/canister/individual_user_template/src/api/hot_or_not_bet/reenqueue_timers_for_pending_bet_outcomes.rs
+++ b/src/canister/individual_user_template/src/api/hot_or_not_bet/reenqueue_timers_for_pending_bet_outcomes.rs
@@ -3,7 +3,7 @@ use std::time::{Duration, SystemTime};
 use ic_cdk_macros::update;
 // use rand::Rng;
 use shared_utils::{
-    utils::permissions::is_caller_controller,
+    common::utils::permissions::is_caller_controller,
     canister_specific::individual_user_template::types::hot_or_not::{
         GlobalRoomId, RoomBetPossibleOutcomes, SlotId, DURATION_OF_EACH_SLOT_IN_SECONDS,
     },

--- a/src/canister/individual_user_template/src/api/post/add_post_v2.rs
+++ b/src/canister/individual_user_template/src/api/post/add_post_v2.rs
@@ -46,7 +46,7 @@ fn add_post_v2(post_details: PostDetailsFromFrontend) -> Result<u64, String> {
 
     update_scores_and_share_with_post_cache_if_difference_beyond_threshold(&post_id);
 
-    if post_details.creator_consent_for_inclusion_in_hot_or_not {
+    // if post_details.creator_consent_for_inclusion_in_hot_or_not {
         // * schedule hot_or_not outcome tabulation for the 48 hours after the post is created
         (1..=48).for_each(|slot_number: u8| {
             ic_cdk_timers::set_timer(
@@ -61,8 +61,8 @@ fn add_post_v2(post_details: PostDetailsFromFrontend) -> Result<u64, String> {
                     });
                 },
             );
-        })
-    }
+        });
+    // }
 
     Ok(post_id)
 }

--- a/src/canister/platform_orchestrator/can.did
+++ b/src/canister/platform_orchestrator/can.did
@@ -83,6 +83,7 @@ service : (PlatformOrchestratorInitArgs) -> {
   update_canisters_last_functionality_access_time : () -> (Result);
   update_global_known_principal : (KnownPrincipalType, principal) -> (Result);
   update_profile_owner_for_individual_canisters : () -> ();
+  update_restart_timers_hon_game : () -> (Result);
   update_subnet_known_principal : (
       principal,
       KnownPrincipalType,

--- a/src/canister/platform_orchestrator/src/api/canister_management/mod.rs
+++ b/src/canister/platform_orchestrator/src/api/canister_management/mod.rs
@@ -19,6 +19,7 @@ mod update_profile_owner_for_individual_users;
 pub mod upgrade_canisters_in_network;
 mod upgrade_specific_individual_canister;
 pub mod upload_wasms;
+pub mod update_timers_for_hon_game;
 
 #[query]
 pub fn get_version() -> String {

--- a/src/canister/platform_orchestrator/src/api/canister_management/update_timers_for_hon_game.rs
+++ b/src/canister/platform_orchestrator/src/api/canister_management/update_timers_for_hon_game.rs
@@ -1,0 +1,27 @@
+use ic_cdk::{api::call::CallResult, call};
+use ic_cdk_macros::update;
+
+use crate::{guard::is_caller::is_caller_global_admin_or_controller, CANISTER_DATA};
+
+#[update(guard = "is_caller_global_admin_or_controller")]
+async fn update_restart_timers_hon_game() -> Result<String, String> {
+    let subnet_orchestrator_list = CANISTER_DATA
+        .with_borrow(|canister_data| canister_data.all_subnet_orchestrator_canisters_list.clone());
+
+    for subnet_orchestrator in subnet_orchestrator_list {
+        let result: CallResult<()> = call(
+            subnet_orchestrator,
+            "update_restart_timers_hon_game",
+            (),
+        )
+        .await;
+        result.map_err(|e| {
+            format!(
+                "failed to call update_restart_timers_hon_game for {} {}",
+                subnet_orchestrator, e.1
+            )
+        })?;
+    }
+
+    Ok("Success".into())
+}

--- a/src/canister/user_index/can.did
+++ b/src/canister/user_index/can.did
@@ -151,6 +151,7 @@ service : (UserIndexInitArgs) -> {
       principal,
     ) -> (Result_3);
   update_profile_owner_for_individual_canisters : () -> ();
+  update_restart_timers_hon_game : () -> (text);
   update_well_known_principal : (KnownPrincipalType, principal) -> ();
   upgrade_specific_individual_user_canister_with_latest_wasm : (
       principal,

--- a/src/canister/user_index/src/api/canister_management/mod.rs
+++ b/src/canister/user_index/src/api/canister_management/mod.rs
@@ -44,6 +44,7 @@ pub mod recycle_canisters;
 pub mod request_cycles;
 pub mod start_upgrades_for_individual_canisters;
 pub mod update_canisters_access_time;
+pub mod update_user_canister_restart_timers;
 
 #[update]
 pub async fn get_user_canister_status(

--- a/src/canister/user_index/src/api/canister_management/update_user_canister_restart_timers.rs
+++ b/src/canister/user_index/src/api/canister_management/update_user_canister_restart_timers.rs
@@ -1,0 +1,36 @@
+
+use futures::StreamExt;
+use ic_cdk::api::call::CallResult;
+use ic_cdk_macros::update;
+
+use crate::CANISTER_DATA;
+use shared_utils::common::utils::permissions::is_caller_controller;
+
+#[update(guard = "is_caller_controller")]
+async fn update_restart_timers_hon_game() -> String {
+    ic_cdk::spawn(update_restart_timers_hon_game_impl());
+    "Success".to_string()
+}
+
+async fn update_restart_timers_hon_game_impl() {
+    let canisters = CANISTER_DATA.with_borrow_mut(|canister_data| {
+        canister_data
+            .user_principal_id_to_canister_id_map
+            .values()
+            .cloned()
+            .collect::<Vec<_>>()
+    });
+
+    let futures = canisters.iter().map(|canister_id| async {
+        let _: CallResult<()> = ic_cdk::call(
+            *canister_id,
+            "once_reenqueue_timers_for_pending_bet_outcomes",
+            (),
+        )
+        .await;
+    });
+
+    let stream = futures::stream::iter(futures).boxed().buffer_unordered(25);
+
+    let _ = stream.collect::<Vec<()>>().await;
+}

--- a/src/lib/shared_utils/src/canister_specific/individual_user_template/types/hot_or_not/mod.rs
+++ b/src/lib/shared_utils/src/canister_specific/individual_user_template/types/hot_or_not/mod.rs
@@ -395,18 +395,21 @@ impl Post {
                 let denominator = DURATION_OF_EACH_SLOT_IN_SECONDS;
                 let currently_ongoing_slot = ((numerator / denominator) + 1) as u8;
 
-                let temp_room_details_default = RoomDetailsV1::default();
+                // let temp_room_details_default = RoomDetailsV1::default();
 
                 // get currently active room
                 let active_room_id = slot_details_map
                     .get(&(self.id, currently_ongoing_slot))
-                    .unwrap_or(SlotDetailsV1::default())
+                    .unwrap_or_default()
+                    // .unwrap_or(SlotDetailsV1::default())
                     .active_room_id;
+
                 let global_room_id = GlobalRoomId(self.id, currently_ongoing_slot, active_room_id);
 
                 let room_details = room_details_map
                     .get(&global_room_id)
-                    .unwrap_or(temp_room_details_default);
+                    .unwrap_or_default();
+                    // .unwrap_or(temp_room_details_default);
 
                 let number_of_participants =
                     (room_details.total_hot_bets + room_details.total_not_bets) as u8;
@@ -638,7 +641,8 @@ impl Post {
                 let mut hot_or_not_details = self
                     .hot_or_not_details
                     .take()
-                    .unwrap_or(HotOrNotDetails::default());
+                    // .unwrap_or(HotOrNotDetails::default());
+                    .unwrap_or_default();
                 let mut global_room_id = GlobalRoomId(self.id, ongoing_slot, ongoing_room);
                 let mut global_bet_id =
                     GlobalBetId(global_room_id, StablePrincipal(*bet_maker_principal_id));
@@ -684,12 +688,12 @@ impl Post {
 
                 room_details_map.insert(global_room_id, room_detail);
                 if global_room_id.2 != ongoing_room {
-                    slot_details_map.insert(
-                        (self.id, ongoing_slot),
-                        SlotDetailsV1 {
-                            active_room_id: global_room_id.2,
-                        },
-                    );
+                slot_details_map.insert(
+                    (self.id, ongoing_slot),
+                    SlotDetailsV1 {
+                        active_room_id: global_room_id.2,
+                    },
+                );
                 }
 
                 self.hot_or_not_details = Some(hot_or_not_details);


### PR DESCRIPTION
- migration for the existing hung_timers in post_upgrade 
- removed the check to enable timers on all posts.


fixes: #387 
#### To check the status of the deployment

- check if the platform orchestrator performed the step to upgrade subnet canister with appropriate version: [Platform Orchestrator function](https://dashboard.internetcomputer.org/canister/74zq4-iqaaa-aaaam-ab53a-cai#get_subnet_last_upgrade_status)
- check the status of upgrade for individual canisters in subnet orchestrators and verify the version. Example for one of the subnet orchesrator: [Subnet Orchestrator function](https://dashboard.internetcomputer.org/canister/rimrc-piaaa-aaaao-aaljq-cai#get_index_details_last_upgrade_status)

To test the platform orchestrator, you can use the following command:

`dfx canister call --query 74zq4-iqaaa-aaaam-ab53a-cai get_subnet_last_upgrade_status --network=ic`
 the canister id (74zq4-iqaaa-aaaam-ab53a-cai) is taken from the canister_ids.json file