### PR TITLE
feat: add prune_notifications function to notification_store canister

### DIFF
--- a/src/canister/notification_store/can.did
+++ b/src/canister/notification_store/can.did
@@ -34,4 +34,5 @@ service : (NotificationStoreInitArgs) -> {
   get_notifications : (nat64, nat64) -> (vec NotificationData) query;
   get_version : () -> (text) query;
   mark_notification_as_read : (nat64) -> (Result);
+  prune_notifications : () -> ();
 }

--- a/src/canister/notification_store/src/api/mod.rs
+++ b/src/canister/notification_store/src/api/mod.rs
@@ -1,3 +1,4 @@
 pub mod add_notification;
 pub mod mark_read;
 pub mod get_notifications;
+pub mod prune_notfications;

--- a/src/canister/notification_store/src/api/prune_notfications.rs
+++ b/src/canister/notification_store/src/api/prune_notfications.rs
@@ -2,6 +2,7 @@ use candid::Principal;
 use ic_cdk_macros::update;
 use shared_utils::common::utils::system_time::get_current_system_time_from_ic;
 use shared_utils::common::utils::permissions::is_caller_controller_or_global_admin;
+use std::time::Duration;
 
 use crate::CANISTER_DATA;
 
@@ -9,13 +10,17 @@ use crate::CANISTER_DATA;
 pub fn prune_notifications() {
     CANISTER_DATA.with_borrow_mut(|map| {
         let now = get_current_system_time_from_ic();
+        // Keep notifications from the last 30 days
+        let thirty_days = Duration::from_secs(30 * 24 * 60 * 60);
+        let thirty_days_ago = now.checked_sub(thirty_days).unwrap_or(std::time::UNIX_EPOCH);
 
         // Collecting the user principals first to avoid borrowing issues while mutating the map
         let users: Vec<Principal> = map.notifications.iter().map(|(user, _)| user).collect();
 
         for user in users {
             if let Some(mut notifications) = map.notifications.get(&user) {
-                notifications.0.retain(|n| n.created_at > now);
+                // Keep notifications that were created after thirty_days_ago
+                notifications.0.retain(|n| n.created_at > thirty_days_ago);
 
                 map.notifications.insert(user, notifications);
             }

--- a/src/canister/notification_store/src/api/prune_notfications.rs
+++ b/src/canister/notification_store/src/api/prune_notfications.rs
@@ -1,0 +1,24 @@
+use candid::Principal;
+use ic_cdk_macros::update;
+use shared_utils::common::utils::system_time::get_current_system_time_from_ic;
+use shared_utils::common::utils::permissions::is_caller_controller_or_global_admin;
+
+use crate::CANISTER_DATA;
+
+#[update(guard = "is_caller_controller_or_global_admin")]
+pub fn prune_notifications() {
+    CANISTER_DATA.with_borrow_mut(|map| {
+        let now = get_current_system_time_from_ic();
+
+        // Collecting the user principals first to avoid borrowing issues while mutating the map
+        let users: Vec<Principal> = map.notifications.iter().map(|(user, _)| user).collect();
+
+        for user in users {
+            if let Some(mut notifications) = map.notifications.get(&user) {
+                notifications.0.retain(|n| n.created_at > now);
+
+                map.notifications.insert(user, notifications);
+            }
+        }
+    })
+}

--- a/src/canister/notification_store/src/api/prune_notfications.rs
+++ b/src/canister/notification_store/src/api/prune_notfications.rs
@@ -1,5 +1,6 @@
 use candid::Principal;
 use ic_cdk_macros::update;
+use shared_utils::canister_specific::notification_store::types::notification::Notification;
 use shared_utils::common::utils::system_time::get_current_system_time_from_ic;
 use shared_utils::common::utils::permissions::is_caller_controller_or_global_admin;
 use std::time::Duration;

--- a/src/canister/notification_store/src/api/prune_notfications.rs
+++ b/src/canister/notification_store/src/api/prune_notfications.rs
@@ -11,19 +11,21 @@ pub fn prune_notifications() {
     CANISTER_DATA.with_borrow_mut(|map| {
         let now = get_current_system_time_from_ic();
         // Keep notifications from the last 30 days
-        let thirty_days = Duration::from_secs(30 * 24 * 60 * 60);
-        let thirty_days_ago = now.checked_sub(thirty_days).unwrap_or(std::time::UNIX_EPOCH);
+           let thirty_days = Duration::from_secs(30 * 24 * 60 * 60);
+        let thirty_days_ago = now
+            .checked_sub(thirty_days)
+            .unwrap_or(std::time::UNIX_EPOCH);
 
-        // Collecting the user principals first to avoid borrowing issues while mutating the map
-        let users: Vec<Principal> = map.notifications.iter().map(|(user, _)| user).collect();
+        let mut notifications: Vec<(Principal, Notification)> = map.notifications.iter().collect();
 
-        for user in users {
-            if let Some(mut notifications) = map.notifications.get(&user) {
-                // Keep notifications that were created after thirty_days_ago
-                notifications.0.retain(|n| n.created_at > thirty_days_ago);
+        notifications
+            .iter_mut()
+            .for_each(|(principal, notification)| {
+                notification
+                    .0
+                    .retain(|data| data.created_at >= thirty_days_ago);
 
-                map.notifications.insert(user, notifications);
-            }
-        }
-    })
+                map.notifications.insert(*principal, notification.clone());
+            });
+    });
 }

--- a/src/canister/notification_store/src/canister_lifecycle/init.rs
+++ b/src/canister/notification_store/src/canister_lifecycle/init.rs
@@ -1,12 +1,11 @@
 use ic_cdk_macros::init;
 use shared_utils::canister_specific::notification_store::types::args::NotificationStoreInitArgs;
 
-use crate::{set_pruning_timer, CANISTER_DATA};
+use crate::CANISTER_DATA;
 
 #[init]
 fn init(args: NotificationStoreInitArgs) {
     CANISTER_DATA.with_borrow_mut(|canister_data| {
         canister_data.version = args.version;
     });
-    set_pruning_timer();
 }

--- a/src/canister/notification_store/src/canister_lifecycle/post_upgrade.rs
+++ b/src/canister/notification_store/src/canister_lifecycle/post_upgrade.rs
@@ -1,4 +1,4 @@
-use crate::{data_model::memory, set_pruning_timer, CANISTER_DATA};
+use crate::{data_model::memory, CANISTER_DATA};
 use ciborium::de;
 use ic_cdk_macros::post_upgrade;
 use ic_stable_structures::Memory;
@@ -8,7 +8,6 @@ use shared_utils::canister_specific::notification_store::types::args::Notificati
 pub fn post_upgrade() {
     restore_data_from_stable_memory();
     update_version_from_args();
-    set_pruning_timer();
 }
 
 fn restore_data_from_stable_memory() {

--- a/src/canister/notification_store/src/lib.rs
+++ b/src/canister/notification_store/src/lib.rs
@@ -21,26 +21,5 @@ thread_local! {
     static CANISTER_DATA: RefCell<CanisterData> = RefCell::default();
 }
 
-const PRUNING_INTERVAL_IN_NANOS: u64 = 30 * 24 * 60 * 60 * 1_000_000_000;
-
-fn set_pruning_timer() {
-    ic_cdk_timers::set_timer_interval(Duration::from_nanos(PRUNING_INTERVAL_IN_NANOS), move || {
-        CANISTER_DATA.with_borrow_mut(|map| {
-            let now = get_current_system_time_from_ic();
-
-            // Collecting the user principals first to avoid borrowing issues while mutating the map
-            let users: Vec<Principal> = map.notifications.iter().map(|(user, _)| user).collect();
-
-            for user in users {
-                if let Some(mut notifications) = map.notifications.get(&user) {
-                    notifications.0.retain(|n| n.created_at > now);
-
-                    map.notifications.insert(user, notifications);
-                }
-            }
-        })
-    });
-}
-
 export_candid!();
 

--- a/src/lib/integration_tests/tests/notification_store/crud.rs
+++ b/src/lib/integration_tests/tests/notification_store/crud.rs
@@ -1,7 +1,7 @@
 use candid::Encode;
 use pocket_ic::WasmResult;
 use shared_utils::{canister_specific::notification_store::types::{error::NotificationStoreError, notification::{NotificationData, NotificationType, VideoUploadPayload}}, common::types::known_principal::KnownPrincipalType};
-use test_utils::setup::{env::pocket_ic_env::{get_new_pocket_ic_env, get_new_pocket_ic_env_with_service_canisters_provisioned}, test_constants::get_mock_user_alice_principal_id};
+use test_utils::setup::{env::pocket_ic_env::{get_new_pocket_ic_env, get_new_pocket_ic_env_with_service_canisters_provisioned}, test_constants::{get_global_super_admin_principal_id, get_mock_user_alice_principal_id}};
 
 #[test]
 fn test_crud() {
@@ -81,4 +81,92 @@ fn test_increment_notification_id() {
     assert_eq!(notifications.len(), 2);
     assert_eq!(notifications[0].notification_id, 0);
     assert_eq!(notifications[1].notification_id, 1);
+}
+
+#[test]
+fn test_prune_notifications() {
+    let (pic, known_principals) = get_new_pocket_ic_env_with_service_canisters_provisioned();
+    
+    // Deploy notification store canister
+    let notification_store_canister = known_principals.notification_store_canister_id;
+    // Set up global admin principal
+    let global_admin = get_global_super_admin_principal_id();
+    
+    let alice_principal = get_mock_user_alice_principal_id();
+    
+    // Add some notifications
+    for i in 0..5 {
+        let res = pic.update_call(
+            notification_store_canister, 
+            alice_principal, 
+            "add_notification", 
+            Encode!(&alice_principal, &NotificationType::VideoUpload(VideoUploadPayload {
+                video_uid: i,
+            })).unwrap()
+        ).unwrap();
+        let res: Result<(), NotificationStoreError> = match res {
+            WasmResult::Reply(payload) => candid::decode_one(&payload).unwrap(),
+            _ => panic!("\n🛑 add notification failed\n"),
+        };
+        res.unwrap();
+    }
+    
+    // Verify all notifications exist
+    let notifications = pic.query_call(
+        notification_store_canister, 
+        alice_principal, 
+        "get_notifications", 
+        Encode!(&10u64, &0u64).unwrap()
+    ).unwrap();
+    let notifications: Vec<NotificationData> = match notifications {
+        WasmResult::Reply(payload) => candid::decode_one(&payload).unwrap(),
+        _ => panic!("\n🛑 get notifications failed\n"),
+    };
+    assert_eq!(notifications.len(), 5);
+    
+    // Call prune_notifications as global admin
+    let res = pic.update_call(
+        notification_store_canister,
+        global_admin,
+        "prune_notifications",
+        vec![]
+    ).unwrap();
+    match res {
+        WasmResult::Reply(_) => {},
+        _ => panic!("\n🛑 prune notifications failed\n"),
+    };
+    
+    // Check that notifications were NOT pruned (they're recent)
+    let notifications = pic.query_call(
+        notification_store_canister, 
+        alice_principal, 
+        "get_notifications", 
+        Encode!(&10u64, &0u64).unwrap()
+    ).unwrap();
+    let notifications: Vec<NotificationData> = match notifications {
+        WasmResult::Reply(payload) => candid::decode_one(&payload).unwrap(),
+        _ => panic!("\n🛑 get notifications failed\n"),
+    };
+    
+    // All notifications should still exist because they were just created (within 30 days)
+    assert_eq!(notifications.len(), 5);
+}
+
+#[test]
+fn test_prune_notifications_unauthorized() {
+    let (pic, service_canisters) = get_new_pocket_ic_env_with_service_canisters_provisioned();
+    
+    let notification_store_canister_id = service_canisters.notification_store_canister_id;
+    let alice_principal = get_global_super_admin_principal_id();
+    
+    // Try to call prune_notifications as regular user (not admin/controller)
+    let res = pic.update_call(
+        notification_store_canister_id,
+        alice_principal,
+        "prune_notifications",
+        vec![]
+    );
+    
+    // Should fail due to guard
+    assert!(res.is_err() || matches!(res.unwrap(), WasmResult::Reject(_)));
 }

--- a/src/lib/integration_tests/tests/notification_store/crud.rs
+++ b/src/lib/integration_tests/tests/notification_store/crud.rs
@@ -129,7 +129,7 @@ fn test_prune_notifications() {
         notification_store_canister,
         global_admin,
         "prune_notifications",
-        vec![]
+        candid::encode_args(()).unwrap()
     ).unwrap();
     match res {
         WasmResult::Reply(_) => {},
@@ -164,7 +164,7 @@ fn test_prune_notifications_unauthorized() {
         notification_store_canister_id,
         alice_principal,
         "prune_notifications",
-        vec![]
+        candid::encode_args(()).unwrap()
     );
     
     // Should fail due to guard

--- a/src/lib/integration_tests/tests/notification_store/crud.rs
+++ b/src/lib/integration_tests/tests/notification_store/crud.rs
@@ -157,12 +157,12 @@ fn test_prune_notifications_unauthorized() {
     let (pic, service_canisters) = get_new_pocket_ic_env_with_service_canisters_provisioned();
     
     let notification_store_canister_id = service_canisters.notification_store_canister_id;
-    let alice_principal = get_global_super_admin_principal_id();
+    let regular_user = get_mock_user_alice_principal_id(); // Regular user, not admin
     
     // Try to call prune_notifications as regular user (not admin/controller)
     let res = pic.update_call(
         notification_store_canister_id,
-        alice_principal,
+        regular_user,
         "prune_notifications",
         candid::encode_args(()).unwrap()
     );


### PR DESCRIPTION
closes https://github.com/dolr-ai/product-roadmap/issues/941

- Introduced a new `prune_notifications` function to the Candid interface for managing notification cleanup.
- Removed the `set_pruning_timer` function from the initialization and post-upgrade processes to streamline notification management.
- Updated relevant module imports to reflect the removal of the pruning timer functionality.



#### To check the status of the deployment

- check if the platform orchestrator performed the step to upgrade subnet canister with appropriate version: [Platform Orchestrator function](https://dashboard.internetcomputer.org/canister/74zq4-iqaaa-aaaam-ab53a-cai#get_subnet_last_upgrade_status)
- check the status of upgrade for individual canisters in subnet orchestrators and verify the version. Example for one of the subnet orchesrator: [Subnet Orchestrator function](https://dashboard.internetcomputer.org/canister/rimrc-piaaa-aaaao-aaljq-cai#get_index_details_last_upgrade_status)

To test the platform orchestrator, you can use the following command:

`dfx canister call --query 74zq4-iqaaa-aaaam-ab53a-cai get_subnet_last_upgrade_status --network=ic`
 the canister id (74zq4-iqaaa-aaaam-ab53a-cai) is taken from the canister_ids.json file