### PR TITLE
add methods to upgrade specific individual canister with wasm version

### DIFF
--- a/src/canister/individual_user_template/src/api/canister_lifecycle/post_upgrade.rs
+++ b/src/canister/individual_user_template/src/api/canister_lifecycle/post_upgrade.rs
@@ -74,10 +74,6 @@ fn save_upgrade_args_to_memory() {
             canister_data_ref_cell.known_principal_ids = known_principal_ids;
         }
 
-        if let Some(profile_owner) = upgrade_args.profile_owner {
-            canister_data_ref_cell.profile.principal_id = Some(profile_owner);
-        }
-
         if let Some(upgrade_version_number) = upgrade_args.upgrade_version_number {
             canister_data_ref_cell.version_details.version_number = upgrade_version_number;
         }

--- a/src/canister/individual_user_template/src/api/hot_or_not_bet/tabulate_hot_or_not_outcome_for_post_slot.rs
+++ b/src/canister/individual_user_template/src/api/hot_or_not_bet/tabulate_hot_or_not_outcome_for_post_slot.rs
@@ -218,7 +218,7 @@ async fn receive_bet_winnings_when_distributed(
         ic_cdk::println!(
             "Informing bet maker canister {} failed {:?}",
             bet_maker_canister_id,
-            e.1
+            e
         );
     }
 

--- a/src/canister/platform_orchestrator/can.did
+++ b/src/canister/platform_orchestrator/can.did
@@ -156,6 +156,12 @@ service : (PlatformOrchestratorInitArgs) -> {
       Result,
     );
   upgrade_specific_individual_canister : (principal) -> ();
+  upgrade_specific_individual_canister_with_version : (principal, text) -> (
+      Result,
+    );
+  upgrade_specific_individual_canister_with_wasm : (principal, text, blob) -> (
+      Result,
+    );
   upgrade_subnet_orchestrator_canister_with_latest_wasm : (principal) -> (
       Result,
     );

--- a/src/canister/platform_orchestrator/src/api/canister_management/delete_all_sns_creator_token_in_the_network.rs
+++ b/src/canister/platform_orchestrator/src/api/canister_management/delete_all_sns_creator_token_in_the_network.rs
@@ -2,11 +2,11 @@ use ic_cdk_macros::update;
 use shared_utils::common::utils::task::run_task_concurrently;
 
 use crate::{
-    guard::is_caller::is_caller_global_admin_or_controller,
+    guard::is_caller::is_caller_platform_global_admin_or_controller,
     utils::registered_subnet_orchestrator::RegisteredSubnetOrchestrator, CANISTER_DATA,
 };
 
