### PR TITLE
fix: hung timers back fill data

### DIFF
--- a/src/canister/individual_user_template/src/api/hot_or_not_bet/get_resolved_bets_for_caller.rs
+++ b/src/canister/individual_user_template/src/api/hot_or_not_bet/get_resolved_bets_for_caller.rs
@@ -1,3 +1,4 @@
+use candid::Principal;
 use ic_cdk::api::management_canister::provisional::CanisterId;
 use ic_cdk_macros::query;
 
@@ -5,7 +6,8 @@ use shared_utils::{
     canister_specific::individual_user_template::types::hot_or_not::PlacedBetDetail,
     common::types::app_primitive_type::PostId,
 };
-
+use shared_utils::canister_specific::individual_user_template::types::hot_or_not::{GlobalBetId, GlobalRoomId, StablePrincipal};
+use shared_utils::canister_specific::individual_user_template::types::hot_or_not::BetDetails;
 use crate::{
     api::canister_management::update_last_access_time::update_last_canister_functionality_access_time,
     CANISTER_DATA,
@@ -13,14 +15,16 @@ use crate::{
 
 #[query]
 fn get_bet_details_for_bet_id(
-    bet_id: GlobalBetId
+    bet_id: ((u64,u8,u64),Principal)
 ) -> Option<BetDetails> {
+    let ((post_canister_id,slot_id,room_id),caller) = bet_id;
+    let bet_id_struct = GlobalBetId(GlobalRoomId(post_canister_id,slot_id,room_id),StablePrincipal(caller));
     update_last_canister_functionality_access_time();
     CANISTER_DATA.with(|canister_data_ref_cell| {
         canister_data_ref_cell
             .borrow()
             .bet_details_map
-            .get(&bet_id)
-            .cloned()
+            .get(&bet_id_struct)
+            // .cloned()
     })
 }

--- a/src/canister/individual_user_template/src/api/hot_or_not_bet/get_resolved_bets_for_caller.rs
+++ b/src/canister/individual_user_template/src/api/hot_or_not_bet/get_resolved_bets_for_caller.rs
@@ -1,0 +1,26 @@
+use ic_cdk::api::management_canister::provisional::CanisterId;
+use ic_cdk_macros::query;
+
+use shared_utils::{
+    canister_specific::individual_user_template::types::hot_or_not::PlacedBetDetail,
+    common::types::app_primitive_type::PostId,
+};
+
+use crate::{
+    api::canister_management::update_last_access_time::update_last_canister_functionality_access_time,
+    CANISTER_DATA,
+};
+
+#[query]
+fn get_bet_details_for_bet_id(
+    bet_id: GlobalBetId
+) -> Option<BetDetails> {
+    update_last_canister_functionality_access_time();
+    CANISTER_DATA.with(|canister_data_ref_cell| {
+        canister_data_ref_cell
+            .borrow()
+            .bet_details_map
+            .get(&bet_id)
+            .cloned()
+    })
+}

--- a/src/canister/individual_user_template/src/api/hot_or_not_bet/mod.rs
+++ b/src/canister/individual_user_template/src/api/hot_or_not_bet/mod.rs
@@ -6,3 +6,5 @@ pub mod receive_bet_from_bet_makers_canister;
 pub mod receive_bet_winnings_when_distributed;
 pub mod reenqueue_timers_for_pending_bet_outcomes;
 pub mod tabulate_hot_or_not_outcome_for_post_slot;
+pub mod resolve_pending_bets;
+pub mod get_resolved_bets_for_caller;

--- a/src/canister/individual_user_template/src/api/hot_or_not_bet/resolve_pending_bets.rs
+++ b/src/canister/individual_user_template/src/api/hot_or_not_bet/resolve_pending_bets.rs
@@ -1,11 +1,12 @@
-use ic_cdk::api::management_canister::provisional::CanisterId;
+use candid::Principal;
+use ic_cdk::{api::management_canister::provisional::CanisterId, update};
 use ic_cdk_macros::query;
-
 use shared_utils::{
     canister_specific::individual_user_template::types::hot_or_not::{
         BetDetail, BetDetails, GlobalBetId, GlobalRoomId, PlacedBetDetail,
     },
     common::types::app_primitive_type::PostId,
+    hot_or_not::BetOutcomeForBetMaker,
 };
 
 use crate::{
@@ -27,7 +28,7 @@ pub async fn resolve_pending_bets() {
             .borrow()
             .all_hot_or_not_bets_placed
             .iter()
-            .filter(|((post_canister_id, post_id), placed_bet_detail)| {
+            .filter(|((_post_canister_id, _post_id), placed_bet_detail)| {
                 matches!(
                     placed_bet_detail.outcome_received,
                     BetOutcomeForBetMaker::AwaitingResult
@@ -36,6 +37,13 @@ pub async fn resolve_pending_bets() {
             .collect()
     });
 
+    resolve_pending_bets_impl(pending_bets, user_principal_id).await;
+}
+
+async fn resolve_pending_bets_impl(
+    pending_bets: Vec<((CanisterId, PostId), PlacedBetDetail)>,
+    user_principal_id: Principal,
+) {
     let futures = pending_bets
         .iter()
         .map(|((post_canister_id, post_id), placed_bet_detail)| {
@@ -50,28 +58,70 @@ pub async fn resolve_pending_bets() {
             call_caller_for_hot_or_not_bet_result(post_canister_id, global_bet_id)
         });
 
-    let result_callback = |res| {
-        if let Ok(bet_details) = res {
-            CANISTER_DATA.with_borrow_mut(|canister_data| {
-                canister_data
-                    .all_hot_or_not_bets_placed
-                    .get((post_canister_id, post_id))
-                    .map(|placed_bet_detail|{
-                        placed_bet_detail.outcome_received = bet_details.into();
-                    })
-            })
-        }
-    };
-
     let stream = futures::stream::iter(futures).boxed().buffer_unordered(20);
 
-    let _ = stream.collect::<Vec<()>>().await;
+    let results = stream
+        .collect::<Vec<Result<(BetDetails, GlobalBetId, CanisterId), Error>>>()
+        .await;
+
+    let success_bet_results = results
+        .into_iter()
+        .filter_map(|r| r.as_ref().ok().cloned())
+        .collect::<Vec<(BetDetails, GlobalBetId, CanisterId)>>();
+
+    let pending_bets_hashmap = pending_bets
+        .into_iter()
+        .collect::<HashMap<(CanisterId, PostId), PlacedBetDetail>>();
+
+    // udpate all the pending bets with the result
+    success_bet_results
+        .iter()
+        .for_each(|(bet_details, global_bet_id, post_canister_id)| {
+            // get the pending_bet_details
+            let pending_bet_details = pending_bets_hashmap
+                .get(&(post_canister_id, global_bet_id.0 .0))
+                .unwrap();
+
+            // update the pending_bet_details
+            pending_bet_details.outcome_received = bet_details.into();
+
+            CANISTER_DATA.with_borrow_mut(|canister_data| {
+                canister_data.all_hot_or_not_bets_placed.insert(
+                    (post_canister_id, global_bet_id.0 .0),
+                    pending_bet_details.clone(),
+                );
+
+                // handle token balance
+                // copied from: src/canister/individual_user_template/src/api/hot_or_not_bet/receive_bet_winnings_when_distributed.rs:58
+                let my_token_balance = &mut canister_data.my_token_balance;
+                my_token_balance.handle_token_event(TokenEvent::HotOrNotOutcomePayout {
+                    amount: match outcome {
+                        BetOutcomeForBetMaker::Draw(amount) => amount,
+                        BetOutcomeForBetMaker::Won(amount) => amount,
+                        _ => 0,
+                    },
+                    details: HotOrNotOutcomePayoutEvent::WinningsEarnedFromBet {
+                        post_canister_id: post_creator_canister_id,
+                        post_id,
+                        slot_id: placed_bet_detail.slot_id,
+                        room_id: placed_bet_detail.room_id,
+                        winnings_amount: match outcome {
+                            BetOutcomeForBetMaker::Draw(amount) => amount,
+                            BetOutcomeForBetMaker::Won(amount) => amount,
+                            _ => 0,
+                        },
+                        event_outcome: outcome,
+                    },
+                    timestamp: current_time,
+                });
+            });
+        });
 }
 
 async fn call_caller_for_hot_or_not_bet_result(
     post_maker_canister_id: CanisterId,
     global_bet_id: GlobalBetId,
-) -> Result<BetDetails, Error> {
+) -> Result<(BetDetails, GlobalBetId, CanisterId), Error> {
     let result = ic_cdk::call::<_, ()>(
         post_maker_canister_id,
         "get_bet_details_for_bet_id",
@@ -81,9 +131,37 @@ async fn call_caller_for_hot_or_not_bet_result(
 
     match result {
         Ok(val) => match val {
-            Some(bet_detail) => Ok(bet_detail),
-            None => Err("Bet Not Resolved yet".to_string()),
+            Some(bet_detail) => Ok((bet_detail, global_bet_id, post_canister_id)),
+            None => Err(format!(
+                "Bet Not Resolved yet for global_bet_id {:?}",
+                global_bet_id
+            )),
         },
         Err(e) => Err(e),
     }
+}
+
+// these two function scaffolds are for testing purposes ONLY
+// they are used to simulate hung timers for integration tests
+
+#[update]
+pub fn insert_in_all_hot_or_not_bets_placed(
+    post_canister_id: CanisterId,
+    post_id: PostId,
+    placed_bet_detail: PlacedBetDetail,
+) {
+    CANISTER_DATA.with_borrow_mut(|canister_data| {
+        canister_data
+            .all_hot_or_not_bets_placed
+            .insert((post_canister_id, post_id), placed_bet_detail);
+    });
+}
+
+#[update]
+pub fn insert_in_bet_details_map(global_bet_id: GlobalBetId, bet_detail: BetDetail) {
+    CANISTER_DATA.with_borrow_mut(|canister_data| {
+        canister_data
+            .bet_details_map
+            .insert(global_bet_id, bet_detail);
+    });
 }

--- a/src/canister/individual_user_template/src/api/hot_or_not_bet/resolve_pending_bets.rs
+++ b/src/canister/individual_user_template/src/api/hot_or_not_bet/resolve_pending_bets.rs
@@ -2,39 +2,50 @@ use candid::Principal;
 use ic_cdk::{api::management_canister::provisional::CanisterId, update};
 use ic_cdk_macros::query;
 use shared_utils::{
+    canister_specific::individual_user_template::types::hot_or_not::BetOutcomeForBetMaker,
     canister_specific::individual_user_template::types::hot_or_not::{
-        BetDetail, BetDetails, GlobalBetId, GlobalRoomId, PlacedBetDetail,
+        BetDetails, GlobalBetId, GlobalRoomId, PlacedBetDetail,
     },
     common::types::app_primitive_type::PostId,
-    hot_or_not::BetOutcomeForBetMaker,
+    common::types::utility_token::token_event::TokenEvent,
 };
+
+use futures::StreamExt;
+use shared_utils::canister_specific::individual_user_template::types::hot_or_not::StablePrincipal;
+use shared_utils::common::types::utility_token::token_event::HotOrNotOutcomePayoutEvent;
+use shared_utils::common::utils::system_time;
+use std::collections::HashMap;
 
 use crate::{
     api::canister_management::update_last_access_time::update_last_canister_functionality_access_time,
     CANISTER_DATA,
 };
-use ic_cdk::caller;
 
 #[update]
 pub async fn resolve_pending_bets() {
     update_last_canister_functionality_access_time();
 
-    let user_principal_id = CANISTER_DATA.with_borrow(|canister_data| {
-        canister_data.profile.principal_id.cloned();
-    });
+    let user_principal_id =
+        CANISTER_DATA.with_borrow(|canister_data| canister_data.profile.principal_id.clone());
+
+    let user_principal_id = match user_principal_id {
+        Some(id) => (id),
+        None => return,
+    };
 
     let pending_bets = CANISTER_DATA.with(|canister_data_ref_cell| {
         canister_data_ref_cell
             .borrow()
             .all_hot_or_not_bets_placed
-            .iter()
+            .clone()
+            .into_iter()
             .filter(|((_post_canister_id, _post_id), placed_bet_detail)| {
                 matches!(
                     placed_bet_detail.outcome_received,
                     BetOutcomeForBetMaker::AwaitingResult
                 )
             })
-            .collect()
+            .collect::<Vec<_>>()
     });
 
     resolve_pending_bets_impl(pending_bets, user_principal_id).await;
@@ -49,19 +60,19 @@ async fn resolve_pending_bets_impl(
         .map(|((post_canister_id, post_id), placed_bet_detail)| {
             let global_bet_id = GlobalBetId(
                 GlobalRoomId(
-                    post_id,
+                    *post_id,
                     placed_bet_detail.slot_id,
                     placed_bet_detail.room_id,
                 ),
-                user_principal_id,
+                StablePrincipal(user_principal_id),
             );
-            call_caller_for_hot_or_not_bet_result(post_canister_id, global_bet_id)
+            call_caller_for_hot_or_not_bet_result(post_canister_id.clone(), global_bet_id.clone())
         });
 
     let stream = futures::stream::iter(futures).boxed().buffer_unordered(20);
 
     let results = stream
-        .collect::<Vec<Result<(BetDetails, GlobalBetId, CanisterId), Error>>>()
+        .collect::<Vec<Result<(BetDetails, GlobalBetId, CanisterId), String>>>()
         .await;
 
     let success_bet_results = results
@@ -77,19 +88,27 @@ async fn resolve_pending_bets_impl(
     success_bet_results
         .iter()
         .for_each(|(bet_details, global_bet_id, post_canister_id)| {
+            let post_id = global_bet_id.0 .0;
+
+            let current_time = system_time::get_current_system_time_from_ic();
+
             // get the pending_bet_details
             let pending_bet_details = pending_bets_hashmap
-                .get(&(post_canister_id, global_bet_id.0 .0))
+                .get(&(*post_canister_id, post_id))
                 .unwrap();
 
+            let mut pending_bet_details = pending_bet_details.clone();
             // update the pending_bet_details
-            pending_bet_details.outcome_received = bet_details.into();
+            pending_bet_details.update_outcome(bet_details.clone().into());
 
             CANISTER_DATA.with_borrow_mut(|canister_data| {
                 canister_data.all_hot_or_not_bets_placed.insert(
-                    (post_canister_id, global_bet_id.0 .0),
+                    (post_canister_id.clone(), post_id),
                     pending_bet_details.clone(),
                 );
+
+                let placed_bet_detail = pending_bet_details.clone();
+                let outcome: BetOutcomeForBetMaker = placed_bet_detail.outcome_received;
 
                 // handle token balance
                 // copied from: src/canister/individual_user_template/src/api/hot_or_not_bet/receive_bet_winnings_when_distributed.rs:58
@@ -101,7 +120,7 @@ async fn resolve_pending_bets_impl(
                         _ => 0,
                     },
                     details: HotOrNotOutcomePayoutEvent::WinningsEarnedFromBet {
-                        post_canister_id: post_creator_canister_id,
+                        post_canister_id: *post_canister_id,
                         post_id,
                         slot_id: placed_bet_detail.slot_id,
                         room_id: placed_bet_detail.room_id,
@@ -121,23 +140,25 @@ async fn resolve_pending_bets_impl(
 async fn call_caller_for_hot_or_not_bet_result(
     post_maker_canister_id: CanisterId,
     global_bet_id: GlobalBetId,
-) -> Result<(BetDetails, GlobalBetId, CanisterId), Error> {
+) -> Result<(BetDetails, GlobalBetId, CanisterId), String> {
+    let GlobalBetId(GlobalRoomId(post_canister_id, slot_id, room_id), caller) = global_bet_id;
+    let StablePrincipal(caller_principal) = caller;
     let result = ic_cdk::call::<_, ()>(
         post_maker_canister_id,
         "get_bet_details_for_bet_id",
-        (global_bet_id),
+        ((post_canister_id, slot_id, room_id), caller_principal),
     )
-    .await;
+    .await
+    .map_err(|_| {
+        "Could not call post maker canister for bet_details".into()
+    })?.0?;
 
     match result {
         Ok(val) => match val {
-            Some(bet_detail) => Ok((bet_detail, global_bet_id, post_canister_id)),
-            None => Err(format!(
-                "Bet Not Resolved yet for global_bet_id {:?}",
-                global_bet_id
-            )),
+            Some(bet_detail) => Ok((bet_detail, global_bet_id, post_maker_canister_id)),
+            None => Err(format!("Bet Not Resolved yet for global_bet_id {:?}",global_bet_id)),
         },
-        Err(e) => Err(e),
+        Err(e) => Err("Unknown Error while resolving pending bets".into()),
     }
 }
 
@@ -158,7 +179,7 @@ pub fn insert_in_all_hot_or_not_bets_placed(
 }
 
 #[update]
-pub fn insert_in_bet_details_map(global_bet_id: GlobalBetId, bet_detail: BetDetail) {
+pub fn insert_in_bet_details_map(global_bet_id: GlobalBetId, bet_detail: BetDetails) {
     CANISTER_DATA.with_borrow_mut(|canister_data| {
         canister_data
             .bet_details_map

--- a/src/canister/individual_user_template/src/api/hot_or_not_bet/resolve_pending_bets.rs
+++ b/src/canister/individual_user_template/src/api/hot_or_not_bet/resolve_pending_bets.rs
@@ -1,0 +1,89 @@
+use ic_cdk::api::management_canister::provisional::CanisterId;
+use ic_cdk_macros::query;
+
+use shared_utils::{
+    canister_specific::individual_user_template::types::hot_or_not::{
+        BetDetail, BetDetails, GlobalBetId, GlobalRoomId, PlacedBetDetail,
+    },
+    common::types::app_primitive_type::PostId,
+};
+
+use crate::{
+    api::canister_management::update_last_access_time::update_last_canister_functionality_access_time,
+    CANISTER_DATA,
+};
+use ic_cdk::caller;
+
+#[update]
+pub async fn resolve_pending_bets() {
+    update_last_canister_functionality_access_time();
+
+    let user_principal_id = CANISTER_DATA.with_borrow(|canister_data| {
+        canister_data.profile.principal_id.cloned();
+    });
+
+    let pending_bets = CANISTER_DATA.with(|canister_data_ref_cell| {
+        canister_data_ref_cell
+            .borrow()
+            .all_hot_or_not_bets_placed
+            .iter()
+            .filter(|((post_canister_id, post_id), placed_bet_detail)| {
+                matches!(
+                    placed_bet_detail.outcome_received,
+                    BetOutcomeForBetMaker::AwaitingResult
+                )
+            })
+            .collect()
+    });
+
+    let futures = pending_bets
+        .iter()
+        .map(|((post_canister_id, post_id), placed_bet_detail)| {
+            let global_bet_id = GlobalBetId(
+                GlobalRoomId(
+                    post_id,
+                    placed_bet_detail.slot_id,
+                    placed_bet_detail.room_id,
+                ),
+                user_principal_id,
+            );
+            call_caller_for_hot_or_not_bet_result(post_canister_id, global_bet_id)
+        });
+
+    let result_callback = |res| {
+        if let Ok(bet_details) = res {
+            CANISTER_DATA.with_borrow_mut(|canister_data| {
+                canister_data
+                    .all_hot_or_not_bets_placed
+                    .get((post_canister_id, post_id))
+                    .map(|placed_bet_detail|{
+                        placed_bet_detail.outcome_received = bet_details.into();
+                    })
+            })
+        }
+    };
+
+    let stream = futures::stream::iter(futures).boxed().buffer_unordered(20);
+
+    let _ = stream.collect::<Vec<()>>().await;
+}
+
+async fn call_caller_for_hot_or_not_bet_result(
+    post_maker_canister_id: CanisterId,
+    global_bet_id: GlobalBetId,
+) -> Result<BetDetails, Error> {
+    let result = ic_cdk::call::<_, ()>(
+        post_maker_canister_id,
+        "get_bet_details_for_bet_id",
+        (global_bet_id),
+    )
+    .await;
+
+    match result {
+        Ok(val) => match val {
+            Some(bet_detail) => Ok(bet_detail),
+            None => Err("Bet Not Resolved yet".to_string()),
+        },
+        Err(e) => Err(e),
+    }
+}

--- a/src/canister/individual_user_template/src/lib.rs
+++ b/src/canister/individual_user_template/src/lib.rs
@@ -9,6 +9,8 @@ use candid::{Principal, Nat};
 use data_model::CanisterData;
 use ic_cdk::api::management_canister::provisional::CanisterId;
 use ic_cdk_macros::export_candid;
+use shared_utils::canister_specific::individual_user_template::types::hot_or_not::{GlobalBetId,BetDetails};
+
 use shared_utils::{
     canister_specific::individual_user_template::types::{
         arg::{FolloweeArg, IndividualUserTemplateInitArgs, PlaceBetArg},

--- a/src/lib/integration_tests/tests/hot_or_not/main.rs
+++ b/src/lib/integration_tests/tests/hot_or_not/main.rs
@@ -2,3 +2,4 @@ pub mod hot_or_not_timely_index_update_test;
 pub mod hotornot_game_simulation_test;
 pub mod reconcile_scores_test;
 pub mod when_bob_charlie_dan_place_bet_on_alice_created_post_then_expected_outcomes_occur;
+pub mod resolve_pending_bet_test;

--- a/src/lib/integration_tests/tests/hot_or_not/resolve_pending_bet_test.rs
+++ b/src/lib/integration_tests/tests/hot_or_not/resolve_pending_bet_test.rs
@@ -1,0 +1,211 @@
+use std::{collections::HashMap, time::Duration};
+
+use candid::{encode_args, encode_one, Principal};
+use pocket_ic::{PocketIc, WasmResult};
+use shared_utils::{
+    canister_specific::{
+        individual_user_template::types::{
+            arg::{IndividualUserTemplateInitArgs, PlaceBetArg},
+            error::BetOnCurrentlyViewingPostError,
+            hot_or_not::{BetDirection, BettingStatus, GlobalBetId, GlobalRoomId, PlacedBetDetail},
+            post::PostDetailsFromFrontend,
+            profile::UserProfileDetailsForFrontend,
+        },
+        post_cache::types::arg::PostCacheInitArgs,
+    },
+    common::types::known_principal::KnownPrincipalType,
+};
+use test_utils::setup::test_constants::{
+    get_global_super_admin_principal_id, get_mock_user_alice_principal_id,
+    get_mock_user_bob_principal_id, get_mock_user_charlie_principal_id,
+    get_mock_user_dan_principal_id,
+};
+
+const INDIVIDUAL_TEMPLATE_WASM_PATH: &str =
+    "../../../target/wasm32-unknown-unknown/release/individual_user_template.wasm.gz";
+const POST_CACHE_WASM_PATH: &str =
+    "../../../target/wasm32-unknown-unknown/release/post_cache.wasm.gz";
+
+fn individual_template_canister_wasm() -> Vec<u8> {
+    std::fs::read(INDIVIDUAL_TEMPLATE_WASM_PATH).unwrap()
+}
+
+fn post_cache_canister_wasm() -> Vec<u8> {
+    std::fs::read(POST_CACHE_WASM_PATH).unwrap()
+}
+
+#[test]
+// ONLY local testing because simulating a hung timer requires to expose additional functions
+// insert_in_all_hot_or_not_bets_placed , insert_in_bet_details_map  -> src/canister/individual_user_template/src/api/hot_or_not_bet/resolve_pending_bets.rs
+// #[cfg(feature = "integration_tests")]
+fn resolve_pending_bet_test() {
+    let pic = PocketIc::new();
+
+    let alice_principal_id = get_mock_user_alice_principal_id();
+    let bob_principal_id = get_mock_user_bob_principal_id();
+    let dan_principal_id = get_mock_user_dan_principal_id();
+    let admin_principal_id = get_mock_user_charlie_principal_id();
+
+    let post_cache_canister_id = pic.create_canister();
+    pic.add_cycles(post_cache_canister_id, 2_000_000_000_000);
+
+    let mut known_principal_values = HashMap::new();
+    known_principal_values.insert(
+        KnownPrincipalType::CanisterIdPostCache,
+        post_cache_canister_id,
+    );
+    known_principal_values.insert(
+        KnownPrincipalType::UserIdGlobalSuperAdmin,
+        admin_principal_id,
+    );
+
+    known_prinicipal_values.insert(KnownPrincipalType::CanisterIdUserIndex, admin_principal_id);
+
+    let post_cache_wasm_bytes = post_cache_canister_wasm();
+    let post_cache_args = PostCacheInitArgs {
+        known_principal_ids: Some(known_prinicipal_values.clone()),
+        upgrade_version_number: Some(1),
+        version: "1".to_string(),
+    };
+    let post_cache_args_bytes = encode_one(post_cache_args).unwrap();
+    
+    pic.install_canister(
+        post_cache_canister_id,
+        post_cache_wasm_bytes,
+        post_cache_args_bytes,
+        None,
+    );
+
+    // Individual template canisters
+    let individual_template_wasm_bytes = individual_template_canister_wasm();
+
+    // Init individual template canister - alice
+
+    let alice_individual_template_canister_id = pic.create_canister();
+    pic.add_cycles(alice_individual_template_canister_id, 2_000_000_000_000);
+
+    let individual_template_args = IndividualUserTemplateInitArgs {
+        known_principal_ids: Some(known_prinicipal_values.clone()),
+        profile_owner: Some(alice_principal_id),
+        upgrade_version_number: None,
+        url_to_send_canister_metrics_to: None,
+        version: "1".to_string(),
+    };
+    let individual_template_args_bytes = encode_one(individual_template_args).unwrap();
+
+    pic.install_canister(
+        alice_individual_template_canister_id,
+        individual_template_wasm_bytes.clone(),
+        individual_template_args_bytes,
+        None,
+    );
+
+    // Init individual template canister - bob
+
+    let bob_individual_template_canister_id = pic.create_canister();
+    pic.add_cycles(bob_individual_template_canister_id, 2_000_000_000_000);
+
+    let individual_template_args = IndividualUserTemplateInitArgs {
+        known_principal_ids: Some(known_prinicipal_values.clone()),
+        profile_owner: Some(bob_principal_id),
+        upgrade_version_number: None,
+        url_to_send_canister_metrics_to: None,
+        version: "1".to_string(),
+    };
+    let individual_template_args_bytes = encode_one(individual_template_args).unwrap();
+
+    pic.install_canister(
+        bob_individual_template_canister_id,
+        individual_template_wasm_bytes.clone(),
+        individual_template_args_bytes,
+        None,
+    );
+
+
+    // Create posts
+    // Alice creates a post
+
+    let alice_post_1 = PostDetailsFromFrontend {
+        is_nsfw: false,
+        description: "This is a fun video to watch".to_string(),
+        hashtags: vec!["fun".to_string(), "video".to_string()],
+        video_uid: "abcd#1234".to_string(),
+        creator_consent_for_inclusion_in_hot_or_not: true,
+    };
+    let res1 = pic
+        .update_call(
+            alice_individual_template_canister_id,
+            alice_principal_id,
+            "add_post_v2",
+            encode_one(alice_post_1).unwrap(),
+        )
+        .map(|reply_payload| {
+            let newly_created_post_id_result: Result<u64, String> = match reply_payload {
+                WasmResult::Reply(payload) => candid::decode_one(&payload).unwrap(),
+                _ => panic!("\n🛑 add_post failed\n"),
+            };
+            newly_created_post_id_result.unwrap()
+        })
+        .unwrap();
+
+        // Top up Bob's account
+    let reward = pic.update_call(
+        bob_individual_template_canister_id,
+        admin_principal_id,
+        "get_rewarded_for_signing_up",
+        encode_one(()).unwrap(),
+    );
+
+    // simulate a hung timer 
+
+    // insert in bob_canister.all_hot_or_not_bet_placed.insert(alice_canister_id, post_id)
+    let arguments = (alice_individual_template_canister_id, res1, PlacedBetDetail{
+        canister_id: alice_individual_template_canister_id,
+        post_id: res1,
+        slot_id: 1,
+        room_id: 1,
+        amount_bet: 100,
+        bet_direction: BetDirection::Hot,
+        outcome_received: BetOutcomeForBetMaker::default(),
+        bet_placed_at: pic.get_time()
+    });
+
+
+    pic.update_call(bob_individual_template_canister_id, bob_principal_id, "insert_in_all_hot_or_not_bets_placed", encode_args(arguments).unwrap());
+    
+    // insert in alice_canister.bet_details_map.insert(global_bet_id, bob_principal_id)
+
+    let bdm_value = BetDetails {
+        amount: 100,
+        bet_direction: BetDirection::Hot,
+        payout: BetPayout::Calculated(180),
+        bet_maker_canister_id: bob_individual_template_canister_id,
+    };
+        
+    let bdm_args = (GlobalBetId(GlobalRoomId(res1, 1_u8, 1_u64), alice_principal_id), bdm_value);
+    
+    pic.update_call(alice_individual_template_canister_id, bob_principal_id, "insert_in_bet_details_map", encode_one(bdm_args).unwrap());
+
+    // check if bob.all_hot_or_not_bets_placed.get(alice_canister_id, post_id)
+    //  use get_hot_or_not_bets_placed_by_this_profile_with_pagination
+    let bob_all_hot_or_not_bets_placed = pic
+        .query_call(
+            bob_individual_template_canister_id,
+            bob_principal_id,
+            "get_hot_or_not_bets_placed_by_this_profile_with_pagination",
+            encode_one(0).unwrap(),
+        )
+        .map(|reply_payload| {
+            let bets: Vec<PlacedBetDetail> = match reply_payload {
+                WasmResult::Reply(payload) => candid::decode_one(&payload).unwrap(),
+                _ => panic!("\n🛑 get_hot_or_not_bets_placed_by_this_profile_with_pagination failed\n"),
+            };
+            bets
+        })
+        .unwrap();
+
+    ic_cdk::println!("Bob all hot or not bets placed: {:?}", bob_all_hot_or_not_bets_placed);
+    
+    // check if alice.bet_details_map.get(global_bet_id)
+    
+}

--- a/src/lib/shared_utils/src/canister_specific/individual_user_template/types/hot_or_not/mod.rs
+++ b/src/lib/shared_utils/src/canister_specific/individual_user_template/types/hot_or_not/mod.rs
@@ -304,6 +304,12 @@ pub struct PlacedBetDetail {
     pub outcome_received: BetOutcomeForBetMaker,
 }
 
+impl PlacedBetDetail{
+    pub fn update_outcome(&mut self, new_outcome: BetOutcomeForBetMaker) {
+        self.outcome_received = new_outcome;
+    }
+}
+
 #[derive(Deserialize, Serialize, Default, CandidType, PartialEq, Eq, Clone, Debug)]
 pub enum BetOutcomeForBetMaker {
     #[default]

--- a/src/lib/shared_utils/src/canister_specific/individual_user_template/types/hot_or_not/mod.rs
+++ b/src/lib/shared_utils/src/canister_specific/individual_user_template/types/hot_or_not/mod.rs
@@ -114,7 +114,7 @@ impl Default for SlotDetailsV1 {
     }
 }
 
-const MAX_SLOT_DETAILS_VALUE_SIZE: u32 = 100 as u32;
+const MAX_SLOT_DETAILS_VALUE_SIZE: u32 = 100_u32;
 
 impl Storable for SlotDetailsV1 {
     fn to_bytes(&self) -> std::borrow::Cow<[u8]> {
@@ -138,7 +138,7 @@ pub struct RoomDetailsV1 {
     pub total_hot_bets: u64,
     pub total_not_bets: u64,
 }
-const MAX_ROOM_DETAILS_VALUE_SIZE: u32 = 100 as u32;
+const MAX_ROOM_DETAILS_VALUE_SIZE: u32 = 100_u32;
 
 impl Storable for RoomDetailsV1 {
     fn to_bytes(&self) -> std::borrow::Cow<[u8]> {
@@ -164,7 +164,7 @@ pub struct BetDetails {
     pub payout: BetPayout,
     pub bet_maker_canister_id: CanisterId,
 }
-const MAX_BET_DETAILS_VALUE_SIZE: u32 = 200 as u32;
+const MAX_BET_DETAILS_VALUE_SIZE: u32 = 200_u32;
 
 impl Storable for BetDetails {
     fn to_bytes(&self) -> std::borrow::Cow<[u8]> {
@@ -180,6 +180,22 @@ impl Storable for BetDetails {
         is_fixed_size: false,
     };
 }
+
+impl From<BetDetails> for BetOutcomeForBetMaker {
+    fn from(bet_details: BetDetails) -> Self {
+        match bet_details.payout {
+            BetPayout::NotCalculatedYet => BetOutcomeForBetMaker::AwaitingResult,
+            BetPayout::Calculated(calculated_amount) => {
+              match bet_details.amount.cmp(&calculated_amount) {
+                std::cmp::Ordering::Less =>  BetOutcomeForBetMaker::Lost,
+                std::cmp::Ordering::Greater =>BetOutcomeForBetMaker::Won(calculated_amount),
+                std::cmp::Ordering::Equal => BetOutcomeForBetMaker::Draw(calculated_amount),
+              }
+            }
+        }
+    }
+}
+
 
 #[derive(
     CandidType, Clone, Deserialize, Debug, Serialize, Ord, PartialOrd, Eq, PartialEq, Hash,


### PR DESCRIPTION


 - logic:

1. all_hot_or_not_bets_placed => have AwaitingResult
2. filter those out, and request the post_canister_id for the outcome. It is in bet_details_map of post_canister_id
   3. after getting result back, update the all_hot_or_not_bets_placed



#### To check the status of the deployment

- check if the platform orchestrator performed the step to upgrade subnet canister with appropriate version: [Platform Orchestrator function](https://dashboard.internetcomputer.org/canister/74zq4-iqaaa-aaaam-ab53a-cai#get_subnet_last_upgrade_status)
- check the status of upgrade for individual canisters in subnet orchestrators and verify the version. Example for one of the subnet orchesrator: [Subnet Orchestrator function](https://dashboard.internetcomputer.org/canister/rimrc-piaaa-aaaao-aaljq-cai#get_index_details_last_upgrade_status)

To test the platform orchestrator, you can use the following command:

`dfx canister call --query 74zq4-iqaaa-aaaam-ab53a-cai get_subnet_last_upgrade_status --network=ic`
 the canister id (74zq4-iqaaa-aaaam-ab53a-cai) is taken from the canister_ids.json file