### PR TITLE
fix renqueue timers issue

### DIFF
--- a/src/canister/individual_user_template/src/api/hot_or_not_bet/reenqueue_timers_for_pending_bet_outcomes.rs
+++ b/src/canister/individual_user_template/src/api/hot_or_not_bet/reenqueue_timers_for_pending_bet_outcomes.rs
@@ -56,7 +56,7 @@ fn reenqueue_timers_for_these_posts(
                         .duration_since(*current_time)
                         .unwrap_or_default(),
                     move || {
-                        tabulate_hot_or_not_outcome_for_post_slot(post_id, slot_id);
+                        ic_cdk::spawn(tabulate_hot_or_not_outcome_for_post_slot(post_id, slot_id));
                     },
                 );
             })

--- a/src/canister/individual_user_template/src/api/hot_or_not_bet/reenqueue_timers_for_pending_bet_outcomes.rs
+++ b/src/canister/individual_user_template/src/api/hot_or_not_bet/reenqueue_timers_for_pending_bet_outcomes.rs
@@ -89,7 +89,10 @@ fn once_reenqueue_timers_for_these_posts(post_slot_ids: Vec<(u64, u8)>) {
             // random jitter
             Duration::from_secs(300),
             move || {
-                tabulate_hot_or_not_outcome_for_post_slot(post_id, slot_number);
+                ic_cdk::spawn(tabulate_hot_or_not_outcome_for_post_slot(
+                    post_id,
+                    slot_number,
+                ));
             },
         );
     }


### PR DESCRIPTION
## Changes

- use `ic_cdk::spawn` to reenqueue timers.