-#[update(guard = "is_caller_global_admin_or_controller")]
+#[update(guard = "is_caller_platform_global_admin_or_controller")]
 pub async fn delete_all_sns_creator_token_in_the_network() {
     let subnet_orchestrator_canister_ids = CANISTER_DATA
         .with_borrow(|canister_data| canister_data.all_subnet_orchestrator_canisters_list.clone());

--- a/src/canister/platform_orchestrator/src/api/canister_management/delete_all_sns_creator_token_of_an_individual_canister.rs
+++ b/src/canister/platform_orchestrator/src/api/canister_management/delete_all_sns_creator_token_of_an_individual_canister.rs
@@ -3,11 +3,11 @@ use ic_cdk::api::management_canister::main::{canister_info, CanisterInfoRequest}
 use ic_cdk_macros::update;
 
 use crate::{
-    guard::is_caller::is_caller_global_admin_or_controller,
+    guard::is_caller::is_caller_platform_global_admin_or_controller,
     utils::registered_subnet_orchestrator::RegisteredSubnetOrchestrator,
 };
 
-#[update(guard = "is_caller_global_admin_or_controller")]
+#[update(guard = "is_caller_platform_global_admin_or_controller")]
 pub async fn delete_all_sns_creator_token_of_an_individual_canister(
     individual_canister_id: Principal,
 ) -> Result<(), String> {

--- a/src/canister/platform_orchestrator/src/api/canister_management/deregister_subnet_orchestrator.rs
+++ b/src/canister/platform_orchestrator/src/api/canister_management/deregister_subnet_orchestrator.rs
@@ -1,9 +1,9 @@
 use candid::Principal;
 use ic_cdk_macros::update;
 
-use crate::{guard::is_caller::is_caller_global_admin_or_controller, CANISTER_DATA};
+use crate::{guard::is_caller::is_caller_platform_global_admin_or_controller, CANISTER_DATA};
 
-#[update(guard = "is_caller_global_admin_or_controller")]
+#[update(guard = "is_caller_platform_global_admin_or_controller")]
 fn deregister_subnet_orchestrator(canister_id: Principal, remove_it_completely: bool) {
     CANISTER_DATA.with_borrow_mut(|canister_data| {
         canister_data

--- a/src/canister/platform_orchestrator/src/api/canister_management/fixup_individual_cainsters_in_the_network.rs
+++ b/src/canister/platform_orchestrator/src/api/canister_management/fixup_individual_cainsters_in_the_network.rs
@@ -1,16 +1,33 @@
 use ic_cdk_macros::update;
 use shared_utils::common::utils::task::run_task_concurrently;
 
-use crate::{guard::is_caller::is_caller_global_admin_or_controller, utils::registered_subnet_orchestrator::RegisteredSubnetOrchestrator, CANISTER_DATA};
+use crate::{
+    guard::is_caller::is_caller_platform_global_admin_or_controller,
+    utils::registered_subnet_orchestrator::RegisteredSubnetOrchestrator, CANISTER_DATA,
+};
 
-
-#[update(guard = "is_caller_global_admin_or_controller")]
+#[update(guard = "is_caller_platform_global_admin_or_controller")]
 async fn fixup_individual_cainsters_in_thebreaking_condition_network() {
-    let subnet_orchestrators = CANISTER_DATA.with_borrow(|canister_data| canister_data.all_subnet_orchestrator_canisters_list.clone().into_iter());
-    let fixup_individual_canisters_in_subnet_futures = subnet_orchestrators.map(|subnet_orchestrator| async move {
-        let registered_subnetorchestrator = RegisteredSubnetOrchestrator::new(subnet_orchestrator)?;
-        registered_subnetorchestrator.fixup_individual_cansiters_mapping().await
+    let subnet_orchestrators = CANISTER_DATA.with_borrow(|canister_data| {
+        canister_data
+            .all_subnet_orchestrator_canisters_list
+            .clone()
+            .into_iter()
     });
+    let fixup_individual_canisters_in_subnet_futures =
+        subnet_orchestrators.map(|subnet_orchestrator| async move {
+            let registered_subnetorchestrator =
+                RegisteredSubnetOrchestrator::new(subnet_orchestrator)?;
+            registered_subnetorchestrator
+                .fixup_individual_cansiters_mapping()
+                .await
+        });
 
-    run_task_concurrently(fixup_individual_canisters_in_subnet_futures, 10, |_| {}, || false).await;
+    run_task_concurrently(
+        fixup_individual_canisters_in_subnet_futures,
+        10,
+        |_| {},
+        || false,
+    )
+    .await;
 }

--- a/src/canister/platform_orchestrator/src/api/canister_management/fixup_individual_canisters_in_a_subnet.rs
+++ b/src/canister/platform_orchestrator/src/api/canister_management/fixup_individual_canisters_in_a_subnet.rs
@@ -1,12 +1,18 @@
 use candid::Principal;
 use ic_cdk::update;
 
-use crate::{guard::is_caller::is_caller_global_admin_or_controller, utils::registered_subnet_orchestrator::RegisteredSubnetOrchestrator};
+use crate::{
+    guard::is_caller::is_caller_platform_global_admin_or_controller,
+    utils::registered_subnet_orchestrator::RegisteredSubnetOrchestrator,
+};
 
-#[update(guard = "is_caller_global_admin_or_controller")]
-async fn fixup_individual_canisters_in_a_subnet(subnet_orchestrator: Principal) -> Result<(), String>{
+#[update(guard = "is_caller_platform_global_admin_or_controller")]
+async fn fixup_individual_canisters_in_a_subnet(
+    subnet_orchestrator: Principal,
+) -> Result<(), String> {
     let resgistered_subnet_orchestrator = RegisteredSubnetOrchestrator::new(subnet_orchestrator)?;
 
-    resgistered_subnet_orchestrator.fixup_individual_cansiters_mapping().await
-
+    resgistered_subnet_orchestrator
+        .fixup_individual_cansiters_mapping()
+        .await
 }

--- a/src/canister/platform_orchestrator/src/api/canister_management/global_admin.rs
+++ b/src/canister/platform_orchestrator/src/api/canister_management/global_admin.rs
@@ -1,17 +1,14 @@
 use candid::Principal;
-use ic_cdk_macros::{update, query};
+use ic_cdk_macros::{query, update};
 
-use crate::{guard::is_caller::is_caller_global_admin_or_controller, CANISTER_DATA};
+use crate::{guard::is_caller::is_caller_platform_global_admin_or_controller, CANISTER_DATA};
 
-#[update(guard= "is_caller_global_admin_or_controller")]
+#[update(guard = "is_caller_platform_global_admin_or_controller")]
 fn add_principal_as_global_admin(id: Principal) {
-    CANISTER_DATA.with_borrow_mut(|canister_data| {
-        canister_data.platform_global_admins.insert(id)
-    });
+    CANISTER_DATA.with_borrow_mut(|canister_data| canister_data.platform_global_admins.insert(id));
 }
 
-
-#[update(guard = "is_caller_global_admin_or_controller")]
+#[update(guard = "is_caller_platform_global_admin_or_controller")]
 fn remove_principal_from_global_admins(id: Principal) {
     CANISTER_DATA.with_borrow_mut(|canister_data| {
         canister_data.platform_global_admins.remove(&id);
@@ -21,6 +18,10 @@ fn remove_principal_from_global_admins(id: Principal) {
 #[query]
 fn get_all_global_admins() -> Vec<Principal> {
     CANISTER_DATA.with_borrow_mut(|canister_data| {
-        canister_data.platform_global_admins.clone().into_iter().collect()
+        canister_data
+            .platform_global_admins
+            .clone()
+            .into_iter()
+            .collect()
     })
 }

--- a/src/canister/platform_orchestrator/src/api/canister_management/known_principal.rs
+++ b/src/canister/platform_orchestrator/src/api/canister_management/known_principal.rs
@@ -5,7 +5,7 @@ use shared_utils::common::{
     types::known_principal::KnownPrincipalType, utils::task::run_task_concurrently,
 };
 
-use crate::{guard::is_caller::is_caller_global_admin_or_controller, CANISTER_DATA};
+use crate::{guard::is_caller::is_caller_platform_global_admin_or_controller, CANISTER_DATA};
 
 #[query]
 fn get_global_known_principal(known_principal_type: KnownPrincipalType) -> Principal {
@@ -28,7 +28,7 @@ fn get_subnet_known_principal(
     })
 }
 
-#[update(guard = "is_caller_global_admin_or_controller")]
+#[update(guard = "is_caller_platform_global_admin_or_controller")]
 fn update_global_known_principal(
     known_principal_type: KnownPrincipalType,
     value: Principal,
@@ -47,7 +47,7 @@ fn update_global_known_principal(
     Ok("Success".into())
 }
 
-#[update(guard = "is_caller_global_admin_or_controller")]
+#[update(guard = "is_caller_platform_global_admin_or_controller")]
 async fn update_subnet_known_principal(
     subnet_id: Principal,
     know_principal_type: KnownPrincipalType,

--- a/src/canister/platform_orchestrator/src/api/canister_management/logging/make_individual_canister_logs_public.rs
+++ b/src/canister/platform_orchestrator/src/api/canister_management/logging/make_individual_canister_logs_public.rs
@@ -3,11 +3,11 @@ use ic_cdk::api::management_canister::main::{canister_info, CanisterInfoRequest}
 use ic_cdk_macros::update;
 
 use crate::{
-    guard::is_caller::is_caller_global_admin_or_controller,
+    guard::is_caller::is_caller_platform_global_admin_or_controller,
     utils::registered_subnet_orchestrator::RegisteredSubnetOrchestrator,
 };
 
-#[update(guard = "is_caller_global_admin_or_controller")]
+#[update(guard = "is_caller_platform_global_admin_or_controller")]
 pub async fn make_individual_canister_logs_public(
     individual_canister_id: Principal,
 ) -> Result<(), String> {

--- a/src/canister/platform_orchestrator/src/api/canister_management/logging/make_subnet_orchestrator_logs_private.rs
+++ b/src/canister/platform_orchestrator/src/api/canister_management/logging/make_subnet_orchestrator_logs_private.rs
@@ -1,11 +1,11 @@
 use candid::Principal;
 
 use crate::{
-    guard::is_caller::is_caller_global_admin_or_controller,
+    guard::is_caller::is_caller_platform_global_admin_or_controller,
     utils::registered_subnet_orchestrator::RegisteredSubnetOrchestrator,
 };
 
-#[ic_cdk_macros::update(guard = "is_caller_global_admin_or_controller")]
+#[ic_cdk_macros::update(guard = "is_caller_platform_global_admin_or_controller")]
 async fn make_subnet_orchestrator_logs_private(canister_id: Principal) -> Result<(), String> {
     let registered_subnet_orchestrator = RegisteredSubnetOrchestrator::new(canister_id)?;
     registered_subnet_orchestrator.make_logs_private().await

--- a/src/canister/platform_orchestrator/src/api/canister_management/logging/make_subnet_orchestrator_logs_public.rs
+++ b/src/canister/platform_orchestrator/src/api/canister_management/logging/make_subnet_orchestrator_logs_public.rs
@@ -1,11 +1,11 @@
 use candid::Principal;
 
 use crate::{
-    guard::is_caller::is_caller_global_admin_or_controller,
+    guard::is_caller::is_caller_platform_global_admin_or_controller,
     utils::registered_subnet_orchestrator::RegisteredSubnetOrchestrator,
 };
 
-#[ic_cdk_macros::update(guard = "is_caller_global_admin_or_controller")]
+#[ic_cdk_macros::update(guard = "is_caller_platform_global_admin_or_controller")]
 async fn make_subnet_orchestrator_logs_public(canister_id: Principal) -> Result<(), String> {
     let registered_subnet_orchestrator = RegisteredSubnetOrchestrator::new(canister_id)?;
     registered_subnet_orchestrator.make_logs_public().await

--- a/src/canister/platform_orchestrator/src/api/canister_management/mod.rs
+++ b/src/canister/platform_orchestrator/src/api/canister_management/mod.rs
@@ -34,6 +34,8 @@ pub mod upgrade_all_creator_dao_governance_canisters_in_the_network;
 pub mod upgrade_canisters_in_network;
 mod upgrade_individual_canisters_in_a_subnet_with_latest_wasm;
 mod upgrade_specific_individual_canister;
+mod upgrade_specific_individual_canister_with_version;
+mod upgrade_specific_individual_canister_with_wasm;
 pub mod upgrade_subnet_orchestrator_canister_with_latest_wasm;
 pub mod upload_wasms;
 

--- a/src/canister/platform_orchestrator/src/api/canister_management/notify_specific_individual_canister_to_upgrade_creator_dao_governance_canisters.rs
+++ b/src/canister/platform_orchestrator/src/api/canister_management/notify_specific_individual_canister_to_upgrade_creator_dao_governance_canisters.rs
@@ -3,11 +3,11 @@ use ic_cdk::api::management_canister::main::{canister_info, CanisterInfoRequest}
 use ic_cdk_macros::update;
 
 use crate::{
-    guard::is_caller::is_caller_global_admin_or_controller,
+    guard::is_caller::is_caller_platform_global_admin_or_controller,
     utils::registered_subnet_orchestrator::RegisteredSubnetOrchestrator,
 };
 
-#[update(guard = "is_caller_global_admin_or_controller")]
+#[update(guard = "is_caller_platform_global_admin_or_controller")]
 pub async fn notify_specific_individual_canister_to_upgrade_creator_dao_governance_canisters(
     individual_canister_id: Principal,
     wasm_module: Vec<u8>,

--- a/src/canister/platform_orchestrator/src/api/canister_management/populate_known_principal_for_all_subnet.rs
+++ b/src/canister/platform_orchestrator/src/api/canister_management/populate_known_principal_for_all_subnet.rs
@@ -5,21 +5,33 @@ use ic_cdk::call;
 use ic_cdk_macros::update;
 use shared_utils::common::types::known_principal::{self, KnownPrincipalMap, KnownPrincipalType};
 
-use crate::{guard::is_caller::is_caller_global_admin_or_controller, CANISTER_DATA};
+use crate::{guard::is_caller::is_caller_platform_global_admin_or_controller, CANISTER_DATA};
 
-#[update(guard = "is_caller_global_admin_or_controller")]
+#[update(guard = "is_caller_platform_global_admin_or_controller")]
 async fn populate_known_principal_for_all_subnet() {
     let subnet_orchestrators: Vec<Principal> = CANISTER_DATA.with_borrow(|canister_data| {
-        canister_data.all_subnet_orchestrator_canisters_list.iter().copied().collect()
+        canister_data
+            .all_subnet_orchestrator_canisters_list
+            .iter()
+            .copied()
+            .collect()
     });
 
     for subnet_id in subnet_orchestrators {
-        let (subnet_known_principals,): (Vec<(KnownPrincipalType, Principal)>, )= call(subnet_id, "get_current_list_of_all_well_known_principal_values", ()).await.unwrap();
-        let subnet_known_principal_map: KnownPrincipalMap = subnet_known_principals.into_iter().collect();
+        let (subnet_known_principals,): (Vec<(KnownPrincipalType, Principal)>,) = call(
+            subnet_id,
+            "get_current_list_of_all_well_known_principal_values",
+            (),
+        )
+        .await
+        .unwrap();
+        let subnet_known_principal_map: KnownPrincipalMap =
+            subnet_known_principals.into_iter().collect();
         CANISTER_DATA.with_borrow_mut(|canister_data| {
-            canister_data.known_principals.subnet_orchestrator_known_principals_map.insert(subnet_id, subnet_known_principal_map)
+            canister_data
+                .known_principals
+                .subnet_orchestrator_known_principals_map
+                .insert(subnet_id, subnet_known_principal_map)
         });
-
     }
-
 }

--- a/src/canister/platform_orchestrator/src/api/canister_management/provision_empty_canisters_in_a_subnet.rs
+++ b/src/canister/platform_orchestrator/src/api/canister_management/provision_empty_canisters_in_a_subnet.rs
@@ -2,11 +2,11 @@ use candid::Principal;
 use ic_cdk_macros::update;
 
 use crate::{
-    guard::is_caller::is_caller_global_admin_or_controller,
+    guard::is_caller::is_caller_platform_global_admin_or_controller,
     utils::registered_subnet_orchestrator::RegisteredSubnetOrchestrator,
 };
 
-#[update(guard = "is_caller_global_admin_or_controller")]
+#[update(guard = "is_caller_platform_global_admin_or_controller")]
 async fn provision_empty_canisters_in_a_subnet(
     subnet_orchestrator_canister_id: Principal,
     number_of_canisters: u64,

--- a/src/canister/platform_orchestrator/src/api/canister_management/provision_subnet_orchestrator.rs
+++ b/src/canister/platform_orchestrator/src/api/canister_management/provision_subnet_orchestrator.rs
@@ -1,7 +1,8 @@
 use candid::{CandidType, Principal};
 use ic_cdk::{
     api::{
-        self, call, management_canister::{
+        self, call,
+        management_canister::{
             main::{self, CanisterInstallMode, InstallCodeArgument},
             provisional::CanisterSettings,
         },
@@ -12,18 +13,15 @@ use ic_cdk_macros::update;
 use serde::{Deserialize, Serialize};
 use shared_utils::{
     canister_specific::user_index::types::args::UserIndexInitArgs,
-    common::types::{
-        known_principal::KnownPrincipalType,
-        wasm::WasmType,
-    },
+    common::types::{known_principal::KnownPrincipalType, wasm::WasmType},
     constant::{
         GLOBAL_SUPER_ADMIN_USER_ID, NNS_CYCLE_MINTING_CANISTER,
-        SUBNET_ORCHESTRATOR_CANISTER_INITIAL_CYCLES, 
+        SUBNET_ORCHESTRATOR_CANISTER_INITIAL_CYCLES,
     },
 };
 use std::{str::FromStr, vec};
 
-use crate::{guard::is_caller::is_caller_global_admin_or_controller, CANISTER_DATA};
+use crate::{guard::is_caller::is_caller_platform_global_admin_or_controller, CANISTER_DATA};
 
 #[derive(CandidType, Serialize)]
 enum SubnetType {
@@ -55,7 +53,7 @@ struct CreateCanisterCmcArgument {
     subnet_type: Option<String>,
 }
 
-#[update(guard = "is_caller_global_admin_or_controller")]
+#[update(guard = "is_caller_platform_global_admin_or_controller")]
 pub async fn provision_subnet_orchestrator_canister(
     subnet: Principal,
 ) -> Result<Principal, String> {

--- a/src/canister/platform_orchestrator/src/api/canister_management/pump_dump.rs
+++ b/src/canister/platform_orchestrator/src/api/canister_management/pump_dump.rs
@@ -2,9 +2,9 @@ use candid::Nat;
 use futures::{stream, StreamExt};
 use ic_cdk::update;
 
-use crate::{CANISTER_DATA, guard::is_caller::is_caller_global_admin_or_controller};
+use crate::{guard::is_caller::is_caller_platform_global_admin_or_controller, CANISTER_DATA};
 
-#[update(guard = "is_caller_global_admin_or_controller")]
+#[update(guard = "is_caller_platform_global_admin_or_controller")]
 pub fn update_pd_onboarding_reward_for_all_subnets(new_reward: Nat) -> Result<(), String> {
     let mut update_futs = CANISTER_DATA.with_borrow(|cdata| {
         let update_futs = cdata
@@ -15,7 +15,7 @@ pub fn update_pd_onboarding_reward_for_all_subnets(new_reward: Nat) -> Result<()
                 ic_cdk::call::<_, ()>(
                     can,
                     "update_pd_onboarding_reward_for_all_individual_users",
-                    (new_reward.clone(),)
+                    (new_reward.clone(),),
                 )
             });
         let stream = stream::iter(update_futs);

--- a/src/canister/platform_orchestrator/src/api/canister_management/register_new_subnet_orhestrator.rs
+++ b/src/canister/platform_orchestrator/src/api/canister_management/register_new_subnet_orhestrator.rs
@@ -7,9 +7,9 @@ use ic_cdk_macros::update;
 use ic_stable_structures::Storable;
 use shared_utils::common::types::wasm::WasmType;
 
-use crate::{guard::is_caller::is_caller_global_admin_or_controller, CANISTER_DATA};
+use crate::{guard::is_caller::is_caller_platform_global_admin_or_controller, CANISTER_DATA};
 
-#[update(guard = "is_caller_global_admin_or_controller")]
+#[update(guard = "is_caller_platform_global_admin_or_controller")]
 async fn register_new_subnet_orchestrator(
     new_subnet_orchestrator_caniter_id: Principal,
     subnet_is_available_for_provisioning_individual_canister: bool,

--- a/src/canister/platform_orchestrator/src/api/canister_management/remove_subnet_orchestrator_from_available_list.rs
+++ b/src/canister/platform_orchestrator/src/api/canister_management/remove_subnet_orchestrator_from_available_list.rs
@@ -1,15 +1,18 @@
+use crate::{guard::is_caller::is_caller_platform_global_admin_or_controller, CANISTER_DATA};
 use candid::Principal;
 use ic_cdk_macros::update;
-use crate::{guard::is_caller::is_caller_global_admin_or_controller, CANISTER_DATA};
 
-
-#[update(guard = "is_caller_global_admin_or_controller")]
-pub fn remove_subnet_orchestrators_from_available_list(subnet_orchestrator: Principal) -> Result<String, String> {
+#[update(guard = "is_caller_platform_global_admin_or_controller")]
+pub fn remove_subnet_orchestrators_from_available_list(
+    subnet_orchestrator: Principal,
+) -> Result<String, String> {
     CANISTER_DATA.with_borrow_mut(|canister_data| {
-        let remove_result = canister_data.subet_orchestrator_with_capacity_left.remove(&subnet_orchestrator);
+        let remove_result = canister_data
+            .subet_orchestrator_with_capacity_left
+            .remove(&subnet_orchestrator);
         match remove_result {
             true => Ok("Success".into()),
-            false => Err("Subnet not found in available list".into())
+            false => Err("Subnet not found in available list".into()),
         }
-    })    
+    })
 }

--- a/src/canister/platform_orchestrator/src/api/canister_management/reset_canisters_ml_feed_cache.rs
+++ b/src/canister/platform_orchestrator/src/api/canister_management/reset_canisters_ml_feed_cache.rs
@@ -1,9 +1,9 @@
 use ic_cdk::{api::call::CallResult, call};
 use ic_cdk_macros::update;
 
-use crate::{guard::is_caller::is_caller_global_admin_or_controller, CANISTER_DATA};
+use crate::{guard::is_caller::is_caller_platform_global_admin_or_controller, CANISTER_DATA};
 
-#[update(guard = "is_caller_global_admin_or_controller")]
+#[update(guard = "is_caller_platform_global_admin_or_controller")]
 async fn reset_canisters_ml_feed_cache() -> Result<String, String> {
     let subnet_orchestrator_list = CANISTER_DATA
         .with_borrow(|canister_data| canister_data.all_subnet_orchestrator_canisters_list.clone());

--- a/src/canister/platform_orchestrator/src/api/canister_management/set_reserved_cycle_limit_for_subnet_orchestrator.rs
+++ b/src/canister/platform_orchestrator/src/api/canister_management/set_reserved_cycle_limit_for_subnet_orchestrator.rs
@@ -2,11 +2,11 @@ use candid::Principal;
 use ic_cdk_macros::update;
 
 use crate::{
-    guard::is_caller::is_caller_global_admin_or_controller,
+    guard::is_caller::is_caller_platform_global_admin_or_controller,
     utils::registered_subnet_orchestrator::RegisteredSubnetOrchestrator,
 };
 
-#[update(guard = "is_caller_global_admin_or_controller")]
+#[update(guard = "is_caller_platform_global_admin_or_controller")]
 async fn set_reserved_cycle_limit_for_subnet_orchestrator(
     subnet_orchestrator_canister_id: Principal,
     amount: u128,

--- a/src/canister/platform_orchestrator/src/api/canister_management/start_subnet_orchestrator_canister.rs
+++ b/src/canister/platform_orchestrator/src/api/canister_management/start_subnet_orchestrator_canister.rs
@@ -1,11 +1,11 @@
 use crate::{
-    guard::is_caller::is_caller_global_admin_or_controller,
+    guard::is_caller::is_caller_platform_global_admin_or_controller,
     utils::registered_subnet_orchestrator::RegisteredSubnetOrchestrator,
 };
 use candid::Principal;
 use ic_cdk_macros::update;
 
-#[update(guard = "is_caller_global_admin_or_controller")]
+#[update(guard = "is_caller_platform_global_admin_or_controller")]
 async fn start_subnet_orchestrator_canister(
     subnet_orchestrator_canister_id: Principal,
 ) -> Result<(), String> {

--- a/src/canister/platform_orchestrator/src/api/canister_management/stop_upgrades_for_individual_user_canisters.rs
+++ b/src/canister/platform_orchestrator/src/api/canister_management/stop_upgrades_for_individual_user_canisters.rs
@@ -1,18 +1,29 @@
-use ic_cdk::{api::{call::CallResult, is_controller}, call, caller};
+use ic_cdk::{
+    api::{call::CallResult, is_controller},
+    call, caller,
+};
 use ic_cdk_macros::update;
 
-use crate::{guard::is_caller::is_caller_global_admin_or_controller, CANISTER_DATA};
+use crate::{guard::is_caller::is_caller_platform_global_admin_or_controller, CANISTER_DATA};
 
-#[update(guard = "is_caller_global_admin_or_controller")]
+#[update(guard = "is_caller_platform_global_admin_or_controller")]
 async fn stop_upgrades_for_individual_user_canisters() -> Result<String, String> {
-
-    let subnet_orchestrator_list = CANISTER_DATA.with_borrow(|canister_data| {
-        canister_data.all_subnet_orchestrator_canisters_list.clone()
-    });
+    let subnet_orchestrator_list = CANISTER_DATA
+        .with_borrow(|canister_data| canister_data.all_subnet_orchestrator_canisters_list.clone());
 
     for subnet_orchestrator in subnet_orchestrator_list {
-        let result: CallResult<()> = call(subnet_orchestrator, "set_permission_to_upgrade_individual_canisters", (false, )).await;
-        result.map_err(|e| format!("failed to stop upgrades for {} {}", subnet_orchestrator, e.1))?;
+        let result: CallResult<()> = call(
+            subnet_orchestrator,
+            "set_permission_to_upgrade_individual_canisters",
+            (false,),
+        )
+        .await;
+        result.map_err(|e| {
+            format!(
+                "failed to stop upgrades for {} {}",
+                subnet_orchestrator, e.1
+            )
+        })?;
     }
 
     Ok("Success".into())

--- a/src/canister/platform_orchestrator/src/api/canister_management/update_timers_for_hon_game.rs
+++ b/src/canister/platform_orchestrator/src/api/canister_management/update_timers_for_hon_game.rs
@@ -1,20 +1,16 @@
 use ic_cdk::{api::call::CallResult, call};
 use ic_cdk_macros::update;
 
-use crate::{guard::is_caller::is_caller_global_admin_or_controller, CANISTER_DATA};
+use crate::{guard::is_caller::is_caller_platform_global_admin_or_controller, CANISTER_DATA};
 
-#[update(guard = "is_caller_global_admin_or_controller")]
+#[update(guard = "is_caller_platform_global_admin_or_controller")]
 async fn update_restart_timers_hon_game() -> Result<String, String> {
     let subnet_orchestrator_list = CANISTER_DATA
         .with_borrow(|canister_data| canister_data.all_subnet_orchestrator_canisters_list.clone());
 
     for subnet_orchestrator in subnet_orchestrator_list {
-        let result: CallResult<()> = call(
-            subnet_orchestrator,
-            "update_restart_timers_hon_game",
-            (),
-        )
-        .await;
+        let result: CallResult<()> =
+            call(subnet_orchestrator, "update_restart_timers_hon_game", ()).await;
         result.map_err(|e| {
             format!(
                 "failed to call update_restart_timers_hon_game for {} {}",

--- a/src/canister/platform_orchestrator/src/api/canister_management/upgrade_all_creator_dao_governance_canisters_in_the_network.rs
+++ b/src/canister/platform_orchestrator/src/api/canister_management/upgrade_all_creator_dao_governance_canisters_in_the_network.rs
@@ -1,9 +1,9 @@
 use ic_cdk_macros::update;
 use shared_utils::common::{types::wasm, utils::task::run_task_concurrently};
 
-use crate::{guard::is_caller::is_caller_global_admin_or_controller, CANISTER_DATA};
+use crate::{guard::is_caller::is_caller_platform_global_admin_or_controller, CANISTER_DATA};
 
-#[update(guard = "is_caller_global_admin_or_controller")]
+#[update(guard = "is_caller_platform_global_admin_or_controller")]
 pub fn upgrade_all_creator_dao_governance_canisters_in_the_network(wasm_module: Vec<u8>) {
     let subnet_orchestrators = CANISTER_DATA
         .with_borrow(|canister_data| canister_data.all_subnet_orchestrator_canisters_list.clone());

--- a/src/canister/platform_orchestrator/src/api/canister_management/upgrade_canisters_in_network.rs
+++ b/src/canister/platform_orchestrator/src/api/canister_management/upgrade_canisters_in_network.rs
@@ -10,12 +10,12 @@ use shared_utils::{
 
 use crate::{
     data_model::CanisterUpgradeStatus,
-    guard::is_caller::is_caller_global_admin_or_controller,
+    guard::is_caller::is_caller_platform_global_admin_or_controller,
     utils::{recharge_and_upgrade_subnet_orchestrator, recharge_subnet_orchestrator_if_needed},
     CANISTER_DATA,
 };
 
-#[update(guard = "is_caller_global_admin_or_controller")]
+#[update(guard = "is_caller_platform_global_admin_or_controller")]
 pub async fn upgrade_canisters_in_network(
     upgrade_arg: UpgradeCanisterArg,
 ) -> Result<String, String> {
@@ -84,6 +84,13 @@ async fn upgrade_individual_canisters(upgrade_arg: UpgradeCanisterArg) {
             canister_data.last_subnet_canister_upgrade_status.count += 1;
         })
     }
+
+    CANISTER_DATA.with_borrow_mut(|canister_data| {
+        canister_data
+            .subnet_canister_upgrade_log
+            .append(&canister_data.last_subnet_canister_upgrade_status)
+            .expect("Could not write into subnet upgrade log");
+    });
 }
 
 async fn upgrade_subnet_canisters(upgrade_arg: UpgradeCanisterArg) {

--- a/src/canister/platform_orchestrator/src/api/canister_management/upgrade_individual_canisters_in_a_subnet_with_latest_wasm.rs
+++ b/src/canister/platform_orchestrator/src/api/canister_management/upgrade_individual_canisters_in_a_subnet_with_latest_wasm.rs
@@ -2,11 +2,11 @@ use candid::Principal;
 use ic_cdk_macros::update;
 
 use crate::{
-    guard::is_caller::is_caller_global_admin_or_controller,
+    guard::is_caller::is_caller_platform_global_admin_or_controller,
     utils::registered_subnet_orchestrator::RegisteredSubnetOrchestrator,
 };
 
-#[update(guard = "is_caller_global_admin_or_controller")]
+#[update(guard = "is_caller_platform_global_admin_or_controller")]
 async fn upgrade_individual_canisters_in_a_subnet_with_latest_wasm(
     subnet_orchestrator_canister_id: Principal,
 ) -> Result<(), String> {

--- a/src/canister/platform_orchestrator/src/api/canister_management/upgrade_specific_individual_canister.rs
+++ b/src/canister/platform_orchestrator/src/api/canister_management/upgrade_specific_individual_canister.rs
@@ -1,13 +1,19 @@
+use crate::{guard::is_caller::is_caller_platform_global_admin_or_controller, CANISTER_DATA};
 use candid::Principal;
 use ic_cdk_macros::update;
-use crate::{guard::is_caller::is_caller_global_admin_or_controller, CANISTER_DATA}; 
 
-
-#[update(guard = "is_caller_global_admin_or_controller")]
+#[update(guard = "is_caller_platform_global_admin_or_controller")]
 fn upgrade_specific_individual_canister(individual_canister_id: Principal) {
     CANISTER_DATA.with_borrow(|canister_data| {
-        canister_data.all_subnet_orchestrator_canisters_list.iter().for_each(|subnet_id| {
-            let _ = ic_cdk::notify(*subnet_id, "upgrade_specific_individual_user_canister_with_latest_wasm", (individual_canister_id, ));
-        })
+        canister_data
+            .all_subnet_orchestrator_canisters_list
+            .iter()
+            .for_each(|subnet_id| {
+                let _ = ic_cdk::notify(
+                    *subnet_id,
+                    "upgrade_specific_individual_user_canister_with_latest_wasm",
+                    (individual_canister_id,),
+                );
+            })
     })
-}   
+}

--- a/src/canister/platform_orchestrator/src/api/canister_management/upgrade_specific_individual_canister_with_version.rs
+++ b/src/canister/platform_orchestrator/src/api/canister_management/upgrade_specific_individual_canister_with_version.rs
@@ -1,0 +1,67 @@
+use std::error::Error;
+
+use candid::Principal;
+use ic_cdk::api::management_canister::main::{canister_info, CanisterInfoRequest};
+use ic_cdk_macros::update;
+use shared_utils::common::types::wasm::WasmType;
+
+use crate::{
+    guard::is_caller::is_caller_platform_global_admin_or_controller,
+    utils::registered_subnet_orchestrator::RegisteredSubnetOrchestrator, CANISTER_DATA,
+};
+
+#[update(guard = "is_caller_platform_global_admin_or_controller")]
+async fn upgrade_specific_individual_canister_with_version(
+    individual_canister_id: Principal,
+    version: String,
+) -> Result<(), String> {
+    upgrade_individual_canister_to_particular_version_impl(individual_canister_id, &version)
+        .await
+        .map_err(|e| e.to_string())
+}
+
+pub async fn upgrade_individual_canister_to_particular_version_impl(
+    individual_canister_id: Principal,
+    version: &str,
+) -> Result<(), Box<dyn Error>> {
+    let individual_canister_info = canister_info(CanisterInfoRequest {
+        canister_id: individual_canister_id,
+        num_requested_changes: None,
+    })
+    .await
+    .map_err(|e| -> Box<dyn Error> { format!("{:?} {}", e.0, e.1).into() })?
+    .0;
+
+    let registered_subnet_orchestrator =
+        RegisteredSubnetOrchestrator::new(individual_canister_info.controllers[0])?;
+
+    let wasm = CANISTER_DATA.with_borrow(|canister_data| {
+        let wasm_blob = canister_data
+            .subnet_canister_upgrade_log
+            .iter()
+            .find(|canister_upgrade_status| {
+                canister_upgrade_status.upgrade_arg.version.eq(version)
+                    && canister_upgrade_status
+                        .upgrade_arg
+                        .canister
+                        .eq(&WasmType::IndividualUserWasm)
+            })
+            .ok_or::<Box<dyn Error>>(
+                format!("Canister Wasm for version {version} not found").into(),
+            )?
+            .upgrade_arg
+            .wasm_blob;
+
+        Ok::<_, Box<dyn Error>>(wasm_blob)
+    })?;
+
+    registered_subnet_orchestrator
+        .upgrade_specific_individual_canister_with_wasm_version(
+            individual_canister_id,
+            version.to_string(),
+            wasm,
+        )
+        .await?;
+
+    Ok(())
+}

--- a/src/canister/platform_orchestrator/src/api/canister_management/upgrade_subnet_orchestrator_canister_with_latest_wasm.rs
+++ b/src/canister/platform_orchestrator/src/api/canister_management/upgrade_subnet_orchestrator_canister_with_latest_wasm.rs
@@ -6,7 +6,7 @@ use shared_utils::{
 };
 
 use crate::{
-    guard::is_caller::is_caller_global_admin_or_controller,
+    guard::is_caller::is_caller_platform_global_admin_or_controller,
     utils::{
         recharge_and_upgrade_subnet_orchestrator,
         registered_subnet_orchestrator::RegisteredSubnetOrchestrator,
@@ -15,7 +15,7 @@ use crate::{
     CANISTER_DATA,
 };
 
-#[update(guard = "is_caller_global_admin_or_controller")]
+#[update(guard = "is_caller_platform_global_admin_or_controller")]
 pub async fn upgrade_subnet_orchestrator_canister_with_latest_wasm(
     subnet_orchestrator_cansiter_id: Principal,
 ) -> Result<(), String> {

--- a/src/canister/platform_orchestrator/src/api/canister_management/upload_wasms.rs
+++ b/src/canister/platform_orchestrator/src/api/canister_management/upload_wasms.rs
@@ -2,18 +2,17 @@ use ic_cdk::{api::is_controller, caller};
 use ic_cdk_macros::update;
 use shared_utils::common::types::wasm::{CanisterWasm, WasmType};
 
-use crate::{guard::is_caller::is_caller_global_admin_or_controller, CANISTER_DATA};
+use crate::{guard::is_caller::is_caller_platform_global_admin_or_controller, CANISTER_DATA};
 
- 
-#[update(guard = "is_caller_global_admin_or_controller")]
+#[update(guard = "is_caller_platform_global_admin_or_controller")]
 pub fn upload_wasms(wasm_type: WasmType, wasm: Vec<u8>) -> Result<String, String> {
     CANISTER_DATA.with_borrow_mut(|canister_data| {
-        let canister_wasm  = CanisterWasm {
+        let canister_wasm = CanisterWasm {
             wasm_blob: wasm,
             version: "1.0.0".into(),
         };
         canister_data.wasms.insert(wasm_type, canister_wasm);
-        ic_cdk::println!("{} version ",canister_data.version_detail.version);
+        ic_cdk::println!("{} version ", canister_data.version_detail.version);
         canister_data.subnet_canister_upgrade_log.get(0);
     });
     Ok("Success".into())

--- a/src/canister/platform_orchestrator/src/api/cycle_management/deposit_cycles_to_canister.rs
+++ b/src/canister/platform_orchestrator/src/api/cycle_management/deposit_cycles_to_canister.rs
@@ -4,9 +4,9 @@ use ic_cdk::{
     update,
 };
 
-use crate::guard::is_caller::is_caller_global_admin_or_controller;
+use crate::guard::is_caller::is_caller_platform_global_admin_or_controller;
 
-#[update(guard = "is_caller_global_admin_or_controller")]
+#[update(guard = "is_caller_platform_global_admin_or_controller")]
 async fn deposit_cycles_to_canister(
     canister_id: Principal,
     cycles: u128,

--- a/src/canister/platform_orchestrator/src/api/cycle_management/start_reclaiming_cycles_from_individual_canisters.rs
+++ b/src/canister/platform_orchestrator/src/api/cycle_management/start_reclaiming_cycles_from_individual_canisters.rs
@@ -1,8 +1,8 @@
 use ic_cdk_macros::update;
 
-use crate::{guard::is_caller::is_caller_global_admin_or_controller, CANISTER_DATA};
+use crate::{guard::is_caller::is_caller_platform_global_admin_or_controller, CANISTER_DATA};
 
-#[update(guard = "is_caller_global_admin_or_controller")]
+#[update(guard = "is_caller_platform_global_admin_or_controller")]
 fn start_reclaiming_cycles_from_individual_canisters() -> Result<String, String> {
     CANISTER_DATA.with_borrow(|canister_data| {
         canister_data

--- a/src/canister/platform_orchestrator/src/api/cycle_management/start_reclaiming_cycles_from_subnet_orchestrator_canister.rs
+++ b/src/canister/platform_orchestrator/src/api/cycle_management/start_reclaiming_cycles_from_subnet_orchestrator_canister.rs
@@ -1,16 +1,22 @@
 use ic_cdk_macros::update;
 
-use crate::{guard::is_caller::is_caller_global_admin_or_controller, CANISTER_DATA};
+use crate::{guard::is_caller::is_caller_platform_global_admin_or_controller, CANISTER_DATA};
 
-
-
-#[update(guard = "is_caller_global_admin_or_controller")]
+#[update(guard = "is_caller_platform_global_admin_or_controller")]
 async fn start_reclaiming_cycles_from_subnet_orchestrator_canister() -> String {
     CANISTER_DATA.with_borrow(|canister_data| {
-        canister_data.all_subnet_orchestrator_canisters_list.iter().for_each(|subnet_orchestrator_id| {
-            ic_cdk::notify(*subnet_orchestrator_id, "return_cycles_to_platform_orchestrator_canister", ()).unwrap();
-        });
-   });
-   
-   String::from("Success")
+        canister_data
+            .all_subnet_orchestrator_canisters_list
+            .iter()
+            .for_each(|subnet_orchestrator_id| {
+                ic_cdk::notify(
+                    *subnet_orchestrator_id,
+                    "return_cycles_to_platform_orchestrator_canister",
+                    (),
+                )
+                .unwrap();
+            });
+    });
+
+    String::from("Success")
 }

--- a/src/canister/platform_orchestrator/src/api/stats/collect_creator_dao_stats_in_the_network.rs
+++ b/src/canister/platform_orchestrator/src/api/stats/collect_creator_dao_stats_in_the_network.rs
@@ -8,9 +8,9 @@ use shared_utils::{
     types::creator_dao_stats::{self, IndividualUserCreatorDaoEntry},
 };
 
-use crate::{guard::is_caller::is_caller_global_admin_or_controller, CANISTER_DATA};
+use crate::{guard::is_caller::is_caller_platform_global_admin_or_controller, CANISTER_DATA};
 
-#[update(guard = "is_caller_global_admin_or_controller")]
+#[update(guard = "is_caller_platform_global_admin_or_controller")]
 pub fn collect_creator_dao_stats_in_the_network() {
     let subnet_orchestrators = CANISTER_DATA
         .with_borrow(|canister_data| canister_data.all_subnet_orchestrator_canisters_list.clone());

--- a/src/canister/platform_orchestrator/src/api/stats/get_creator_dao_stats.rs
+++ b/src/canister/platform_orchestrator/src/api/stats/get_creator_dao_stats.rs
@@ -1,9 +1,9 @@
 use ic_cdk_macros::query;
 use shared_utils::types::creator_dao_stats::CreatorDaoTokenStats;
 
-use crate::{guard::is_caller::is_caller_global_admin_or_controller, CANISTER_DATA};
+use crate::{guard::is_caller::is_caller_platform_global_admin_or_controller, CANISTER_DATA};
 
-#[query(guard = "is_caller_global_admin_or_controller")]
+#[query(guard = "is_caller_platform_global_admin_or_controller")]
 pub fn get_creator_dao_stats() -> CreatorDaoTokenStats {
     CANISTER_DATA.with_borrow(|canister_data| canister_data.creator_dao_stats.clone())
 }

--- a/src/canister/platform_orchestrator/src/guard/is_caller.rs
+++ b/src/canister/platform_orchestrator/src/guard/is_caller.rs
@@ -12,7 +12,7 @@ pub(crate) fn is_caller_global_admin() -> Result<(), String> {
     })
 }
 
-pub(crate) fn is_caller_global_admin_or_controller() -> Result<(), String> {
+pub(crate) fn is_caller_platform_global_admin_or_controller() -> Result<(), String> {
     CANISTER_DATA.with_borrow(|canister_data| {
         match canister_data.platform_global_admins.contains(&caller()) || is_controller(&caller()) {
             true => Ok(()),

--- a/src/canister/platform_orchestrator/src/utils/registered_subnet_orchestrator.rs
+++ b/src/canister/platform_orchestrator/src/utils/registered_subnet_orchestrator.rs
@@ -151,7 +151,9 @@ impl RegisteredSubnetOrchestrator {
     }
 
     pub async fn fixup_individual_cansiters_mapping(&self) -> Result<(), String> {
-        ic_cdk::call::<_, ()>(self.canister_id, "fixup_individual_canisters_mapping", ()).await.map_err(|e| e.1)
+        ic_cdk::call::<_, ()>(self.canister_id, "fixup_individual_canisters_mapping", ())
+            .await
+            .map_err(|e| e.1)
     }
 
     pub async fn make_individual_canister_logs_private(
@@ -256,5 +258,21 @@ impl RegisteredSubnetOrchestrator {
             (individual_canister_id, wasm_module),
         )
         .map_err(|e| format!("Notify to subnet orchestrator failed {:?}", e))
+    }
+
+    pub async fn upgrade_specific_individual_canister_with_wasm_version(
+        &self,
+        individual_canister_id: Principal,
+        version: String,
+        wasm_module: Vec<u8>,
+    ) -> Result<(), String> {
+        ic_cdk::call::<_, (Result<(), String>,)>(
+            self.canister_id,
+            "upgrade_specific_individual_canister_with_wasm_version",
+            (individual_canister_id, version, wasm_module),
+        )
+        .await
+        .map_err(|e| format!("{:?} {}", e.0, e.1))?
+        .0
     }
 }

--- a/src/canister/user_index/can.did
+++ b/src/canister/user_index/can.did
@@ -207,6 +207,11 @@ service : (UserIndexInitArgs) -> {
   update_restart_timers_hon_game : () -> (text);
   update_well_known_principal : (KnownPrincipalType, principal) -> ();
   upgrade_all_creator_dao_governance_canisters_in_the_network : (blob) -> ();
+  upgrade_specific_individual_canister_with_wasm_version : (
+      principal,
+      text,
+      blob,
+    ) -> (Result_3);
   upgrade_specific_individual_user_canister_with_latest_wasm : (
       principal,
       opt principal,

--- a/src/canister/user_index/src/api/upgrade_individual_user_template/mod.rs
+++ b/src/canister/user_index/src/api/upgrade_individual_user_template/mod.rs
@@ -1,3 +1,4 @@
 pub mod get_index_details_last_upgrade_status;
 pub mod update_user_index_upgrade_user_canisters_with_latest_wasm;
+pub mod upgrade_specific_individual_canister_with_wasm_version;
 pub mod upgrade_specific_individual_user_canister_with_latest_wasm;

--- a/src/canister/user_index/src/api/upgrade_individual_user_template/upgrade_specific_individual_canister_with_wasm_version.rs
+++ b/src/canister/user_index/src/api/upgrade_individual_user_template/upgrade_specific_individual_canister_with_wasm_version.rs
@@ -1,0 +1,43 @@
+use candid::Principal;
+use ic_cdk::api::management_canister::main::CanisterInstallMode;
+use ic_cdk_macros::update;
+use shared_utils::{
+    canister_specific::individual_user_template::types::arg::IndividualUserTemplateInitArgs,
+    common::{
+        types::{known_principal, wasm},
+        utils::permissions::is_caller_controller,
+    },
+};
+
+use crate::{util::canister_management::recharge_and_upgrade, CANISTER_DATA};
+
+#[update(guard = "is_caller_controller")]
+async fn upgrade_specific_individual_canister_with_wasm_version(
+    individual_user_canister_id: Principal,
+    version: String,
+    wasm_blob: Vec<u8>,
+) -> Result<(), String> {
+    let known_principal_ids = CANISTER_DATA
+        .with_borrow(|canister_data| canister_data.configuration.known_principal_ids.clone());
+
+    let pump_dump_onboarding_reward = CANISTER_DATA
+        .with_borrow(|canister_data| canister_data.pump_dump_onboarding_reward.clone());
+
+    recharge_and_upgrade(
+        individual_user_canister_id,
+        Principal::anonymous(),
+        wasm_blob,
+        IndividualUserTemplateInitArgs {
+            known_principal_ids: Some(known_principal_ids.clone()),
+            profile_owner: None,
+            upgrade_version_number: None,
+            url_to_send_canister_metrics_to: None,
+            version,
+            pump_dump_onboarding_reward: Some(pump_dump_onboarding_reward),
+        },
+    )
+    .await
+    .map_err(|e| e.1)?;
+
+    Ok(())
+}

--- a/src/lib/integration_tests/tests/platform_orchestrator/main.rs
+++ b/src/lib/integration_tests/tests/platform_orchestrator/main.rs
@@ -5,3 +5,6 @@ pub mod recharge_subnet_orchestrator_test;
 pub mod register_and_deregister_new_subnet_orchestrator_test;
 pub mod test_upgrade_subnet_orchestrator_canister_with_latest_wasm;
 pub mod update_canisters_last_access_time_test;
+
+pub mod test_upgrading_specific_individual_canister_with_version;
+pub mod test_upgrading_specific_individual_canister_with_wasm;

--- a/src/lib/integration_tests/tests/platform_orchestrator/test_upgrading_specific_individual_canister_with_version.rs
+++ b/src/lib/integration_tests/tests/platform_orchestrator/test_upgrading_specific_individual_canister_with_version.rs
@@ -1,0 +1,167 @@
+use candid::Principal;
+use pocket_ic::WasmResult;
+use shared_utils::{
+    canister_specific::platform_orchestrator::types::args::UpgradeCanisterArg,
+    common::types::{known_principal::KnownPrincipalType, wasm::WasmType},
+};
+use test_utils::setup::{
+    env::{
+        pocket_ic_env::get_new_pocket_ic_env,
+        pocket_ic_init::get_initialized_env_with_provisioned_known_canisters,
+    },
+    test_constants::get_mock_user_alice_principal_id,
+};
+
+#[test]
+fn test_upgrading_specific_individual_canister_with_version() {
+    let (pocket_ic, known_principal_map) = get_new_pocket_ic_env();
+
+    let platform_orchestrator = known_principal_map
+        .get(&KnownPrincipalType::CanisterIdPlatformOrchestrator)
+        .copied()
+        .unwrap();
+
+    let known_principal_map =
+        get_initialized_env_with_provisioned_known_canisters(&pocket_ic, known_principal_map);
+    let user_index_canister_id = known_principal_map
+        .get(&KnownPrincipalType::CanisterIdUserIndex)
+        .copied()
+        .unwrap();
+
+    let global_admin_principal = known_principal_map
+        .get(&KnownPrincipalType::UserIdGlobalSuperAdmin)
+        .copied()
+        .unwrap();
+
+    let alice_principal_id = get_mock_user_alice_principal_id();
+
+    let alice_canister_id = pocket_ic
+        .update_call(
+            user_index_canister_id,
+            alice_principal_id,
+            "get_requester_principals_canister_id_create_if_not_exists",
+            candid::encode_one(()).unwrap(),
+        )
+        .map(|reply_payload| {
+            let alice_canister_id: Result<Principal, String> = match reply_payload {
+                WasmResult::Reply(payload) => candid::decode_one(&payload).unwrap(),
+                _ => panic!(
+                    "\n🛑 get_requester_principals_canister_id_create_if_not_exists failed\n"
+                ),
+            };
+            alice_canister_id
+        })
+        .unwrap()
+        .unwrap();
+
+    let individual_user_template_wasm_module = include_bytes!(
+        "../../../../../target/wasm32-unknown-unknown/release/individual_user_template.wasm.gz"
+    );
+
+    pocket_ic
+        .update_call(
+            platform_orchestrator,
+            global_admin_principal,
+            "upgrade_canisters_in_network",
+            candid::encode_one(UpgradeCanisterArg {
+                canister: WasmType::IndividualUserWasm,
+                version: "v2.0.0".to_string(),
+                wasm_blob: individual_user_template_wasm_module.to_vec(),
+            })
+            .unwrap(),
+        )
+        .map(|res| {
+            let res: Result<String, String> = match res {
+                WasmResult::Reply(payload) => candid::decode_one(&payload).unwrap(),
+                _ => panic!("get subnet available capacity call failed"),
+            };
+            res
+        })
+        .unwrap()
+        .unwrap();
+
+    for _ in 0..100 {
+        pocket_ic.tick();
+    }
+
+    pocket_ic
+        .update_call(
+            platform_orchestrator,
+            global_admin_principal,
+            "upgrade_canisters_in_network",
+            candid::encode_one(UpgradeCanisterArg {
+                canister: WasmType::IndividualUserWasm,
+                version: "v2.1.0".to_string(),
+                wasm_blob: individual_user_template_wasm_module.to_vec(),
+            })
+            .unwrap(),
+        )
+        .map(|res| {
+            let res: Result<String, String> = match res {
+                WasmResult::Reply(payload) => candid::decode_one(&payload).unwrap(),
+                _ => panic!("get subnet available capacity call failed"),
+            };
+            res
+        })
+        .unwrap()
+        .unwrap();
+
+    for _ in 0..100 {
+        pocket_ic.tick();
+    }
+
+    let alice_canister_version = pocket_ic
+        .query_call(
+            alice_canister_id,
+            Principal::anonymous(),
+            "get_version",
+            candid::encode_one(()).unwrap(),
+        )
+        .map(|reply_payload| {
+            let version: String = match reply_payload {
+                WasmResult::Reply(payload) => candid::decode_one(&payload).unwrap(),
+                e => panic!("\n🛑 get_utility_token_balance failed\n {e:?}"),
+            };
+            version
+        })
+        .unwrap();
+
+    assert_eq!(alice_canister_version, "v2.1.0");
+
+    pocket_ic
+        .update_call(
+            platform_orchestrator,
+            global_admin_principal,
+            "upgrade_specific_individual_canister_with_version",
+            candid::encode_args((alice_canister_id, "v2.0.0")).unwrap(),
+        )
+        .map(|reply_payload| {
+            let result: Result<(), String> = match reply_payload {
+                WasmResult::Reply(payload) => candid::decode_one(&payload).unwrap(),
+                e => {
+                    panic!("\n🛑 upgrade_specific_individual_canister_with_version failed\n {e:?}")
+                }
+            };
+            result
+        })
+        .unwrap()
+        .unwrap();
+
+    let alice_canister_version = pocket_ic
+        .query_call(
+            alice_canister_id,
+            Principal::anonymous(),
+            "get_version",
+            candid::encode_one(()).unwrap(),
+        )
+        .map(|reply_payload| {
+            let version: String = match reply_payload {
+                WasmResult::Reply(payload) => candid::decode_one(&payload).unwrap(),
+                e => panic!("\n🛑 get_utility_token_balance failed\n {e:?}"),
+            };
+            version
+        })
+        .unwrap();
+
+    assert_eq!(alice_canister_version, "v2.0.0");
+}

--- a/src/lib/integration_tests/tests/platform_orchestrator/test_upgrading_specific_individual_canister_with_wasm.rs
+++ b/src/lib/integration_tests/tests/platform_orchestrator/test_upgrading_specific_individual_canister_with_wasm.rs
@@ -1,0 +1,146 @@
+use candid::Principal;
+use pocket_ic::WasmResult;
+use shared_utils::{
+    canister_specific::platform_orchestrator::types::args::UpgradeCanisterArg,
+    common::types::{known_principal::KnownPrincipalType, wasm::WasmType},
+};
+use test_utils::setup::{
+    env::{
+        pocket_ic_env::get_new_pocket_ic_env,
+        pocket_ic_init::get_initialized_env_with_provisioned_known_canisters,
+    },
+    test_constants::get_mock_user_alice_principal_id,
+};
+
+#[test]
+fn test_upgrading_specific_individual_canister_with_wasm() {
+    let (pocket_ic, known_principal_map) = get_new_pocket_ic_env();
+
+    let platform_orchestrator = known_principal_map
+        .get(&KnownPrincipalType::CanisterIdPlatformOrchestrator)
+        .copied()
+        .unwrap();
+
+    let known_principal_map =
+        get_initialized_env_with_provisioned_known_canisters(&pocket_ic, known_principal_map);
+    let user_index_canister_id = known_principal_map
+        .get(&KnownPrincipalType::CanisterIdUserIndex)
+        .copied()
+        .unwrap();
+
+    let global_admin_principal = known_principal_map
+        .get(&KnownPrincipalType::UserIdGlobalSuperAdmin)
+        .copied()
+        .unwrap();
+
+    let alice_principal_id = get_mock_user_alice_principal_id();
+
+    let alice_canister_id = pocket_ic
+        .update_call(
+            user_index_canister_id,
+            alice_principal_id,
+            "get_requester_principals_canister_id_create_if_not_exists",
+            candid::encode_one(()).unwrap(),
+        )
+        .map(|reply_payload| {
+            let alice_canister_id: Result<Principal, String> = match reply_payload {
+                WasmResult::Reply(payload) => candid::decode_one(&payload).unwrap(),
+                _ => panic!(
+                    "\n🛑 get_requester_principals_canister_id_create_if_not_exists failed\n"
+                ),
+            };
+            alice_canister_id
+        })
+        .unwrap()
+        .unwrap();
+
+    let individual_user_template_wasm_module = include_bytes!(
+        "../../../../../target/wasm32-unknown-unknown/release/individual_user_template.wasm.gz"
+    );
+
+    pocket_ic
+        .update_call(
+            platform_orchestrator,
+            global_admin_principal,
+            "upgrade_canisters_in_network",
+            candid::encode_one(UpgradeCanisterArg {
+                canister: WasmType::IndividualUserWasm,
+                version: "v2.0.0".to_string(),
+                wasm_blob: individual_user_template_wasm_module.to_vec(),
+            })
+            .unwrap(),
+        )
+        .map(|res| {
+            let res: Result<String, String> = match res {
+                WasmResult::Reply(payload) => candid::decode_one(&payload).unwrap(),
+                _ => panic!("get subnet available capacity call failed"),
+            };
+            res
+        })
+        .unwrap()
+        .unwrap();
+
+    for _ in 0..100 {
+        pocket_ic.tick();
+    }
+
+    let alice_canister_version = pocket_ic
+        .query_call(
+            alice_canister_id,
+            Principal::anonymous(),
+            "get_version",
+            candid::encode_one(()).unwrap(),
+        )
+        .map(|reply_payload| {
+            let version: String = match reply_payload {
+                WasmResult::Reply(payload) => candid::decode_one(&payload).unwrap(),
+                e => panic!("\n🛑 get_utility_token_balance failed\n {e:?}"),
+            };
+            version
+        })
+        .unwrap();
+
+    assert_eq!(alice_canister_version, "v2.0.0");
+
+    pocket_ic
+        .update_call(
+            platform_orchestrator,
+            global_admin_principal,
+            "upgrade_specific_individual_canister_with_wasm",
+            candid::encode_args((
+                alice_canister_id,
+                "v2.2.0",
+                individual_user_template_wasm_module,
+            ))
+            .unwrap(),
+        )
+        .map(|reply_payload| {
+            let result: Result<(), String> = match reply_payload {
+                WasmResult::Reply(payload) => candid::decode_one(&payload).unwrap(),
+                e => {
+                    panic!("\n🛑 upgrade_specific_individual_canister_with_wasm failed\n {e:?}")
+                }
+            };
+            result
+        })
+        .unwrap()
+        .unwrap();
+
+    let alice_canister_version = pocket_ic
+        .query_call(
+            alice_canister_id,
+            Principal::anonymous(),
+            "get_version",
+            candid::encode_one(()).unwrap(),
+        )
+        .map(|reply_payload| {
+            let version: String = match reply_payload {
+                WasmResult::Reply(payload) => candid::decode_one(&payload).unwrap(),
+                e => panic!("\n🛑 get_version failed\n {e:?}"),
+            };
+            version
+        })
+        .unwrap();
+
+    assert_eq!(alice_canister_version, "v2.2.0");
+}

--- a/src/lib/shared_utils/src/canister_specific/individual_user_template/types/arg.rs
+++ b/src/lib/shared_utils/src/canister_specific/individual_user_template/types/arg.rs
@@ -5,7 +5,7 @@ use crate::common::types::known_principal::KnownPrincipalMap;
 
 use super::hot_or_not::BetDirection;
 
-#[derive(Deserialize, CandidType)]
+#[derive(Deserialize, CandidType, Clone)]
 pub struct IndividualUserTemplateInitArgs {
     pub known_principal_ids: Option<KnownPrincipalMap>,
     pub profile_owner: Option<Principal>,


### PR DESCRIPTION
## Changes
- refactor guard from `is_caller_global_admin_or_controller` to `is_caller_platform_global_admin_or_controller` to avoid confusion.
- Avoid changing profile owners in post upgrades in individual canisters.
- added methods to upgrade individual canisters with version or wasm
- store individual user canister wasm in platform orchestrator upgrade log.

## Impacts
- fixes https://github.com/dolr-ai/product-roadmap/issues/322