### PR TITLE
handle errors around using backup pool

### DIFF
--- a/src/canister/user_index/src/api/canister_management/allot_empty_canister.rs
+++ b/src/canister/user_index/src/api/canister_management/allot_empty_canister.rs
@@ -19,22 +19,10 @@ use crate::{
 #[update]
 async fn allot_empty_canister() -> Result<Principal, String> {
     let registered_individual_canister = IndividualUserCanister::new(caller())?;
-    let result = registered_individual_canister.allot_empty_canister();
+    let result = registered_individual_canister.allot_empty_canister().await;
 
     let backup_canister_count =
         CANISTER_DATA.with_borrow(|canister_data| canister_data.backup_canister_pool.len() as u64);
-
-    if let Ok(canister_id) = result {
-        update_settings(UpdateSettingsArgument {
-            canister_id,
-            settings: CanisterSettings {
-                controllers: Some(vec![registered_individual_canister.canister_id]),
-                ..Default::default()
-            },
-        })
-        .await
-        .map_err(|e| e.1)?;
-    }
 
     if backup_canister_count < get_backup_individual_user_canister_threshold() {
         let number_of_canisters = get_backup_individual_user_canister_batch_size();

--- a/src/canister/user_index/src/util/canister_management.rs
+++ b/src/canister/user_index/src/util/canister_management.rs
@@ -111,7 +111,7 @@ pub async fn install_canister_wasm(
     profile_owner: Option<Principal>,
     version: String,
     wasm: Vec<u8>,
-) -> Principal {
+) -> Result<Principal, (Principal, String)> {
     let configuration = CANISTER_DATA
         .with(|canister_data_ref_cell| canister_data_ref_cell.borrow().configuration.clone());
 
@@ -141,9 +141,9 @@ pub async fn install_canister_wasm(
         arg,
     })
     .await
-    .unwrap();
+    .map_err(|e| (canister_id, e.1))?;
 
-    canister_id
+    Ok(canister_id)
 }
 
 pub async fn reinstall_canister_wasm(


### PR DESCRIPTION
## Changes
- remove canister id before installing wasm and moving it to available pool if fails add it back again to backup canister pool.
- if allot canister fails add the cansiter id back to the pool.