### PR TITLE
avoid leaving canisters in stopped state if an upgrade fails

### DIFF
--- a/src/canister/platform_orchestrator/can.did
+++ b/src/canister/platform_orchestrator/can.did
@@ -105,6 +105,7 @@ service : (PlatformOrchestratorInitArgs) -> {
     );
   start_reclaiming_cycles_from_individual_canisters : () -> (Result);
   start_reclaiming_cycles_from_subnet_orchestrator_canister : () -> (text);
+  start_subnet_orchestrator_canister : (principal) -> (Result_1);
   stop_upgrades_for_individual_user_canisters : () -> (Result);
   subnet_orchestrator_maxed_out : () -> ();
   update_canisters_last_functionality_access_time : () -> (Result);

--- a/src/canister/platform_orchestrator/src/api/canister_management/mod.rs
+++ b/src/canister/platform_orchestrator/src/api/canister_management/mod.rs
@@ -19,6 +19,7 @@ mod reinstall_yral_post_cache_canister;
 pub mod remove_subnet_orchestrator_from_available_list;
 pub mod report_subnet_upgrade_status;
 pub mod set_reserved_cycle_limit_for_subnet_orchestrator;
+pub mod start_subnet_orchestrator_canister;
 mod stop_upgrades_for_individual_user_canisters;
 mod subnet_orchestrator_maxed_out;
 mod update_canisters_last_access_time;

--- a/src/canister/platform_orchestrator/src/api/canister_management/start_subnet_orchestrator_canister.rs
+++ b/src/canister/platform_orchestrator/src/api/canister_management/start_subnet_orchestrator_canister.rs
@@ -1,0 +1,14 @@
+use crate::{
+    guard::is_caller::is_caller_global_admin_or_controller,
+    utils::registered_subnet_orchestrator::RegisteredSubnetOrchestrator,
+};
+use candid::Principal;
+use ic_cdk_macros::update;
+
+#[update(guard = "is_caller_global_admin_or_controller")]
+async fn start_subnet_orchestrator_canister(
+    subnet_orchestrator_canister_id: Principal,
+) -> Result<(), String> {
+    let subnet_orchestrator = RegisteredSubnetOrchestrator::new(subnet_orchestrator_canister_id)?;
+    subnet_orchestrator.start_canister().await
+}

--- a/src/canister/platform_orchestrator/src/utils/registered_subnet_orchestrator.rs
+++ b/src/canister/platform_orchestrator/src/utils/registered_subnet_orchestrator.rs
@@ -1,7 +1,7 @@
 use candid::{Nat, Principal};
 use ic_cdk::api::management_canister::main::{
-    canister_status, deposit_cycles, update_settings, CanisterIdRecord, CanisterSettings,
-    LogVisibility, UpdateSettingsArgument,
+    canister_status, deposit_cycles, start_canister, update_settings, CanisterIdRecord,
+    CanisterSettings, LogVisibility, UpdateSettingsArgument,
 };
 use shared_utils::{
     common::types::wasm::WasmType, constant::SUBNET_ORCHESTRATOR_CANISTER_CYCLES_THRESHOLD,
@@ -71,6 +71,14 @@ impl RegisteredSubnetOrchestrator {
 
     pub fn get_canister_id(&self) -> Principal {
         self.canister_id
+    }
+
+    pub async fn start_canister(&self) -> Result<(), String> {
+        start_canister(CanisterIdRecord {
+            canister_id: self.canister_id,
+        })
+        .await
+        .map_err(|e| e.1)
     }
 
     pub async fn deposit_cycles(&self) -> Result<(), String> {

--- a/src/lib/shared_utils/src/common/utils/upgrade_canister.rs
+++ b/src/lib/shared_utils/src/common/utils/upgrade_canister.rs
@@ -1,10 +1,15 @@
-use ic_cdk::api::{call::CallResult, management_canister::{main::{self, start_canister, stop_canister, InstallCodeArgument}, provisional::CanisterIdRecord}};
+use ic_cdk::api::{
+    call::CallResult,
+    management_canister::{
+        main::{self, start_canister, stop_canister, InstallCodeArgument},
+        provisional::CanisterIdRecord,
+    },
+};
 
-
-pub async fn upgrade_canister_util (arg: InstallCodeArgument) -> CallResult<()>{
+pub async fn upgrade_canister_util(arg: InstallCodeArgument) -> CallResult<()> {
     let canister_id = arg.canister_id;
-    stop_canister(CanisterIdRecord {canister_id}).await?;
-    main::install_code(arg).await?;
-    start_canister(CanisterIdRecord {canister_id}).await
+    stop_canister(CanisterIdRecord { canister_id }).await?;
+    let install_code_result = main::install_code(arg).await;
+    start_canister(CanisterIdRecord { canister_id }).await?;
+    install_code_result
 }
-


### PR DESCRIPTION
## Changes
- start the canister even if the upgrades fails.
- added method to start the subnet orchestrator canisters.