### PR TITLE
remove anonymous condition for profile calls

### DIFF
--- a/src/canister/user_info_service/src/api/follow_user.rs
+++ b/src/canister/user_info_service/src/api/follow_user.rs
@@ -1,13 +1,10 @@
 use candid::Principal;
 use ic_cdk::caller;
 use ic_cdk_macros::update;
-use shared_utils::common::utils::permissions::is_not_anonymous;
 
 use crate::CANISTER_DATA;
 
-#[update(guard = "is_not_anonymous")]
+#[update]
 fn follow_user(target: Principal) -> Result<(), String> {
-    CANISTER_DATA.with_borrow_mut(|canister_data| {
-        canister_data.follow_user(caller(), target)
-    })
+    CANISTER_DATA.with_borrow_mut(|canister_data| canister_data.follow_user(caller(), target))
 }

--- a/src/canister/user_info_service/src/api/unfollow_user.rs
+++ b/src/canister/user_info_service/src/api/unfollow_user.rs
@@ -1,13 +1,10 @@
 use candid::Principal;
 use ic_cdk::caller;
 use ic_cdk_macros::update;
-use shared_utils::common::utils::permissions::is_not_anonymous;
 
 use crate::CANISTER_DATA;
 
-#[update(guard = "is_not_anonymous")]
+#[update]
 fn unfollow_user(target: Principal) -> Result<(), String> {
-    CANISTER_DATA.with_borrow_mut(|canister_data| {
-        canister_data.unfollow_user(caller(), target)
-    })
+    CANISTER_DATA.with_borrow_mut(|canister_data| canister_data.unfollow_user(caller(), target))
 }

--- a/src/canister/user_info_service/src/api/update_profile_details.rs
+++ b/src/canister/user_info_service/src/api/update_profile_details.rs
@@ -1,13 +1,11 @@
 use ic_cdk::caller;
 use ic_cdk_macros::update;
-use shared_utils::common::utils::permissions::is_not_anonymous;
 
-use crate::data_model::ProfileUpdateDetails;
 use crate::CANISTER_DATA;
+use crate::data_model::ProfileUpdateDetails;
 
-#[update(guard = "is_not_anonymous")]
+#[update]
 fn update_profile_details(details: ProfileUpdateDetails) -> Result<(), String> {
-    CANISTER_DATA.with_borrow_mut(|canister_data| {
-        canister_data.update_profile_details(caller(), details)
-    })
+    CANISTER_DATA
+        .with_borrow_mut(|canister_data| canister_data.update_profile_details(caller(), details))
 }


### PR DESCRIPTION

#### To check the status of the deployment

- check if the platform orchestrator performed the step to upgrade subnet canister with appropriate version: [Platform Orchestrator function](https://dashboard.internetcomputer.org/canister/74zq4-iqaaa-aaaam-ab53a-cai#get_subnet_last_upgrade_status)
- check the status of upgrade for individual canisters in subnet orchestrators and verify the version. Example for one of the subnet orchesrator: [Subnet Orchestrator function](https://dashboard.internetcomputer.org/canister/rimrc-piaaa-aaaao-aaljq-cai#get_index_details_last_upgrade_status)

To test the platform orchestrator, you can use the following command:

`dfx canister call --query 74zq4-iqaaa-aaaam-ab53a-cai get_subnet_last_upgrade_status --network=ic`
 the canister id (74zq4-iqaaa-aaaam-ab53a-cai) is taken from the canister_ids.json file