### PR TITLE
try stopping canister with retries

### DIFF
--- a/src/lib/shared_utils/src/common/utils/upgrade_canister.rs
+++ b/src/lib/shared_utils/src/common/utils/upgrade_canister.rs
@@ -1,3 +1,5 @@
+use candid::Principal;
+use futures::{future::BoxFuture, FutureExt};
 use ic_cdk::api::{
     call::CallResult,
     management_canister::{
@@ -8,8 +10,33 @@ use ic_cdk::api::{
 
 pub async fn upgrade_canister_util(arg: InstallCodeArgument) -> CallResult<()> {
     let canister_id = arg.canister_id;
-    stop_canister(CanisterIdRecord { canister_id }).await?;
+    try_stopping_canister_with_retries(canister_id, 3).await?;
     let install_code_result = main::install_code(arg).await;
     start_canister(CanisterIdRecord { canister_id }).await?;
     install_code_result
+}
+
+fn try_stopping_canister_with_retries(
+    canister_id: Principal,
+    max_retries: u64,
+) -> BoxFuture<'static, CallResult<()>> {
+    async move {
+        let stop_canister_result = stop_canister(CanisterIdRecord { canister_id }).await;
+
+        match stop_canister_result {
+            Ok(()) => Ok(()),
+            Err(e) => {
+                if max_retries == 0 {
+                    Box::pin(try_stopping_canister_with_retries(
+                        canister_id,
+                        max_retries - 1,
+                    ))
+                    .await
+                } else {
+                    Err(e)
+                }
+            }
+        }
+    }
+    .boxed()
 }

--- a/src/lib/shared_utils/src/common/utils/upgrade_canister.rs
+++ b/src/lib/shared_utils/src/common/utils/upgrade_canister.rs
@@ -26,7 +26,7 @@ fn try_stopping_canister_with_retries(
         match stop_canister_result {
             Ok(()) => Ok(()),
             Err(e) => {
-                if max_retries == 0 {
+                if max_retries > 0 {
                     Box::pin(try_stopping_canister_with_retries(
                         canister_id,
                         max_retries - 1,


### PR DESCRIPTION
## Motivation

`stop_canister` does not always guarantee stopping canister we need to perform retries to stop a canister before performing upgrades.


