### PR TITLE
Feat/add state guard for depositing cycles to subnet orchestrator

### DIFF
--- a/src/canister/platform_orchestrator/src/data_model/mod.rs
+++ b/src/canister/platform_orchestrator/src/data_model/mod.rs
@@ -3,7 +3,6 @@ use ic_stable_structures::{storable::Bound, StableBTreeMap, StableLog, Storable}
 use std::{
     borrow::Cow,
     collections::HashSet,
-    hash::Hash,
     time::{SystemTime, UNIX_EPOCH},
 };
 

--- a/src/canister/platform_orchestrator/src/data_model/mod.rs
+++ b/src/canister/platform_orchestrator/src/data_model/mod.rs
@@ -3,6 +3,7 @@ use ic_stable_structures::{storable::Bound, StableBTreeMap, StableLog, Storable}
 use std::{
     borrow::Cow,
     collections::HashSet,
+    hash::Hash,
     time::{SystemTime, UNIX_EPOCH},
 };
 
@@ -23,6 +24,11 @@ use self::memory::{
 
 pub mod memory;
 
+#[derive(Serialize, Deserialize, Default)]
+pub struct StateGuard {
+    pub ongoing_request_for_cycles_from_subnet_orchestrator: HashSet<Principal>,
+}
+
 #[derive(Serialize, Deserialize)]
 pub struct CanisterData {
     pub all_subnet_orchestrator_canisters_list: HashSet<Principal>,
@@ -40,6 +46,8 @@ pub struct CanisterData {
     pub known_principals: PlatformOrchestratorKnownPrincipal,
     #[serde(default)]
     pub subnets_upgrade_report: SubnetUpgradeReport,
+    #[serde(default)]
+    pub state_guard: StateGuard,
 }
 
 fn _default_wasms() -> StableBTreeMap<WasmType, CanisterWasm, Memory> {
@@ -67,6 +75,7 @@ impl Default for CanisterData {
             known_principals: Default::default(),
             platform_global_admins: Default::default(),
             subnets_upgrade_report: SubnetUpgradeReport::default(),
+            state_guard: StateGuard::default(),
         }
     }
 }

--- a/src/canister/platform_orchestrator/src/utils/registered_subnet_orchestrator.rs
+++ b/src/canister/platform_orchestrator/src/utils/registered_subnet_orchestrator.rs
@@ -7,6 +7,47 @@ use shared_utils::constant::SUBNET_ORCHESTRATOR_CANISTER_CYCLES_THRESHOLD;
 
 use crate::CANISTER_DATA;
 
+pub struct OngoingRequestForCyclesFromSubnetOrchestratorGuard {
+    subnet_orchestrator_canister_id: Principal,
+}
+
+impl OngoingRequestForCyclesFromSubnetOrchestratorGuard {
+    fn new(subnet_orchestrator_canister_id: Principal) -> Result<Self, String> {
+        CANISTER_DATA.with_borrow_mut(|canister_data| {
+            match canister_data
+                .state_guard
+                .ongoing_request_for_cycles_from_subnet_orchestrator
+                .contains(&subnet_orchestrator_canister_id)
+            {
+                true => Err(format!(
+                    "Already Processing a request for Cycles from subnet orchestrator {}",
+                    subnet_orchestrator_canister_id
+                )),
+                false => {
+                    canister_data
+                        .state_guard
+                        .ongoing_request_for_cycles_from_subnet_orchestrator
+                        .insert(subnet_orchestrator_canister_id);
+                    Ok(Self {
+                        subnet_orchestrator_canister_id,
+                    })
+                }
+            }
+        })
+    }
+}
+
+impl Drop for OngoingRequestForCyclesFromSubnetOrchestratorGuard {
+    fn drop(&mut self) {
+        CANISTER_DATA.with_borrow_mut(|canister_data| {
+            canister_data
+                .state_guard
+                .ongoing_request_for_cycles_from_subnet_orchestrator
+                .remove(&self.subnet_orchestrator_canister_id)
+        });
+    }
+}
+
 pub struct RegisteredSubnetOrchestrator {
     canister_id: Principal,
 }
@@ -31,6 +72,8 @@ impl RegisteredSubnetOrchestrator {
     }
 
     pub async fn deposit_cycles(&self) -> Result<(), String> {
+        let _guard = OngoingRequestForCyclesFromSubnetOrchestratorGuard::new(self.canister_id)?;
+
         let (subnet_orchestrator_status_res,) = canister_status(CanisterIdRecord {
             canister_id: self.canister_id,
         })

--- a/src/lib/integration_tests/tests/platform_orchestrator/recharge_subnet_orchestrator_test.rs
+++ b/src/lib/integration_tests/tests/platform_orchestrator/recharge_subnet_orchestrator_test.rs
@@ -1,4 +1,3 @@
-use candid::{Decode, Principal};
 use pocket_ic::WasmResult;
 use shared_utils::{
     common::types::known_principal::KnownPrincipalType,


### PR DESCRIPTION
## Motivation/Issue

- after getting multiple requests for cycles to platform orchestrator from subnet orchestrator, Platform recharges subnet multiple times. This is known problem while dealing with inter canister calls as described here: https://internetcomputer.org/docs/current/developer-docs/security/security-best-practices/inter-canister-calls#be-aware-that-there-is-no-reliable-message-ordering


## Changes 
- added state guard module in platform
- added a guard for ongoing requests from subnet orchestrator to deposit cycles.
