### PR TITLE
added method to update reserved cycles limit for subnet orchestrator

### DIFF
--- a/src/canister/platform_orchestrator/can.did
+++ b/src/canister/platform_orchestrator/can.did
@@ -100,6 +100,9 @@ service : (PlatformOrchestratorInitArgs) -> {
   remove_principal_from_global_admins : (principal) -> ();
   remove_subnet_orchestrators_from_available_list : (principal) -> (Result);
   report_subnet_upgrade_status : (UpgradeStatus) -> (Result_1);
+  set_reserved_cycle_limit_for_subnet_orchestrator : (principal, nat) -> (
+      Result_1,
+    );
   start_reclaiming_cycles_from_individual_canisters : () -> (Result);
   start_reclaiming_cycles_from_subnet_orchestrator_canister : () -> (text);
   stop_upgrades_for_individual_user_canisters : () -> (Result);

--- a/src/canister/platform_orchestrator/src/api/canister_management/mod.rs
+++ b/src/canister/platform_orchestrator/src/api/canister_management/mod.rs
@@ -18,6 +18,7 @@ pub mod register_new_subnet_orhestrator;
 mod reinstall_yral_post_cache_canister;
 pub mod remove_subnet_orchestrator_from_available_list;
 pub mod report_subnet_upgrade_status;
+pub mod set_reserved_cycle_limit_for_subnet_orchestrator;
 mod stop_upgrades_for_individual_user_canisters;
 mod subnet_orchestrator_maxed_out;
 mod update_canisters_last_access_time;

--- a/src/canister/platform_orchestrator/src/api/canister_management/set_reserved_cycle_limit_for_subnet_orchestrator.rs
+++ b/src/canister/platform_orchestrator/src/api/canister_management/set_reserved_cycle_limit_for_subnet_orchestrator.rs
@@ -1,0 +1,19 @@
+use candid::Principal;
+use ic_cdk_macros::update;
+
+use crate::{
+    guard::is_caller::is_caller_global_admin_or_controller,
+    utils::registered_subnet_orchestrator::RegisteredSubnetOrchestrator,
+};
+
+#[update(guard = "is_caller_global_admin_or_controller")]
+async fn set_reserved_cycle_limit_for_subnet_orchestrator(
+    subnet_orchestrator_canister_id: Principal,
+    amount: u128,
+) -> Result<(), String> {
+    let registered_subnet_orchestrator =
+        RegisteredSubnetOrchestrator::new(subnet_orchestrator_canister_id)?;
+    registered_subnet_orchestrator
+        .set_reserved_cycle_limit(amount)
+        .await
+}

--- a/src/canister/platform_orchestrator/src/utils/registered_subnet_orchestrator.rs
+++ b/src/canister/platform_orchestrator/src/utils/registered_subnet_orchestrator.rs
@@ -1,4 +1,4 @@
-use candid::Principal;
+use candid::{Nat, Principal};
 use ic_cdk::api::management_canister::main::{
     canister_status, deposit_cycles, update_settings, CanisterIdRecord, CanisterSettings,
     LogVisibility, UpdateSettingsArgument,
@@ -190,5 +190,17 @@ impl RegisteredSubnetOrchestrator {
             Ok((_str,)) => Ok(()),
             Err(e) => Err(e),
         }
+    }
+
+    pub async fn set_reserved_cycle_limit(&self, amount: u128) -> Result<(), String> {
+        update_settings(UpdateSettingsArgument {
+            canister_id: self.canister_id,
+            settings: CanisterSettings {
+                reserved_cycles_limit: Some(Nat::from(amount)),
+                ..Default::default()
+            },
+        })
+        .await
+        .map_err(|e| e.1)
     }
 }


### PR DESCRIPTION
## Changes
- added method to update `reserved_cycles_limit` in a canister.