### PR TITLE
feat: added reverse pagination to notification store

### DIFF
--- a/src/canister/notification_store/src/api/get_notifications.rs
+++ b/src/canister/notification_store/src/api/get_notifications.rs
@@ -12,11 +12,18 @@ fn get_notifications(limit: usize, offset: usize) -> Vec<NotificationData> {
             .notifications
             .get(&caller)
             .map(|notification_data| {
+                let total = notification_data.notifications.len();
+                if offset >= total {
+                    return Vec::new();
+                }
+                
+                let end = total.saturating_sub(offset);
+                let start = end.saturating_sub(limit);
+                
                 notification_data
-                    .notifications
+                    .notifications[start..end]
                     .iter()
-                    .skip(offset)
-                    .take(limit)
+                    .rev()
                     .cloned()
                     .collect()
             })

--- a/src/lib/integration_tests/tests/notification_store/crud.rs
+++ b/src/lib/integration_tests/tests/notification_store/crud.rs
@@ -70,8 +70,8 @@ fn test_increment_notification_id() {
     };
 
     assert_eq!(notifications.len(), 2);
-    assert_eq!(notifications[0].notification_id, 0);
-    assert_eq!(notifications[1].notification_id, 1);
+    assert_eq!(notifications[0].notification_id, 1);
+    assert_eq!(notifications[1].notification_id, 0);
 }
 
 #[test]
@@ -110,20 +110,20 @@ fn test_auto_prune_notifications() {
     
     assert_eq!(notifications.len(), 500);
     
-    assert_eq!(notifications[0].notification_id, 500);
-    assert_eq!(notifications[499].notification_id, 999);
+    assert_eq!(notifications[0].notification_id, 999);
+    assert_eq!(notifications[499].notification_id, 500);
     
     // Verify we have the most recent notifications (video_uid 500-999)
-    // The oldest remaining notification should have video_uid 500
+    // With reverse order, the newest notification (999) is first
     if let NotificationType::VideoUpload(payload) = &notifications[0].payload {
-        assert_eq!(payload.video_uid, 500.to_string());
+        assert_eq!(payload.video_uid, 999.to_string());
     } else {
         panic!("Expected VideoUpload notification type");
     }
     
-    // The newest notification should have video_uid 999
+    // The oldest remaining notification (500) is last
     if let NotificationType::VideoUpload(payload) = &notifications[499].payload {
-        assert_eq!(payload.video_uid, 999.to_string());
+        assert_eq!(payload.video_uid, 500.to_string());
     } else {
         panic!("Expected VideoUpload notification type");
     }
@@ -226,8 +226,8 @@ fn test_pagination() {
     };
     
     assert_eq!(notifications.len(), 5);
-    assert_eq!(notifications[0].notification_id, 0);
-    assert_eq!(notifications[4].notification_id, 4);
+    assert_eq!(notifications[0].notification_id, 9);
+    assert_eq!(notifications[4].notification_id, 5);
     
     let notifications = pic.query_call(
         notification_store_canister,
@@ -241,8 +241,8 @@ fn test_pagination() {
     };
     
     assert_eq!(notifications.len(), 5);
-    assert_eq!(notifications[0].notification_id, 5);
-    assert_eq!(notifications[4].notification_id, 9);
+    assert_eq!(notifications[0].notification_id, 4);
+    assert_eq!(notifications[4].notification_id, 0);
     
     let notifications = pic.query_call(
         notification_store_canister,


### PR DESCRIPTION

#### To check the status of the deployment

- check if the platform orchestrator performed the step to upgrade subnet canister with appropriate version: [Platform Orchestrator function](https://dashboard.internetcomputer.org/canister/74zq4-iqaaa-aaaam-ab53a-cai#get_subnet_last_upgrade_status)
- check the status of upgrade for individual canisters in subnet orchestrators and verify the version. Example for one of the subnet orchesrator: [Subnet Orchestrator function](https://dashboard.internetcomputer.org/canister/rimrc-piaaa-aaaao-aaljq-cai#get_index_details_last_upgrade_status)

To test the platform orchestrator, you can use the following command:

`dfx canister call --query 74zq4-iqaaa-aaaam-ab53a-cai get_subnet_last_upgrade_status --network=ic`
 the canister id (74zq4-iqaaa-aaaam-ab53a-cai) is taken from the canister_ids.json file