### PR TITLE
WIP:added daily missions canister

### DIFF
--- a/.github/workflows/all_canisters_test_suite_on_any_push.yml
+++ b/.github/workflows/all_canisters_test_suite_on_any_push.yml
@@ -53,6 +53,7 @@ jobs:
           nix-shell --run "dfx canister create --no-wallet dedup_index"
           nix-shell --run "dfx canister create --no-wallet user_info_service"
           nix-shell --run "dfx canister create --no-wallet rate_limits"
+          nix-shell --run "dfx canister create --no-wallet daily_missions"
       - name: Stop local replica
         run: nix-shell --run "dfx stop"
       - name: Build platform_orchestrator canister
@@ -87,6 +88,10 @@ jobs:
         run: |
           nix-shell --run "dfx build rate_limits"
           gzip -f -1 ./target/wasm32-unknown-unknown/release/rate_limits.wasm
+      - name: Build daily_missions canister
+        run: |
+          nix-shell --run "dfx build daily_missions"
+          gzip -f -1 ./target/wasm32-unknown-unknown/release/daily_missions.wasm
       - name: Run canister test suite
         env:
           POCKET_IC_BIN: ${{ github.workspace }}/pocket-ic

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -940,6 +940,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "daily_missions"
+version = "0.1.0"
+dependencies = [
+ "candid",
+ "ciborium",
+ "ic-cdk 0.15.1",
+ "ic-cdk-macros 0.16.0",
+ "ic-cdk-timers",
+ "ic-stable-structures",
+ "serde",
+ "serde_json",
+ "shared_utils",
+ "test_utils",
+]
+
+[[package]]
 name = "darling"
 version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ members = [
     "src/lib/test_utils",
     "src/canister/dedup_index",
     "src/canister/rate_limits",
+    "src/canister/daily_missions",
 ]
 
 [workspace.dependencies]

--- a/dfx.json
+++ b/dfx.json
@@ -170,6 +170,17 @@
       "optimize": "size",
       "package": "user_index",
       "type": "rust"
+    },
+    "daily_missions": {
+      "candid": "./src/canister/daily_missions/can.did",
+      "declarations": {
+        "node_compatibility": true,
+        "output": "./export/declarations/daily_missions"
+      },
+      "gzip": true,
+      "optimize": "size",
+      "package": "daily_missions",
+      "type": "rust"
     }
   },
   "version": 1

--- a/src/canister/daily_missions/Cargo.toml
+++ b/src/canister/daily_missions/Cargo.toml
@@ -1,0 +1,23 @@
+[package]
+name = "daily_missions"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+candid = { workspace = true }
+ciborium = { workspace = true }
+ic-stable-structures = { workspace = true }
+ic-cdk = { workspace = true }
+ic-cdk-timers = { workspace = true }
+ic-cdk-macros = { workspace = true }
+serde = { workspace = true }
+shared_utils = { workspace = true }
+serde_json = { workspace = true }
+
+[dev-dependencies]
+test_utils = { workspace = true }

--- a/src/canister/daily_missions/can.did
+++ b/src/canister/daily_missions/can.did
@@ -4,6 +4,7 @@ type SystemTime = int;
 // Core data structures
 type RewardType = variant {
     LoginStreak;
+    LoginStreakBonus;
     GameCompletion;
     AiVideoGeneration;
     Referral;
@@ -36,7 +37,6 @@ type LoginStreak = record {
     last_login_date: opt SystemTime;
     streak_start_date: opt SystemTime;
     claimed_rewards: vec ClaimedReward;
-    can_claim_today: bool;
 };
 
 type GameStreak = record {

--- a/src/canister/daily_missions/can.did
+++ b/src/canister/daily_missions/can.did
@@ -73,46 +73,7 @@ type UserDailyMissions = record {
     pending_rewards: vec PendingReward;
 };
 
-// Progress structures
-type LoginStreakProgress = record {
-    current_day: nat32;
-    target_day: nat32;
-    can_claim: bool;
-    reward_amount: nat64;
-    next_reset_in_hours: nat32;
-};
 
-type GameProgress = record {
-    current_count: nat32;
-    target_count: nat32;
-    can_claim: bool;
-    reward_amount: nat64;
-    hours_remaining: nat32;
-};
-
-type AiVideoProgress = record {
-    current_count: nat32;
-    target_count: nat32;
-    can_claim: bool;
-    reward_amount: nat64;
-    completed: bool;
-};
-
-type ReferralProgress = record {
-    current_count: nat32;
-    target_count: nat32;
-    can_claim: bool;
-    reward_amount: nat64;
-    completed: bool;
-};
-
-type MissionProgress = record {
-    login_streak: LoginStreakProgress;
-    game_progress: GameProgress;
-    ai_video_progress: AiVideoProgress;
-    referral_progress: ReferralProgress;
-    pending_rewards: vec PendingReward;
-};
 
 // API types
 type MissionType = variant {
@@ -143,7 +104,7 @@ type ClaimRewardRequest = record {
 type MissionUpdateResult = record {
     success: bool;
     message: text;
-    new_progress: opt MissionProgress;
+    new_progress: opt UserDailyMissions;
     reward_earned: opt ClaimedReward;
 };
 
@@ -163,8 +124,7 @@ type DailyMissionsInitArgs = record {
 service : (DailyMissionsInitArgs) -> {
     // Query methods
     "get_version": () -> (text) query;
-    "get_current_missions": () -> (variant { Ok: MissionProgress; Err: text }) query;
-    "get_user_missions_for_principal": (Principal) -> (variant { Ok: MissionProgress; Err: text }) query;
+    "get_user_daily_missions": (opt Principal) -> (variant { Ok: UserDailyMissions; Err: text }) query;
 
     // Update methods
     "update_mission": (UpdateMissionRequest) -> (MissionUpdateResult);

--- a/src/canister/daily_missions/can.did
+++ b/src/canister/daily_missions/can.did
@@ -1,0 +1,162 @@
+type Principal = principal;
+type SystemTime = int;
+
+// Core data structures
+type RewardType = variant {
+    LoginStreak;
+    GameCompletion;
+    AiVideoGeneration;
+    Referral;
+};
+
+type ClaimedReward = record {
+    reward_type: RewardType;
+    amount: nat64;
+    claimed_at: SystemTime;
+    day: nat32;
+};
+
+type ReferredUser = record {
+    principal_id: Principal;
+    referred_at: SystemTime;
+    is_active: bool;
+};
+
+type LoginStreak = record {
+    current_streak: nat32;
+    max_streak: nat32;
+    last_login_date: opt SystemTime;
+    streak_start_date: opt SystemTime;
+    claimed_rewards: vec ClaimedReward;
+    can_claim_today: bool;
+};
+
+type GameStreak = record {
+    games_played_today: nat32;
+    target_games: nat32;
+    last_reset_date: opt SystemTime;
+    claimed_today: bool;
+    total_games_completed: nat32;
+};
+
+type GenerateAiVideoCount = record {
+    videos_generated_today: nat32;
+    target_videos: nat32;
+    last_reset_date: opt SystemTime;
+    claimed_today: bool;
+    total_videos_generated: nat32;
+};
+
+type ReferralCount = record {
+    referrals_made_today: nat32;
+    target_referrals: nat32;
+    last_reset_date: opt SystemTime;
+    claimed_today: bool;
+    total_referrals_made: nat32;
+    referred_users: vec ReferredUser;
+};
+
+type UserDailyMissions = record {
+    login_streak: LoginStreak;
+    game_streak: GameStreak;
+    ai_video_count: GenerateAiVideoCount;
+    referral_count: ReferralCount;
+    last_updated: SystemTime;
+};
+
+// Progress structures
+type LoginStreakProgress = record {
+    current_day: nat32;
+    target_day: nat32;
+    can_claim: bool;
+    reward_amount: nat64;
+    next_reset_in_hours: nat32;
+};
+
+type GameProgress = record {
+    current_count: nat32;
+    target_count: nat32;
+    can_claim: bool;
+    reward_amount: nat64;
+    hours_remaining: nat32;
+};
+
+type AiVideoProgress = record {
+    current_count: nat32;
+    target_count: nat32;
+    can_claim: bool;
+    reward_amount: nat64;
+    hours_remaining: nat32;
+};
+
+type ReferralProgress = record {
+    current_count: nat32;
+    target_count: nat32;
+    can_claim: bool;
+    reward_amount: nat64;
+    hours_remaining: nat32;
+};
+
+type MissionProgress = record {
+    login_streak: LoginStreakProgress;
+    game_progress: GameProgress;
+    ai_video_progress: AiVideoProgress;
+    referral_progress: ReferralProgress;
+};
+
+// API types
+type MissionType = variant {
+    LoginStreak;
+    PlayGames;
+    GenerateAiVideos;
+    Referrals;
+};
+
+type MissionUpdateData = variant {
+    LoginEvent;
+    GamePlayed: record { game_id: text };
+    AiVideoGenerated: record { video_id: text };
+    ReferralMade: record { referred_user: Principal };
+};
+
+type UpdateMissionRequest = record {
+    mission_type: MissionType;
+    data: MissionUpdateData;
+};
+
+type ClaimRewardRequest = record {
+    mission_type: MissionType;
+};
+
+
+
+type MissionUpdateResult = record {
+    success: bool;
+    message: text;
+    new_progress: opt MissionProgress;
+    reward_earned: opt ClaimedReward;
+};
+
+type ClaimRewardResponse = record {
+    success: bool;
+    message: text;
+    reward_amount: opt nat64;
+    claimed_reward: opt ClaimedReward;
+};
+
+// Init args
+type DailyMissionsInitArgs = record {
+    version: text;
+    known_principal_ids: opt vec record { text; Principal };
+};
+
+service : (DailyMissionsInitArgs) -> {
+    // Query methods
+    "get_version": () -> (text) query;
+    "get_current_missions": () -> (variant { Ok: MissionProgress; Err: text }) query;
+    "get_user_missions_for_principal": (Principal) -> (variant { Ok: MissionProgress; Err: text }) query;
+
+    // Update methods
+    "update_mission": (UpdateMissionRequest) -> (MissionUpdateResult);
+    "claim_reward": (ClaimRewardRequest) -> (ClaimRewardResponse);
+}

--- a/src/canister/daily_missions/can.did
+++ b/src/canister/daily_missions/can.did
@@ -16,6 +16,14 @@ type ClaimedReward = record {
     day: nat32;
 };
 
+type PendingReward = record {
+    id: text;
+    reward_type: RewardType;
+    amount: nat64;
+    earned_at: SystemTime;
+    mission_day: nat32;
+};
+
 type ReferredUser = record {
     principal_id: Principal;
     referred_at: SystemTime;
@@ -40,18 +48,18 @@ type GameStreak = record {
 };
 
 type GenerateAiVideoCount = record {
-    videos_generated_today: nat32;
+    videos_generated_total: nat32;
     target_videos: nat32;
-    last_reset_date: opt SystemTime;
-    claimed_today: bool;
+    completed: bool;
+    reward_claimed: bool;
     total_videos_generated: nat32;
 };
 
 type ReferralCount = record {
-    referrals_made_today: nat32;
+    referrals_made_total: nat32;
     target_referrals: nat32;
-    last_reset_date: opt SystemTime;
-    claimed_today: bool;
+    completed: bool;
+    reward_claimed: bool;
     total_referrals_made: nat32;
     referred_users: vec ReferredUser;
 };
@@ -62,6 +70,7 @@ type UserDailyMissions = record {
     ai_video_count: GenerateAiVideoCount;
     referral_count: ReferralCount;
     last_updated: SystemTime;
+    pending_rewards: vec PendingReward;
 };
 
 // Progress structures
@@ -86,7 +95,7 @@ type AiVideoProgress = record {
     target_count: nat32;
     can_claim: bool;
     reward_amount: nat64;
-    hours_remaining: nat32;
+    completed: bool;
 };
 
 type ReferralProgress = record {
@@ -94,7 +103,7 @@ type ReferralProgress = record {
     target_count: nat32;
     can_claim: bool;
     reward_amount: nat64;
-    hours_remaining: nat32;
+    completed: bool;
 };
 
 type MissionProgress = record {
@@ -102,6 +111,7 @@ type MissionProgress = record {
     game_progress: GameProgress;
     ai_video_progress: AiVideoProgress;
     referral_progress: ReferralProgress;
+    pending_rewards: vec PendingReward;
 };
 
 // API types
@@ -125,7 +135,7 @@ type UpdateMissionRequest = record {
 };
 
 type ClaimRewardRequest = record {
-    mission_type: MissionType;
+    reward_id: text;
 };
 
 

--- a/src/canister/daily_missions/src/api/mod.rs
+++ b/src/canister/daily_missions/src/api/mod.rs
@@ -3,15 +3,15 @@ use ic_cdk::{caller, query, update};
 use serde::{Deserialize, Serialize};
 
 use crate::data_model::{
-    ClaimedReward, MissionProgress, MissionType, MissionUpdateResult, RewardType,
-    UserDailyMissions, AI_VIDEO_GENERATION_REWARD, DAILY_LOGIN_REWARD, GAME_COMPLETION_REWARD,
+    ClaimedReward, MissionType, MissionUpdateResult, RewardType, UserDailyMissions,
+    AI_VIDEO_GENERATION_REWARD, DAILY_LOGIN_REWARD, GAME_COMPLETION_REWARD,
     LOGIN_STREAK_COMPLETION_BONUS, LOGIN_STREAK_TARGET, REFERRAL_REWARD,
 };
 use crate::util::mission_utils::{
     add_pending_reward, update_ai_video_count, update_game_streak, update_login_streak,
     update_referral_count,
 };
-use crate::util::progress_utils::{build_mission_progress, remove_pending_reward_by_id};
+use crate::util::progress_utils::remove_pending_reward_by_id;
 use shared_utils::common::utils::system_time::get_current_system_time_from_ic;
 
 use crate::CANISTER_DATA;
@@ -45,24 +45,16 @@ pub struct ClaimRewardResponse {
 
 // Query endpoints
 #[query]
-fn get_current_missions() -> UserDailyMissions {
-    let user = caller();
-    CANISTER_DATA.with_borrow(|canister_data| canister_data.get_user_missions(&user))
-}
+fn get_user_daily_missions(principal: Option<Principal>) -> Result<UserDailyMissions, String> {
+    let user = match principal {
+        Some(p) => p,
+        None => caller(),
+    };
 
-#[query]
-fn get_current_mission_progress() -> MissionProgress {
-    let user = caller();
-    let now = get_current_system_time_from_ic();
     CANISTER_DATA.with_borrow(|canister_data| {
         let missions = canister_data.get_user_missions(&user);
-        build_mission_progress(&missions, now)
+        Ok(missions)
     })
-}
-
-#[query]
-fn get_user_missions_for_principal(principal: Principal) -> UserDailyMissions {
-    CANISTER_DATA.with_borrow(|canister_data| canister_data.get_user_missions(&principal))
 }
 
 // Update endpoints
@@ -218,7 +210,7 @@ fn update_mission(request: UpdateMissionRequest) -> MissionUpdateResult {
         MissionUpdateResult {
             success: result.0,
             message: result.1,
-            new_progress: Some(build_mission_progress(&missions, now)),
+            new_progress: Some(missions),
             reward_earned,
         }
     })

--- a/src/canister/daily_missions/src/api/mod.rs
+++ b/src/canister/daily_missions/src/api/mod.rs
@@ -236,7 +236,6 @@ fn claim_reward(request: ClaimRewardRequest) -> ClaimRewardResponse {
         if let Some(pending_reward) =
             remove_pending_reward_by_id(&mut missions.pending_rewards, &request.reward_id)
         {
-            // Create a claimed reward record
             let claimed_reward = ClaimedReward {
                 reward_type: pending_reward.reward_type.clone(),
                 amount: pending_reward.amount,
@@ -244,7 +243,6 @@ fn claim_reward(request: ClaimRewardRequest) -> ClaimRewardResponse {
                 day: pending_reward.mission_day,
             };
 
-            // Add to claimed rewards history based on reward type
             match pending_reward.reward_type {
                 RewardType::LoginStreak => {
                     missions

--- a/src/canister/daily_missions/src/api/mod.rs
+++ b/src/canister/daily_missions/src/api/mod.rs
@@ -4,16 +4,14 @@ use serde::{Deserialize, Serialize};
 
 use crate::data_model::{
     ClaimedReward, MissionProgress, MissionType, MissionUpdateResult, RewardType,
-    UserDailyMissions, AI_VIDEO_GENERATION_REWARD, GAME_COMPLETION_REWARD, LOGIN_STREAK_REWARD,
-    LOGIN_STREAK_TARGET, REFERRAL_REWARD,
+    UserDailyMissions, AI_VIDEO_GENERATION_REWARD, DAILY_LOGIN_REWARD, GAME_COMPLETION_REWARD,
+    LOGIN_STREAK_COMPLETION_BONUS, LOGIN_STREAK_TARGET, REFERRAL_REWARD,
 };
 use crate::util::mission_utils::{
-    add_pending_reward, generate_reward_id, update_ai_video_count, update_game_streak,
-    update_login_streak, update_referral_count,
+    add_pending_reward, update_ai_video_count, update_game_streak, update_login_streak,
+    update_referral_count,
 };
-use crate::util::progress_utils::{
-    build_mission_progress, find_pending_reward_by_id, remove_pending_reward_by_id,
-};
+use crate::util::progress_utils::{build_mission_progress, remove_pending_reward_by_id};
 use shared_utils::common::utils::system_time::get_current_system_time_from_ic;
 
 use crate::CANISTER_DATA;
@@ -80,23 +78,33 @@ fn update_mission(request: UpdateMissionRequest) -> MissionUpdateResult {
 
         let result = match request.mission_type {
             MissionType::LoginStreak => {
-                let prev_can_claim = missions.login_streak.can_claim_today;
+                let prev_streak = missions.login_streak.current_streak;
 
                 if let MissionUpdateData::LoginEvent = request.data {
                     let result = update_login_streak(&mut missions.login_streak, now);
 
-                    // Check if we should add a pending reward
-                    if !prev_can_claim
-                        && missions.login_streak.can_claim_today
-                        && missions.login_streak.current_streak >= LOGIN_STREAK_TARGET
-                    {
+                    // Add daily login reward if this is a new login (streak increased or started)
+                    if result.0 && missions.login_streak.current_streak > prev_streak {
                         let current_streak = missions.login_streak.current_streak;
                         add_pending_reward(
                             &mut missions,
                             &user,
                             RewardType::LoginStreak,
-                            LOGIN_STREAK_REWARD,
+                            DAILY_LOGIN_REWARD,
                             current_streak,
+                            now,
+                        );
+                    }
+
+                    // Add streak completion bonus when reaching 7-day target
+                    let current_streak = missions.login_streak.current_streak;
+                    if current_streak == LOGIN_STREAK_TARGET && prev_streak < LOGIN_STREAK_TARGET {
+                        add_pending_reward(
+                            &mut missions,
+                            &user,
+                            RewardType::LoginStreakBonus,
+                            LOGIN_STREAK_COMPLETION_BONUS,
+                            LOGIN_STREAK_TARGET,
                             now,
                         );
                     }
@@ -243,7 +251,12 @@ fn claim_reward(request: ClaimRewardRequest) -> ClaimRewardResponse {
                         .login_streak
                         .claimed_rewards
                         .push(claimed_reward.clone());
-                    missions.login_streak.can_claim_today = false;
+                }
+                RewardType::LoginStreakBonus => {
+                    missions
+                        .login_streak
+                        .claimed_rewards
+                        .push(claimed_reward.clone());
                 }
                 RewardType::GameCompletion => {
                     missions.game_streak.claimed_today = true;

--- a/src/canister/daily_missions/src/api/mod.rs
+++ b/src/canister/daily_missions/src/api/mod.rs
@@ -1,0 +1,478 @@
+use candid::{CandidType, Principal};
+use ic_cdk::{caller, query, update};
+use serde::{Deserialize, Serialize};
+use std::time::SystemTime;
+
+use crate::data_model::{
+    AiVideoProgress, ClaimedReward, GameProgress, GameStreak, GenerateAiVideoCount, LoginStreak,
+    LoginStreakProgress, MissionProgress, MissionType, MissionUpdateResult, ReferralCount,
+    ReferralProgress, ReferredUser, RewardType, UserDailyMissions, AI_VIDEO_GENERATION_REWARD,
+    GAME_COMPLETION_REWARD, LOGIN_STREAK_REWARD, LOGIN_STREAK_TARGET, REFERRAL_REWARD,
+};
+use shared_utils::common::utils::system_time::get_current_system_time_from_ic;
+
+use crate::CANISTER_DATA;
+
+#[derive(CandidType, Serialize, Deserialize, Clone, Debug)]
+pub struct UpdateMissionRequest {
+    pub mission_type: MissionType,
+    pub data: MissionUpdateData,
+}
+
+#[derive(CandidType, Serialize, Deserialize, Clone, Debug)]
+pub enum MissionUpdateData {
+    LoginEvent,
+    GamePlayed { game_id: String },
+    AiVideoGenerated { video_id: String },
+    ReferralMade { referred_user: Principal },
+}
+
+#[derive(CandidType, Serialize, Deserialize, Clone, Debug)]
+pub struct ClaimRewardRequest {
+    pub mission_type: MissionType,
+}
+
+#[derive(CandidType, Serialize, Deserialize, Clone, Debug)]
+pub struct ClaimRewardResponse {
+    pub success: bool,
+    pub message: String,
+    pub reward_amount: Option<u64>,
+    pub claimed_reward: Option<ClaimedReward>,
+}
+
+// Query endpoints
+#[query]
+fn get_current_missions() -> Result<MissionProgress, String> {
+    let user = caller();
+
+    CANISTER_DATA.with_borrow(|canister_data| {
+        let missions = canister_data.get_user_missions(&user);
+        Ok(build_mission_progress(&missions))
+    })
+}
+
+#[query]
+fn get_user_missions_for_principal(user: Principal) -> Result<MissionProgress, String> {
+    CANISTER_DATA.with_borrow(|canister_data| {
+        let missions = canister_data.get_user_missions(&user);
+        Ok(build_mission_progress(&missions))
+    })
+}
+
+// Update endpoints
+#[update]
+fn update_mission(request: UpdateMissionRequest) -> MissionUpdateResult {
+    let user = caller();
+    let now = get_current_system_time_from_ic();
+
+    CANISTER_DATA.with_borrow_mut(|canister_data| {
+        let mut missions = canister_data.get_user_missions(&user);
+        missions.last_updated = now;
+
+        let result = match request.mission_type {
+            MissionType::LoginStreak => {
+                if let MissionUpdateData::LoginEvent = request.data {
+                    update_login_streak(&mut missions.login_streak, now)
+                } else {
+                    return MissionUpdateResult {
+                        success: false,
+                        message: "Invalid data for login streak mission".to_string(),
+                        new_progress: None,
+                        reward_earned: None,
+                    };
+                }
+            }
+            MissionType::PlayGames => {
+                if let MissionUpdateData::GamePlayed { .. } = request.data {
+                    update_game_streak(&mut missions.game_streak, now)
+                } else {
+                    return MissionUpdateResult {
+                        success: false,
+                        message: "Invalid data for game mission".to_string(),
+                        new_progress: None,
+                        reward_earned: None,
+                    };
+                }
+            }
+            MissionType::GenerateAiVideos => {
+                if let MissionUpdateData::AiVideoGenerated { .. } = request.data {
+                    update_ai_video_count(&mut missions.ai_video_count, now)
+                } else {
+                    return MissionUpdateResult {
+                        success: false,
+                        message: "Invalid data for AI video mission".to_string(),
+                        new_progress: None,
+                        reward_earned: None,
+                    };
+                }
+            }
+            MissionType::Referrals => {
+                if let MissionUpdateData::ReferralMade { referred_user } = request.data {
+                    update_referral_count(&mut missions.referral_count, referred_user, now)
+                } else {
+                    return MissionUpdateResult {
+                        success: false,
+                        message: "Invalid data for referral mission".to_string(),
+                        new_progress: None,
+                        reward_earned: None,
+                    };
+                }
+            }
+        };
+
+        canister_data.update_user_missions(user, missions.clone());
+
+        MissionUpdateResult {
+            success: result.0,
+            message: result.1,
+            new_progress: Some(build_mission_progress(&missions)),
+            reward_earned: None,
+        }
+    })
+}
+
+#[update]
+fn claim_reward(request: ClaimRewardRequest) -> ClaimRewardResponse {
+    let user = caller();
+    let now = get_current_system_time_from_ic();
+
+    CANISTER_DATA.with_borrow_mut(|canister_data| {
+        let mut missions = canister_data.get_user_missions(&user);
+
+        let result = match request.mission_type {
+            MissionType::LoginStreak => {
+                if missions.login_streak.can_claim_today
+                    && missions.login_streak.current_streak >= LOGIN_STREAK_TARGET
+                {
+                    let reward = ClaimedReward {
+                        reward_type: RewardType::LoginStreak,
+                        amount: LOGIN_STREAK_REWARD,
+                        claimed_at: now,
+                        day: missions.login_streak.current_streak,
+                    };
+                    missions.login_streak.claimed_rewards.push(reward.clone());
+                    missions.login_streak.can_claim_today = false;
+
+                    canister_data.update_user_missions(user, missions);
+
+                    ClaimRewardResponse {
+                        success: true,
+                        message: "Login streak reward claimed successfully".to_string(),
+                        reward_amount: Some(LOGIN_STREAK_REWARD),
+                        claimed_reward: Some(reward),
+                    }
+                } else {
+                    ClaimRewardResponse {
+                        success: false,
+                        message: "Login streak reward not available for claim".to_string(),
+                        reward_amount: None,
+                        claimed_reward: None,
+                    }
+                }
+            }
+            MissionType::PlayGames => {
+                if !missions.game_streak.claimed_today
+                    && missions.game_streak.games_played_today >= missions.game_streak.target_games
+                {
+                    let reward = ClaimedReward {
+                        reward_type: RewardType::GameCompletion,
+                        amount: GAME_COMPLETION_REWARD,
+                        claimed_at: now,
+                        day: 1,
+                    };
+                    missions.game_streak.claimed_today = true;
+                    missions.game_streak.total_games_completed += 1;
+
+                    canister_data.update_user_missions(user, missions);
+
+                    ClaimRewardResponse {
+                        success: true,
+                        message: "Game completion reward claimed successfully".to_string(),
+                        reward_amount: Some(GAME_COMPLETION_REWARD),
+                        claimed_reward: Some(reward),
+                    }
+                } else {
+                    ClaimRewardResponse {
+                        success: false,
+                        message: "Game completion reward not available for claim".to_string(),
+                        reward_amount: None,
+                        claimed_reward: None,
+                    }
+                }
+            }
+            MissionType::GenerateAiVideos => {
+                if !missions.ai_video_count.claimed_today
+                    && missions.ai_video_count.videos_generated_today
+                        >= missions.ai_video_count.target_videos
+                {
+                    let reward = ClaimedReward {
+                        reward_type: RewardType::AiVideoGeneration,
+                        amount: AI_VIDEO_GENERATION_REWARD,
+                        claimed_at: now,
+                        day: 1,
+                    };
+                    missions.ai_video_count.claimed_today = true;
+                    missions.ai_video_count.total_videos_generated +=
+                        missions.ai_video_count.videos_generated_today;
+
+                    canister_data.update_user_missions(user, missions);
+
+                    ClaimRewardResponse {
+                        success: true,
+                        message: "AI video generation reward claimed successfully".to_string(),
+                        reward_amount: Some(AI_VIDEO_GENERATION_REWARD),
+                        claimed_reward: Some(reward),
+                    }
+                } else {
+                    ClaimRewardResponse {
+                        success: false,
+                        message: "AI video generation reward not available for claim".to_string(),
+                        reward_amount: None,
+                        claimed_reward: None,
+                    }
+                }
+            }
+            MissionType::Referrals => {
+                if !missions.referral_count.claimed_today
+                    && missions.referral_count.referrals_made_today
+                        >= missions.referral_count.target_referrals
+                {
+                    let reward = ClaimedReward {
+                        reward_type: RewardType::Referral,
+                        amount: REFERRAL_REWARD,
+                        claimed_at: now,
+                        day: 1,
+                    };
+                    missions.referral_count.claimed_today = true;
+                    missions.referral_count.total_referrals_made +=
+                        missions.referral_count.referrals_made_today;
+
+                    canister_data.update_user_missions(user, missions);
+
+                    ClaimRewardResponse {
+                        success: true,
+                        message: "Referral reward claimed successfully".to_string(),
+                        reward_amount: Some(REFERRAL_REWARD),
+                        claimed_reward: Some(reward),
+                    }
+                } else {
+                    ClaimRewardResponse {
+                        success: false,
+                        message: "Referral reward not available for claim".to_string(),
+                        reward_amount: None,
+                        claimed_reward: None,
+                    }
+                }
+            }
+        };
+
+        result
+    })
+}
+
+// Helper functions
+fn build_mission_progress(missions: &UserDailyMissions) -> MissionProgress {
+    let now = get_current_system_time_from_ic();
+
+    MissionProgress {
+        login_streak: LoginStreakProgress {
+            current_day: missions.login_streak.current_streak,
+            target_day: LOGIN_STREAK_TARGET,
+            can_claim: missions.login_streak.can_claim_today
+                && missions.login_streak.current_streak >= LOGIN_STREAK_TARGET,
+            reward_amount: LOGIN_STREAK_REWARD,
+            next_reset_in_hours: calculate_hours_until_next_day(now),
+        },
+        game_progress: GameProgress {
+            current_count: missions.game_streak.games_played_today,
+            target_count: missions.game_streak.target_games,
+            can_claim: !missions.game_streak.claimed_today
+                && missions.game_streak.games_played_today >= missions.game_streak.target_games,
+            reward_amount: GAME_COMPLETION_REWARD,
+            hours_remaining: calculate_hours_until_reset(
+                &missions.game_streak.last_reset_date,
+                now,
+            ),
+        },
+        ai_video_progress: AiVideoProgress {
+            current_count: missions.ai_video_count.videos_generated_today,
+            target_count: missions.ai_video_count.target_videos,
+            can_claim: !missions.ai_video_count.claimed_today
+                && missions.ai_video_count.videos_generated_today
+                    >= missions.ai_video_count.target_videos,
+            reward_amount: AI_VIDEO_GENERATION_REWARD,
+            hours_remaining: calculate_hours_until_reset(
+                &missions.ai_video_count.last_reset_date,
+                now,
+            ),
+        },
+        referral_progress: ReferralProgress {
+            current_count: missions.referral_count.referrals_made_today,
+            target_count: missions.referral_count.target_referrals,
+            can_claim: !missions.referral_count.claimed_today
+                && missions.referral_count.referrals_made_today
+                    >= missions.referral_count.target_referrals,
+            reward_amount: REFERRAL_REWARD,
+            hours_remaining: calculate_hours_until_reset(
+                &missions.referral_count.last_reset_date,
+                now,
+            ),
+        },
+    }
+}
+
+fn update_login_streak(login_streak: &mut LoginStreak, now: SystemTime) -> (bool, String) {
+    let today = get_day_from_timestamp(now);
+
+    if let Some(last_login) = login_streak.last_login_date {
+        let last_login_day = get_day_from_timestamp(last_login);
+
+        if today == last_login_day {
+            return (true, "Already logged in today".to_string());
+        }
+
+        if today == last_login_day + 1 {
+            // Consecutive day
+            login_streak.current_streak += 1;
+            login_streak.can_claim_today = true;
+        } else {
+            // Streak broken
+            login_streak.current_streak = 1;
+            login_streak.streak_start_date = Some(now);
+            login_streak.can_claim_today = true;
+        }
+    } else {
+        // First login
+        login_streak.current_streak = 1;
+        login_streak.streak_start_date = Some(now);
+        login_streak.can_claim_today = true;
+    }
+
+    login_streak.last_login_date = Some(now);
+    login_streak.max_streak = login_streak.max_streak.max(login_streak.current_streak);
+
+    (
+        true,
+        format!(
+            "Login streak updated to {} days",
+            login_streak.current_streak
+        ),
+    )
+}
+
+fn update_game_streak(game_streak: &mut GameStreak, now: SystemTime) -> (bool, String) {
+    if should_reset_daily_counter(&game_streak.last_reset_date, now) {
+        game_streak.games_played_today = 0;
+        game_streak.claimed_today = false;
+        game_streak.last_reset_date = Some(now);
+    }
+
+    game_streak.games_played_today += 1;
+
+    (
+        true,
+        format!(
+            "Games played today: {}/{}",
+            game_streak.games_played_today, game_streak.target_games
+        ),
+    )
+}
+
+fn update_ai_video_count(
+    ai_video_count: &mut GenerateAiVideoCount,
+    now: SystemTime,
+) -> (bool, String) {
+    if should_reset_daily_counter(&ai_video_count.last_reset_date, now) {
+        ai_video_count.videos_generated_today = 0;
+        ai_video_count.claimed_today = false;
+        ai_video_count.last_reset_date = Some(now);
+    }
+
+    ai_video_count.videos_generated_today += 1;
+
+    (
+        true,
+        format!(
+            "AI videos generated today: {}/{}",
+            ai_video_count.videos_generated_today, ai_video_count.target_videos
+        ),
+    )
+}
+
+fn update_referral_count(
+    referral_count: &mut ReferralCount,
+    referred_user: Principal,
+    now: SystemTime,
+) -> (bool, String) {
+    // Check if user was already referred
+    if referral_count
+        .referred_users
+        .iter()
+        .any(|u| u.principal_id == referred_user)
+    {
+        return (false, "User already referred".to_string());
+    }
+
+    if should_reset_daily_counter(&referral_count.last_reset_date, now) {
+        referral_count.referrals_made_today = 0;
+        referral_count.claimed_today = false;
+        referral_count.last_reset_date = Some(now);
+    }
+
+    referral_count.referrals_made_today += 1;
+    referral_count.referred_users.push(ReferredUser {
+        principal_id: referred_user,
+        referred_at: now,
+        is_active: true,
+    });
+
+    (
+        true,
+        format!(
+            "Referrals made today: {}/{}",
+            referral_count.referrals_made_today, referral_count.target_referrals
+        ),
+    )
+}
+
+fn should_reset_daily_counter(last_reset: &Option<SystemTime>, now: SystemTime) -> bool {
+    match last_reset {
+        Some(last) => {
+            let last_day = get_day_from_timestamp(*last);
+            let current_day = get_day_from_timestamp(now);
+            current_day > last_day
+        }
+        None => true,
+    }
+}
+
+fn get_day_from_timestamp(time: SystemTime) -> u64 {
+    time.duration_since(SystemTime::UNIX_EPOCH)
+        .unwrap()
+        .as_secs()
+        / (24 * 60 * 60)
+}
+
+fn calculate_hours_until_next_day(now: SystemTime) -> u32 {
+    let seconds_since_epoch = now
+        .duration_since(SystemTime::UNIX_EPOCH)
+        .unwrap()
+        .as_secs();
+    let seconds_in_day = 24 * 60 * 60;
+    let seconds_until_next_day = seconds_in_day - (seconds_since_epoch % seconds_in_day);
+    (seconds_until_next_day / 3600) as u32
+}
+
+fn calculate_hours_until_reset(last_reset: &Option<SystemTime>, now: SystemTime) -> u32 {
+    match last_reset {
+        Some(last) => {
+            let hours_since_reset = now.duration_since(*last).unwrap().as_secs() / 3600;
+            if hours_since_reset >= 24 {
+                0
+            } else {
+                (24 - hours_since_reset) as u32
+            }
+        }
+        None => 0,
+    }
+}

--- a/src/canister/daily_missions/src/api/mod.rs
+++ b/src/canister/daily_missions/src/api/mod.rs
@@ -1,13 +1,18 @@
 use candid::{CandidType, Principal};
 use ic_cdk::{caller, query, update};
 use serde::{Deserialize, Serialize};
-use std::time::SystemTime;
 
 use crate::data_model::{
-    AiVideoProgress, ClaimedReward, GameProgress, GameStreak, GenerateAiVideoCount, LoginStreak,
-    LoginStreakProgress, MissionProgress, MissionType, MissionUpdateResult, ReferralCount,
-    ReferralProgress, ReferredUser, RewardType, UserDailyMissions, AI_VIDEO_GENERATION_REWARD,
-    GAME_COMPLETION_REWARD, LOGIN_STREAK_REWARD, LOGIN_STREAK_TARGET, REFERRAL_REWARD,
+    ClaimedReward, MissionProgress, MissionType, MissionUpdateResult, RewardType,
+    UserDailyMissions, AI_VIDEO_GENERATION_REWARD, GAME_COMPLETION_REWARD, LOGIN_STREAK_REWARD,
+    LOGIN_STREAK_TARGET, REFERRAL_REWARD,
+};
+use crate::util::mission_utils::{
+    add_pending_reward, generate_reward_id, update_ai_video_count, update_game_streak,
+    update_login_streak, update_referral_count,
+};
+use crate::util::progress_utils::{
+    build_mission_progress, find_pending_reward_by_id, remove_pending_reward_by_id,
 };
 use shared_utils::common::utils::system_time::get_current_system_time_from_ic;
 
@@ -29,7 +34,7 @@ pub enum MissionUpdateData {
 
 #[derive(CandidType, Serialize, Deserialize, Clone, Debug)]
 pub struct ClaimRewardRequest {
-    pub mission_type: MissionType,
+    pub reward_id: String,
 }
 
 #[derive(CandidType, Serialize, Deserialize, Clone, Debug)]
@@ -42,21 +47,24 @@ pub struct ClaimRewardResponse {
 
 // Query endpoints
 #[query]
-fn get_current_missions() -> Result<MissionProgress, String> {
+fn get_current_missions() -> UserDailyMissions {
     let user = caller();
+    CANISTER_DATA.with_borrow(|canister_data| canister_data.get_user_missions(&user))
+}
 
+#[query]
+fn get_current_mission_progress() -> MissionProgress {
+    let user = caller();
+    let now = get_current_system_time_from_ic();
     CANISTER_DATA.with_borrow(|canister_data| {
         let missions = canister_data.get_user_missions(&user);
-        Ok(build_mission_progress(&missions))
+        build_mission_progress(&missions, now)
     })
 }
 
 #[query]
-fn get_user_missions_for_principal(user: Principal) -> Result<MissionProgress, String> {
-    CANISTER_DATA.with_borrow(|canister_data| {
-        let missions = canister_data.get_user_missions(&user);
-        Ok(build_mission_progress(&missions))
-    })
+fn get_user_missions_for_principal(principal: Principal) -> UserDailyMissions {
+    CANISTER_DATA.with_borrow(|canister_data| canister_data.get_user_missions(&principal))
 }
 
 // Update endpoints
@@ -68,11 +76,31 @@ fn update_mission(request: UpdateMissionRequest) -> MissionUpdateResult {
     CANISTER_DATA.with_borrow_mut(|canister_data| {
         let mut missions = canister_data.get_user_missions(&user);
         missions.last_updated = now;
+        let reward_earned = None;
 
         let result = match request.mission_type {
             MissionType::LoginStreak => {
+                let prev_can_claim = missions.login_streak.can_claim_today;
+
                 if let MissionUpdateData::LoginEvent = request.data {
-                    update_login_streak(&mut missions.login_streak, now)
+                    let result = update_login_streak(&mut missions.login_streak, now);
+
+                    // Check if we should add a pending reward
+                    if !prev_can_claim
+                        && missions.login_streak.can_claim_today
+                        && missions.login_streak.current_streak >= LOGIN_STREAK_TARGET
+                    {
+                        let current_streak = missions.login_streak.current_streak;
+                        add_pending_reward(
+                            &mut missions,
+                            &user,
+                            RewardType::LoginStreak,
+                            LOGIN_STREAK_REWARD,
+                            current_streak,
+                            now,
+                        );
+                    }
+                    result
                 } else {
                     return MissionUpdateResult {
                         success: false,
@@ -83,8 +111,28 @@ fn update_mission(request: UpdateMissionRequest) -> MissionUpdateResult {
                 }
             }
             MissionType::PlayGames => {
+                let prev_games = missions.game_streak.games_played_today;
+                let prev_claimed = missions.game_streak.claimed_today;
+
                 if let MissionUpdateData::GamePlayed { .. } = request.data {
-                    update_game_streak(&mut missions.game_streak, now)
+                    let result = update_game_streak(&mut missions.game_streak, now);
+
+                    // Check if we should add a pending reward
+                    if !prev_claimed
+                        && missions.game_streak.games_played_today
+                            >= missions.game_streak.target_games
+                        && prev_games < missions.game_streak.target_games
+                    {
+                        add_pending_reward(
+                            &mut missions,
+                            &user,
+                            RewardType::GameCompletion,
+                            GAME_COMPLETION_REWARD,
+                            1,
+                            now,
+                        );
+                    }
+                    result
                 } else {
                     return MissionUpdateResult {
                         success: false,
@@ -95,8 +143,26 @@ fn update_mission(request: UpdateMissionRequest) -> MissionUpdateResult {
                 }
             }
             MissionType::GenerateAiVideos => {
+                let prev_completed = missions.ai_video_count.completed;
+
                 if let MissionUpdateData::AiVideoGenerated { .. } = request.data {
-                    update_ai_video_count(&mut missions.ai_video_count, now)
+                    let result = update_ai_video_count(&mut missions.ai_video_count, now);
+
+                    // Check if we should add a pending reward
+                    if !prev_completed
+                        && missions.ai_video_count.completed
+                        && !missions.ai_video_count.reward_claimed
+                    {
+                        add_pending_reward(
+                            &mut missions,
+                            &user,
+                            RewardType::AiVideoGeneration,
+                            AI_VIDEO_GENERATION_REWARD,
+                            1,
+                            now,
+                        );
+                    }
+                    result
                 } else {
                     return MissionUpdateResult {
                         success: false,
@@ -107,8 +173,27 @@ fn update_mission(request: UpdateMissionRequest) -> MissionUpdateResult {
                 }
             }
             MissionType::Referrals => {
+                let prev_completed = missions.referral_count.completed;
+
                 if let MissionUpdateData::ReferralMade { referred_user } = request.data {
-                    update_referral_count(&mut missions.referral_count, referred_user, now)
+                    let result =
+                        update_referral_count(&mut missions.referral_count, referred_user, now);
+
+                    // Check if we should add a pending reward
+                    if !prev_completed
+                        && missions.referral_count.completed
+                        && !missions.referral_count.reward_claimed
+                    {
+                        add_pending_reward(
+                            &mut missions,
+                            &user,
+                            RewardType::Referral,
+                            REFERRAL_REWARD,
+                            1,
+                            now,
+                        );
+                    }
+                    result
                 } else {
                     return MissionUpdateResult {
                         success: false,
@@ -125,8 +210,8 @@ fn update_mission(request: UpdateMissionRequest) -> MissionUpdateResult {
         MissionUpdateResult {
             success: result.0,
             message: result.1,
-            new_progress: Some(build_mission_progress(&missions)),
-            reward_earned: None,
+            new_progress: Some(build_mission_progress(&missions, now)),
+            reward_earned,
         }
     })
 }
@@ -139,340 +224,57 @@ fn claim_reward(request: ClaimRewardRequest) -> ClaimRewardResponse {
     CANISTER_DATA.with_borrow_mut(|canister_data| {
         let mut missions = canister_data.get_user_missions(&user);
 
-        let result = match request.mission_type {
-            MissionType::LoginStreak => {
-                if missions.login_streak.can_claim_today
-                    && missions.login_streak.current_streak >= LOGIN_STREAK_TARGET
-                {
-                    let reward = ClaimedReward {
-                        reward_type: RewardType::LoginStreak,
-                        amount: LOGIN_STREAK_REWARD,
-                        claimed_at: now,
-                        day: missions.login_streak.current_streak,
-                    };
-                    missions.login_streak.claimed_rewards.push(reward.clone());
+        // Find and remove the pending reward with the given ID
+        if let Some(pending_reward) =
+            remove_pending_reward_by_id(&mut missions.pending_rewards, &request.reward_id)
+        {
+            // Create a claimed reward record
+            let claimed_reward = ClaimedReward {
+                reward_type: pending_reward.reward_type.clone(),
+                amount: pending_reward.amount,
+                claimed_at: now,
+                day: pending_reward.mission_day,
+            };
+
+            // Add to claimed rewards history based on reward type
+            match pending_reward.reward_type {
+                RewardType::LoginStreak => {
+                    missions
+                        .login_streak
+                        .claimed_rewards
+                        .push(claimed_reward.clone());
                     missions.login_streak.can_claim_today = false;
-
-                    canister_data.update_user_missions(user, missions);
-
-                    ClaimRewardResponse {
-                        success: true,
-                        message: "Login streak reward claimed successfully".to_string(),
-                        reward_amount: Some(LOGIN_STREAK_REWARD),
-                        claimed_reward: Some(reward),
-                    }
-                } else {
-                    ClaimRewardResponse {
-                        success: false,
-                        message: "Login streak reward not available for claim".to_string(),
-                        reward_amount: None,
-                        claimed_reward: None,
-                    }
                 }
-            }
-            MissionType::PlayGames => {
-                if !missions.game_streak.claimed_today
-                    && missions.game_streak.games_played_today >= missions.game_streak.target_games
-                {
-                    let reward = ClaimedReward {
-                        reward_type: RewardType::GameCompletion,
-                        amount: GAME_COMPLETION_REWARD,
-                        claimed_at: now,
-                        day: 1,
-                    };
+                RewardType::GameCompletion => {
                     missions.game_streak.claimed_today = true;
                     missions.game_streak.total_games_completed += 1;
-
-                    canister_data.update_user_missions(user, missions);
-
-                    ClaimRewardResponse {
-                        success: true,
-                        message: "Game completion reward claimed successfully".to_string(),
-                        reward_amount: Some(GAME_COMPLETION_REWARD),
-                        claimed_reward: Some(reward),
-                    }
-                } else {
-                    ClaimRewardResponse {
-                        success: false,
-                        message: "Game completion reward not available for claim".to_string(),
-                        reward_amount: None,
-                        claimed_reward: None,
-                    }
+                }
+                RewardType::AiVideoGeneration => {
+                    missions.ai_video_count.reward_claimed = true;
+                }
+                RewardType::Referral => {
+                    missions.referral_count.reward_claimed = true;
                 }
             }
-            MissionType::GenerateAiVideos => {
-                if !missions.ai_video_count.claimed_today
-                    && missions.ai_video_count.videos_generated_today
-                        >= missions.ai_video_count.target_videos
-                {
-                    let reward = ClaimedReward {
-                        reward_type: RewardType::AiVideoGeneration,
-                        amount: AI_VIDEO_GENERATION_REWARD,
-                        claimed_at: now,
-                        day: 1,
-                    };
-                    missions.ai_video_count.claimed_today = true;
-                    missions.ai_video_count.total_videos_generated +=
-                        missions.ai_video_count.videos_generated_today;
 
-                    canister_data.update_user_missions(user, missions);
+            canister_data.update_user_missions(user, missions);
 
-                    ClaimRewardResponse {
-                        success: true,
-                        message: "AI video generation reward claimed successfully".to_string(),
-                        reward_amount: Some(AI_VIDEO_GENERATION_REWARD),
-                        claimed_reward: Some(reward),
-                    }
-                } else {
-                    ClaimRewardResponse {
-                        success: false,
-                        message: "AI video generation reward not available for claim".to_string(),
-                        reward_amount: None,
-                        claimed_reward: None,
-                    }
-                }
+            ClaimRewardResponse {
+                success: true,
+                message: format!(
+                    "{:?} reward claimed successfully",
+                    pending_reward.reward_type
+                ),
+                reward_amount: Some(pending_reward.amount),
+                claimed_reward: Some(claimed_reward),
             }
-            MissionType::Referrals => {
-                if !missions.referral_count.claimed_today
-                    && missions.referral_count.referrals_made_today
-                        >= missions.referral_count.target_referrals
-                {
-                    let reward = ClaimedReward {
-                        reward_type: RewardType::Referral,
-                        amount: REFERRAL_REWARD,
-                        claimed_at: now,
-                        day: 1,
-                    };
-                    missions.referral_count.claimed_today = true;
-                    missions.referral_count.total_referrals_made +=
-                        missions.referral_count.referrals_made_today;
-
-                    canister_data.update_user_missions(user, missions);
-
-                    ClaimRewardResponse {
-                        success: true,
-                        message: "Referral reward claimed successfully".to_string(),
-                        reward_amount: Some(REFERRAL_REWARD),
-                        claimed_reward: Some(reward),
-                    }
-                } else {
-                    ClaimRewardResponse {
-                        success: false,
-                        message: "Referral reward not available for claim".to_string(),
-                        reward_amount: None,
-                        claimed_reward: None,
-                    }
-                }
-            }
-        };
-
-        result
-    })
-}
-
-// Helper functions
-fn build_mission_progress(missions: &UserDailyMissions) -> MissionProgress {
-    let now = get_current_system_time_from_ic();
-
-    MissionProgress {
-        login_streak: LoginStreakProgress {
-            current_day: missions.login_streak.current_streak,
-            target_day: LOGIN_STREAK_TARGET,
-            can_claim: missions.login_streak.can_claim_today
-                && missions.login_streak.current_streak >= LOGIN_STREAK_TARGET,
-            reward_amount: LOGIN_STREAK_REWARD,
-            next_reset_in_hours: calculate_hours_until_next_day(now),
-        },
-        game_progress: GameProgress {
-            current_count: missions.game_streak.games_played_today,
-            target_count: missions.game_streak.target_games,
-            can_claim: !missions.game_streak.claimed_today
-                && missions.game_streak.games_played_today >= missions.game_streak.target_games,
-            reward_amount: GAME_COMPLETION_REWARD,
-            hours_remaining: calculate_hours_until_reset(
-                &missions.game_streak.last_reset_date,
-                now,
-            ),
-        },
-        ai_video_progress: AiVideoProgress {
-            current_count: missions.ai_video_count.videos_generated_today,
-            target_count: missions.ai_video_count.target_videos,
-            can_claim: !missions.ai_video_count.claimed_today
-                && missions.ai_video_count.videos_generated_today
-                    >= missions.ai_video_count.target_videos,
-            reward_amount: AI_VIDEO_GENERATION_REWARD,
-            hours_remaining: calculate_hours_until_reset(
-                &missions.ai_video_count.last_reset_date,
-                now,
-            ),
-        },
-        referral_progress: ReferralProgress {
-            current_count: missions.referral_count.referrals_made_today,
-            target_count: missions.referral_count.target_referrals,
-            can_claim: !missions.referral_count.claimed_today
-                && missions.referral_count.referrals_made_today
-                    >= missions.referral_count.target_referrals,
-            reward_amount: REFERRAL_REWARD,
-            hours_remaining: calculate_hours_until_reset(
-                &missions.referral_count.last_reset_date,
-                now,
-            ),
-        },
-    }
-}
-
-fn update_login_streak(login_streak: &mut LoginStreak, now: SystemTime) -> (bool, String) {
-    let today = get_day_from_timestamp(now);
-
-    if let Some(last_login) = login_streak.last_login_date {
-        let last_login_day = get_day_from_timestamp(last_login);
-
-        if today == last_login_day {
-            return (true, "Already logged in today".to_string());
-        }
-
-        if today == last_login_day + 1 {
-            // Consecutive day
-            login_streak.current_streak += 1;
-            login_streak.can_claim_today = true;
         } else {
-            // Streak broken
-            login_streak.current_streak = 1;
-            login_streak.streak_start_date = Some(now);
-            login_streak.can_claim_today = true;
-        }
-    } else {
-        // First login
-        login_streak.current_streak = 1;
-        login_streak.streak_start_date = Some(now);
-        login_streak.can_claim_today = true;
-    }
-
-    login_streak.last_login_date = Some(now);
-    login_streak.max_streak = login_streak.max_streak.max(login_streak.current_streak);
-
-    (
-        true,
-        format!(
-            "Login streak updated to {} days",
-            login_streak.current_streak
-        ),
-    )
-}
-
-fn update_game_streak(game_streak: &mut GameStreak, now: SystemTime) -> (bool, String) {
-    if should_reset_daily_counter(&game_streak.last_reset_date, now) {
-        game_streak.games_played_today = 0;
-        game_streak.claimed_today = false;
-        game_streak.last_reset_date = Some(now);
-    }
-
-    game_streak.games_played_today += 1;
-
-    (
-        true,
-        format!(
-            "Games played today: {}/{}",
-            game_streak.games_played_today, game_streak.target_games
-        ),
-    )
-}
-
-fn update_ai_video_count(
-    ai_video_count: &mut GenerateAiVideoCount,
-    now: SystemTime,
-) -> (bool, String) {
-    if should_reset_daily_counter(&ai_video_count.last_reset_date, now) {
-        ai_video_count.videos_generated_today = 0;
-        ai_video_count.claimed_today = false;
-        ai_video_count.last_reset_date = Some(now);
-    }
-
-    ai_video_count.videos_generated_today += 1;
-
-    (
-        true,
-        format!(
-            "AI videos generated today: {}/{}",
-            ai_video_count.videos_generated_today, ai_video_count.target_videos
-        ),
-    )
-}
-
-fn update_referral_count(
-    referral_count: &mut ReferralCount,
-    referred_user: Principal,
-    now: SystemTime,
-) -> (bool, String) {
-    // Check if user was already referred
-    if referral_count
-        .referred_users
-        .iter()
-        .any(|u| u.principal_id == referred_user)
-    {
-        return (false, "User already referred".to_string());
-    }
-
-    if should_reset_daily_counter(&referral_count.last_reset_date, now) {
-        referral_count.referrals_made_today = 0;
-        referral_count.claimed_today = false;
-        referral_count.last_reset_date = Some(now);
-    }
-
-    referral_count.referrals_made_today += 1;
-    referral_count.referred_users.push(ReferredUser {
-        principal_id: referred_user,
-        referred_at: now,
-        is_active: true,
-    });
-
-    (
-        true,
-        format!(
-            "Referrals made today: {}/{}",
-            referral_count.referrals_made_today, referral_count.target_referrals
-        ),
-    )
-}
-
-fn should_reset_daily_counter(last_reset: &Option<SystemTime>, now: SystemTime) -> bool {
-    match last_reset {
-        Some(last) => {
-            let last_day = get_day_from_timestamp(*last);
-            let current_day = get_day_from_timestamp(now);
-            current_day > last_day
-        }
-        None => true,
-    }
-}
-
-fn get_day_from_timestamp(time: SystemTime) -> u64 {
-    time.duration_since(SystemTime::UNIX_EPOCH)
-        .unwrap()
-        .as_secs()
-        / (24 * 60 * 60)
-}
-
-fn calculate_hours_until_next_day(now: SystemTime) -> u32 {
-    let seconds_since_epoch = now
-        .duration_since(SystemTime::UNIX_EPOCH)
-        .unwrap()
-        .as_secs();
-    let seconds_in_day = 24 * 60 * 60;
-    let seconds_until_next_day = seconds_in_day - (seconds_since_epoch % seconds_in_day);
-    (seconds_until_next_day / 3600) as u32
-}
-
-fn calculate_hours_until_reset(last_reset: &Option<SystemTime>, now: SystemTime) -> u32 {
-    match last_reset {
-        Some(last) => {
-            let hours_since_reset = now.duration_since(*last).unwrap().as_secs() / 3600;
-            if hours_since_reset >= 24 {
-                0
-            } else {
-                (24 - hours_since_reset) as u32
+            ClaimRewardResponse {
+                success: false,
+                message: "Reward not found or already claimed".to_string(),
+                reward_amount: None,
+                claimed_reward: None,
             }
         }
-        None => 0,
-    }
+    })
 }

--- a/src/canister/daily_missions/src/data_model/memory.rs
+++ b/src/canister/daily_missions/src/data_model/memory.rs
@@ -1,0 +1,30 @@
+use ic_stable_structures::memory_manager::{MemoryId, MemoryManager, VirtualMemory};
+use ic_stable_structures::DefaultMemoryImpl;
+use std::cell::RefCell;
+
+// A memory for upgrades, where data from the heap can be serialized/deserialized.
+// const UPGRADES: MemoryId = MemoryId::new(0);
+
+// A memory for upgrades, where data from the heap can be serialized/deserialized.
+const UPGRADES: MemoryId = MemoryId::new(0);
+
+// A memory for the StableBTreeMap we're using. A new memory should be created for
+// every additional stable structure.
+const DAILY_MISSIONS_STORE: MemoryId = MemoryId::new(1);
+
+pub type Memory = VirtualMemory<DefaultMemoryImpl>;
+
+thread_local! {
+    // The memory manager is used for simulating multiple memories. Given a `MemoryId` it can
+    // return a memory that can be used by stable structures.
+    static MEMORY_MANAGER: RefCell<MemoryManager<DefaultMemoryImpl>> =
+        RefCell::new(MemoryManager::init(DefaultMemoryImpl::default()));
+}
+
+pub fn get_upgrades_memory() -> Memory {
+    MEMORY_MANAGER.with(|m| m.borrow().get(UPGRADES))
+}
+
+pub fn get_stable_btree_memory() -> Memory {
+    MEMORY_MANAGER.with(|m| m.borrow().get(DAILY_MISSIONS_STORE))
+}

--- a/src/canister/daily_missions/src/data_model/mod.rs
+++ b/src/canister/daily_missions/src/data_model/mod.rs
@@ -9,6 +9,8 @@ use crate::data_model::memory::Memory;
 
 pub mod memory;
 
+
+//This is the source of truth for a user's daily missions.
 #[derive(CandidType, Serialize, Deserialize, Clone, Debug)]
 pub struct UserDailyMissions {
     pub login_streak: LoginStreak,
@@ -16,6 +18,7 @@ pub struct UserDailyMissions {
     pub ai_video_count: GenerateAiVideoCount,
     pub referral_count: ReferralCount,
     pub last_updated: SystemTime,
+    pub pending_rewards: Vec<PendingReward>,
 }
 
 impl Default for UserDailyMissions {
@@ -26,6 +29,7 @@ impl Default for UserDailyMissions {
             ai_video_count: GenerateAiVideoCount::default(),
             referral_count: ReferralCount::default(),
             last_updated: SystemTime::UNIX_EPOCH,
+            pending_rewards: Vec::new(),
         }
     }
 }
@@ -76,20 +80,20 @@ impl Default for GameStreak {
 
 #[derive(CandidType, Serialize, Deserialize, Clone, Debug)]
 pub struct GenerateAiVideoCount {
-    pub videos_generated_today: u32,
+    pub videos_generated_total: u32,
     pub target_videos: u32,
-    pub last_reset_date: Option<SystemTime>,
-    pub claimed_today: bool,
+    pub completed: bool,
+    pub reward_claimed: bool,
     pub total_videos_generated: u32,
 }
 
 impl Default for GenerateAiVideoCount {
     fn default() -> Self {
         Self {
-            videos_generated_today: 0,
+            videos_generated_total: 0,
             target_videos: 3,
-            last_reset_date: None,
-            claimed_today: false,
+            completed: false,
+            reward_claimed: false,
             total_videos_generated: 0,
         }
     }
@@ -97,10 +101,10 @@ impl Default for GenerateAiVideoCount {
 
 #[derive(CandidType, Serialize, Deserialize, Clone, Debug)]
 pub struct ReferralCount {
-    pub referrals_made_today: u32,
+    pub referrals_made_total: u32,
     pub target_referrals: u32,
-    pub last_reset_date: Option<SystemTime>,
-    pub claimed_today: bool,
+    pub completed: bool,
+    pub reward_claimed: bool,
     pub total_referrals_made: u32,
     pub referred_users: Vec<ReferredUser>,
 }
@@ -108,10 +112,10 @@ pub struct ReferralCount {
 impl Default for ReferralCount {
     fn default() -> Self {
         Self {
-            referrals_made_today: 0,
+            referrals_made_total: 0,
             target_referrals: 3,
-            last_reset_date: None,
-            claimed_today: false,
+            completed: false,
+            reward_claimed: false,
             total_referrals_made: 0,
             referred_users: Vec::new(),
         }
@@ -134,6 +138,15 @@ pub struct ClaimedReward {
 }
 
 #[derive(CandidType, Serialize, Deserialize, Clone, Debug)]
+pub struct PendingReward {
+    pub id: String,
+    pub reward_type: RewardType,
+    pub amount: u64,
+    pub earned_at: SystemTime,
+    pub mission_day: u32,
+}
+
+#[derive(CandidType, Serialize, Deserialize, Clone, Debug, PartialEq)]
 pub enum RewardType {
     LoginStreak,
     GameCompletion,
@@ -141,12 +154,14 @@ pub enum RewardType {
     Referral,
 }
 
+//This struct is a simplified representation of a user's daily missions progress for clients
 #[derive(CandidType, Serialize, Deserialize, Clone, Debug)]
 pub struct MissionProgress {
     pub login_streak: LoginStreakProgress,
     pub game_progress: GameProgress,
     pub ai_video_progress: AiVideoProgress,
     pub referral_progress: ReferralProgress,
+    pub pending_rewards: Vec<PendingReward>,
 }
 
 #[derive(CandidType, Serialize, Deserialize, Clone, Debug)]
@@ -173,7 +188,7 @@ pub struct AiVideoProgress {
     pub target_count: u32,
     pub can_claim: bool,
     pub reward_amount: u64,
-    pub hours_remaining: u32,
+    pub completed: bool,
 }
 
 #[derive(CandidType, Serialize, Deserialize, Clone, Debug)]
@@ -182,7 +197,7 @@ pub struct ReferralProgress {
     pub target_count: u32,
     pub can_claim: bool,
     pub reward_amount: u64,
-    pub hours_remaining: u32,
+    pub completed: bool,
 }
 
 #[derive(CandidType, Serialize, Deserialize, Clone, Debug)]

--- a/src/canister/daily_missions/src/data_model/mod.rs
+++ b/src/canister/daily_missions/src/data_model/mod.rs
@@ -9,7 +9,6 @@ use crate::data_model::memory::Memory;
 
 pub mod memory;
 
-
 //This is the source of truth for a user's daily missions.
 #[derive(CandidType, Serialize, Deserialize, Clone, Debug)]
 pub struct UserDailyMissions {
@@ -41,7 +40,6 @@ pub struct LoginStreak {
     pub last_login_date: Option<SystemTime>,
     pub streak_start_date: Option<SystemTime>,
     pub claimed_rewards: Vec<ClaimedReward>,
-    pub can_claim_today: bool,
 }
 
 impl Default for LoginStreak {
@@ -52,7 +50,6 @@ impl Default for LoginStreak {
             last_login_date: None,
             streak_start_date: None,
             claimed_rewards: Vec::new(),
-            can_claim_today: false,
         }
     }
 }
@@ -149,6 +146,7 @@ pub struct PendingReward {
 #[derive(CandidType, Serialize, Deserialize, Clone, Debug, PartialEq)]
 pub enum RewardType {
     LoginStreak,
+    LoginStreakBonus,
     GameCompletion,
     AiVideoGeneration,
     Referral,
@@ -217,7 +215,8 @@ pub struct MissionUpdateResult {
 }
 
 // Reward amounts in YRAL tokens
-pub const LOGIN_STREAK_REWARD: u64 = 5;
+pub const DAILY_LOGIN_REWARD: u64 = 5;
+pub const LOGIN_STREAK_COMPLETION_BONUS: u64 = 30;
 pub const GAME_COMPLETION_REWARD: u64 = 10;
 pub const AI_VIDEO_GENERATION_REWARD: u64 = 30;
 pub const REFERRAL_REWARD: u64 = 15;

--- a/src/canister/daily_missions/src/data_model/mod.rs
+++ b/src/canister/daily_missions/src/data_model/mod.rs
@@ -1,0 +1,307 @@
+use candid::{CandidType, Principal};
+use ic_stable_structures::{storable::Bound, StableBTreeMap, Storable};
+use serde::{Deserialize, Serialize};
+use shared_utils::service::{GetVersion, SetVersion};
+use std::borrow::Cow;
+use std::time::SystemTime;
+
+use crate::data_model::memory::Memory;
+
+pub mod memory;
+
+#[derive(CandidType, Serialize, Deserialize, Clone, Debug)]
+pub struct UserDailyMissions {
+    pub login_streak: LoginStreak,
+    pub game_streak: GameStreak,
+    pub ai_video_count: GenerateAiVideoCount,
+    pub referral_count: ReferralCount,
+    pub last_updated: SystemTime,
+}
+
+impl Default for UserDailyMissions {
+    fn default() -> Self {
+        Self {
+            login_streak: LoginStreak::default(),
+            game_streak: GameStreak::default(),
+            ai_video_count: GenerateAiVideoCount::default(),
+            referral_count: ReferralCount::default(),
+            last_updated: SystemTime::UNIX_EPOCH,
+        }
+    }
+}
+
+#[derive(CandidType, Serialize, Deserialize, Clone, Debug)]
+pub struct LoginStreak {
+    pub current_streak: u32,
+    pub max_streak: u32,
+    pub last_login_date: Option<SystemTime>,
+    pub streak_start_date: Option<SystemTime>,
+    pub claimed_rewards: Vec<ClaimedReward>,
+    pub can_claim_today: bool,
+}
+
+impl Default for LoginStreak {
+    fn default() -> Self {
+        Self {
+            current_streak: 0,
+            max_streak: 0,
+            last_login_date: None,
+            streak_start_date: None,
+            claimed_rewards: Vec::new(),
+            can_claim_today: false,
+        }
+    }
+}
+
+#[derive(CandidType, Serialize, Deserialize, Clone, Debug)]
+pub struct GameStreak {
+    pub games_played_today: u32,
+    pub target_games: u32,
+    pub last_reset_date: Option<SystemTime>,
+    pub claimed_today: bool,
+    pub total_games_completed: u32,
+}
+
+impl Default for GameStreak {
+    fn default() -> Self {
+        Self {
+            games_played_today: 0,
+            target_games: 10,
+            last_reset_date: None,
+            claimed_today: false,
+            total_games_completed: 0,
+        }
+    }
+}
+
+#[derive(CandidType, Serialize, Deserialize, Clone, Debug)]
+pub struct GenerateAiVideoCount {
+    pub videos_generated_today: u32,
+    pub target_videos: u32,
+    pub last_reset_date: Option<SystemTime>,
+    pub claimed_today: bool,
+    pub total_videos_generated: u32,
+}
+
+impl Default for GenerateAiVideoCount {
+    fn default() -> Self {
+        Self {
+            videos_generated_today: 0,
+            target_videos: 3,
+            last_reset_date: None,
+            claimed_today: false,
+            total_videos_generated: 0,
+        }
+    }
+}
+
+#[derive(CandidType, Serialize, Deserialize, Clone, Debug)]
+pub struct ReferralCount {
+    pub referrals_made_today: u32,
+    pub target_referrals: u32,
+    pub last_reset_date: Option<SystemTime>,
+    pub claimed_today: bool,
+    pub total_referrals_made: u32,
+    pub referred_users: Vec<ReferredUser>,
+}
+
+impl Default for ReferralCount {
+    fn default() -> Self {
+        Self {
+            referrals_made_today: 0,
+            target_referrals: 3,
+            last_reset_date: None,
+            claimed_today: false,
+            total_referrals_made: 0,
+            referred_users: Vec::new(),
+        }
+    }
+}
+
+#[derive(CandidType, Serialize, Deserialize, Clone, Debug)]
+pub struct ReferredUser {
+    pub principal_id: Principal,
+    pub referred_at: SystemTime,
+    pub is_active: bool,
+}
+
+#[derive(CandidType, Serialize, Deserialize, Clone, Debug)]
+pub struct ClaimedReward {
+    pub reward_type: RewardType,
+    pub amount: u64,
+    pub claimed_at: SystemTime,
+    pub day: u32,
+}
+
+#[derive(CandidType, Serialize, Deserialize, Clone, Debug)]
+pub enum RewardType {
+    LoginStreak,
+    GameCompletion,
+    AiVideoGeneration,
+    Referral,
+}
+
+#[derive(CandidType, Serialize, Deserialize, Clone, Debug)]
+pub struct MissionProgress {
+    pub login_streak: LoginStreakProgress,
+    pub game_progress: GameProgress,
+    pub ai_video_progress: AiVideoProgress,
+    pub referral_progress: ReferralProgress,
+}
+
+#[derive(CandidType, Serialize, Deserialize, Clone, Debug)]
+pub struct LoginStreakProgress {
+    pub current_day: u32,
+    pub target_day: u32,
+    pub can_claim: bool,
+    pub reward_amount: u64,
+    pub next_reset_in_hours: u32,
+}
+
+#[derive(CandidType, Serialize, Deserialize, Clone, Debug)]
+pub struct GameProgress {
+    pub current_count: u32,
+    pub target_count: u32,
+    pub can_claim: bool,
+    pub reward_amount: u64,
+    pub hours_remaining: u32,
+}
+
+#[derive(CandidType, Serialize, Deserialize, Clone, Debug)]
+pub struct AiVideoProgress {
+    pub current_count: u32,
+    pub target_count: u32,
+    pub can_claim: bool,
+    pub reward_amount: u64,
+    pub hours_remaining: u32,
+}
+
+#[derive(CandidType, Serialize, Deserialize, Clone, Debug)]
+pub struct ReferralProgress {
+    pub current_count: u32,
+    pub target_count: u32,
+    pub can_claim: bool,
+    pub reward_amount: u64,
+    pub hours_remaining: u32,
+}
+
+#[derive(CandidType, Serialize, Deserialize, Clone, Debug)]
+pub enum MissionType {
+    LoginStreak,
+    PlayGames,
+    GenerateAiVideos,
+    Referrals,
+}
+
+#[derive(CandidType, Serialize, Deserialize, Clone, Debug)]
+pub struct MissionUpdateResult {
+    pub success: bool,
+    pub message: String,
+    pub new_progress: Option<MissionProgress>,
+    pub reward_earned: Option<ClaimedReward>,
+}
+
+// Reward amounts in YRAL tokens
+pub const LOGIN_STREAK_REWARD: u64 = 5;
+pub const GAME_COMPLETION_REWARD: u64 = 10;
+pub const AI_VIDEO_GENERATION_REWARD: u64 = 30;
+pub const REFERRAL_REWARD: u64 = 15;
+
+// Target values
+pub const LOGIN_STREAK_TARGET: u32 = 7;
+pub const GAME_TARGET: u32 = 10;
+pub const AI_VIDEO_TARGET: u32 = 3;
+pub const REFERRAL_TARGET: u32 = 3;
+
+// Storable implementation for UserDailyMissions
+impl Storable for UserDailyMissions {
+    fn to_bytes(&self) -> Cow<[u8]> {
+        let bytes = candid::encode_one(self).expect("Failed to encode UserDailyMissions");
+        Cow::Owned(bytes)
+    }
+
+    fn from_bytes(bytes: Cow<[u8]>) -> Self {
+        candid::decode_one(&bytes).expect("Failed to decode UserDailyMissions")
+    }
+
+    const BOUND: Bound = Bound::Unbounded;
+}
+
+pub struct CanisterData {
+    pub missions: StableBTreeMap<Principal, UserDailyMissions, Memory>,
+    pub version: String,
+}
+
+impl Default for CanisterData {
+    fn default() -> Self {
+        Self {
+            missions: StableBTreeMap::init(memory::get_stable_btree_memory()),
+            version: "1.0.0".to_string(),
+        }
+    }
+}
+
+impl Serialize for CanisterData {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        use serde::ser::SerializeStruct;
+        let mut state = serializer.serialize_struct("CanisterData", 1)?;
+        state.serialize_field("version", &self.version)?;
+        state.end()
+    }
+}
+
+impl<'de> Deserialize<'de> for CanisterData {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        #[derive(Deserialize)]
+        struct TempCanisterData {
+            version: String,
+        }
+
+        let temp = TempCanisterData::deserialize(deserializer)?;
+        Ok(CanisterData {
+            missions: StableBTreeMap::init(memory::get_stable_btree_memory()),
+            version: temp.version,
+        })
+    }
+}
+
+impl CanisterData {
+    pub fn new_with_version(version: String) -> Self {
+        Self {
+            missions: StableBTreeMap::init(memory::get_stable_btree_memory()),
+            version,
+        }
+    }
+}
+
+impl SetVersion for CanisterData {
+    fn set_version(&mut self, version: &str) {
+        self.version = version.to_string();
+    }
+}
+
+impl GetVersion for CanisterData {
+    fn get_version(&self) -> Cow<str> {
+        self.version.as_str().into()
+    }
+}
+
+impl CanisterData {
+    pub fn get_user_missions(&self, user: &Principal) -> UserDailyMissions {
+        self.missions.get(user).unwrap_or_default()
+    }
+
+    pub fn update_user_missions(&mut self, user: Principal, missions: UserDailyMissions) {
+        self.missions.insert(user, missions);
+    }
+
+    pub fn user_exists(&self, user: &Principal) -> bool {
+        self.missions.contains_key(user)
+    }
+}

--- a/src/canister/daily_missions/src/data_model/mod.rs
+++ b/src/canister/daily_missions/src/data_model/mod.rs
@@ -210,7 +210,7 @@ pub enum MissionType {
 pub struct MissionUpdateResult {
     pub success: bool,
     pub message: String,
-    pub new_progress: Option<MissionProgress>,
+    pub new_progress: Option<UserDailyMissions>,
     pub reward_earned: Option<ClaimedReward>,
 }
 

--- a/src/canister/daily_missions/src/lib.rs
+++ b/src/canister/daily_missions/src/lib.rs
@@ -7,7 +7,10 @@ mod api;
 mod data_model;
 mod util;
 
-use data_model::{CanisterData, MissionProgress, MissionUpdateResult};
+#[cfg(test)]
+mod tests;
+
+use data_model::{CanisterData, MissionProgress, MissionUpdateResult, UserDailyMissions};
 use shared_utils::service::{update_version_from_args, GetVersion, SetVersion};
 use std::borrow::Cow;
 

--- a/src/canister/daily_missions/src/lib.rs
+++ b/src/canister/daily_missions/src/lib.rs
@@ -10,7 +10,7 @@ mod util;
 #[cfg(test)]
 mod tests;
 
-use data_model::{CanisterData, MissionProgress, MissionUpdateResult, UserDailyMissions};
+use data_model::{CanisterData, MissionUpdateResult, UserDailyMissions};
 use shared_utils::service::{update_version_from_args, GetVersion, SetVersion};
 use std::borrow::Cow;
 

--- a/src/canister/daily_missions/src/lib.rs
+++ b/src/canister/daily_missions/src/lib.rs
@@ -1,0 +1,103 @@
+use candid::Principal;
+use ic_cdk_macros::{init, post_upgrade, pre_upgrade, query};
+
+use std::cell::RefCell;
+
+mod api;
+mod data_model;
+mod util;
+
+use data_model::{CanisterData, MissionProgress, MissionUpdateResult};
+use shared_utils::service::{update_version_from_args, GetVersion, SetVersion};
+use std::borrow::Cow;
+
+thread_local! {
+    pub static CANISTER_DATA: RefCell<CanisterData> = RefCell::new(CanisterData::default());
+}
+
+// Re-export functions from API module so they're available as canister methods
+pub use api::*;
+
+#[derive(candid::CandidType, serde::Deserialize)]
+pub struct DailyMissionsInitArgs {
+    pub version: String,
+    pub known_principal_ids:
+        Option<shared_utils::common::types::known_principal::KnownPrincipalMap>,
+}
+
+impl From<DailyMissionsInitArgs> for shared_utils::service::ServiceInitArgs {
+    fn from(args: DailyMissionsInitArgs) -> Self {
+        shared_utils::service::ServiceInitArgs {
+            version: args.version,
+        }
+    }
+}
+
+impl GetVersion for DailyMissionsInitArgs {
+    fn get_version(&self) -> Cow<str> {
+        self.version.as_str().into()
+    }
+}
+
+#[init]
+fn init(args: DailyMissionsInitArgs) {
+    CANISTER_DATA.with_borrow_mut(|canister_data| {
+        canister_data.set_version(&args.version);
+    });
+}
+
+#[pre_upgrade]
+fn pre_upgrade() {
+    use crate::data_model::memory;
+    use ciborium::ser;
+    use ic_stable_structures::writer::Writer;
+
+    let mut state_bytes = vec![];
+    CANISTER_DATA
+        .with(|canister_data_ref_cell| {
+            ser::into_writer(&*canister_data_ref_cell.borrow(), &mut state_bytes)
+        })
+        .expect("failed to encode state");
+
+    let len = state_bytes.len() as u32;
+
+    let mut upgrade_memory = memory::get_upgrades_memory();
+    let mut writer = Writer::new(&mut upgrade_memory, 0);
+    writer.write(&len.to_le_bytes()).unwrap();
+    writer.write(&state_bytes).unwrap();
+}
+
+#[post_upgrade]
+fn post_upgrade() {
+    use crate::data_model::memory;
+    use ciborium::de;
+    use ic_stable_structures::reader::Reader;
+
+    let heap_data = memory::get_upgrades_memory();
+    let mut upgrade_reader = Reader::new(&heap_data, 0);
+
+    let mut heap_data_len_bytes = [0; 4];
+    upgrade_reader.read(&mut heap_data_len_bytes).unwrap();
+    let heap_data_len = u32::from_le_bytes(heap_data_len_bytes) as usize;
+
+    let mut canister_data_bytes = vec![0; heap_data_len];
+    upgrade_reader.read(&mut canister_data_bytes).unwrap();
+
+    let canister_data: CanisterData =
+        de::from_reader(&*canister_data_bytes).expect("Failed to deserialize heap data");
+
+    CANISTER_DATA.with_borrow_mut(|cdata| {
+        *cdata = canister_data;
+    });
+
+    // Update version if provided in upgrade args
+    update_version_from_args::<DailyMissionsInitArgs>(&CANISTER_DATA);
+}
+
+#[query]
+fn get_version() -> String {
+    CANISTER_DATA.with_borrow(|canister_data| canister_data.version.clone())
+}
+
+// Export the candid interface
+candid::export_service!();

--- a/src/canister/daily_missions/src/tests/api_tests.rs
+++ b/src/canister/daily_missions/src/tests/api_tests.rs
@@ -1,0 +1,293 @@
+use candid::Principal;
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+use crate::api::{update_ai_video_count, update_referral_count};
+use crate::data_model::{GenerateAiVideoCount, ReferralCount};
+
+fn create_test_time() -> SystemTime {
+    UNIX_EPOCH + Duration::from_secs(1000000)
+}
+
+#[cfg(test)]
+mod api_integration_tests {
+    use super::*;
+
+    #[test]
+    fn test_update_ai_video_count_function() {
+        let mut ai_video_count = GenerateAiVideoCount::default();
+        let now = create_test_time();
+
+        // First update - should succeed
+        let (success, message) = update_ai_video_count(&mut ai_video_count, now);
+        assert!(success);
+        assert_eq!(ai_video_count.videos_generated_total, 1);
+        assert!(!ai_video_count.completed);
+        assert!(message.contains("AI videos generated: 1/3"));
+
+        // Second update - should succeed
+        let (success, _) = update_ai_video_count(&mut ai_video_count, now);
+        assert!(success);
+        assert_eq!(ai_video_count.videos_generated_total, 2);
+        assert!(!ai_video_count.completed);
+
+        // Third update - should succeed and complete mission
+        let (success, message) = update_ai_video_count(&mut ai_video_count, now);
+        assert!(success);
+        assert_eq!(ai_video_count.videos_generated_total, 3);
+        assert!(ai_video_count.completed);
+        assert!(message.contains("Mission Complete!"));
+
+        // Try to update after completion - should fail
+        let (success, message) = update_ai_video_count(&mut ai_video_count, now);
+        assert!(!success);
+        assert!(message.contains("already completed"));
+        assert!(message.contains("No more rewards available"));
+    }
+
+    #[test]
+    fn test_update_referral_count_function() {
+        let mut referral_count = ReferralCount::default();
+        let now = create_test_time();
+        let user1 = Principal::from_slice(&[1, 2, 3, 4]);
+        let user2 = Principal::from_slice(&[2, 3, 4, 5]);
+        let user3 = Principal::from_slice(&[3, 4, 5, 6]);
+
+        // First referral - should succeed
+        let (success, message) = update_referral_count(&mut referral_count, user1, now);
+        assert!(success);
+        assert_eq!(referral_count.referrals_made_total, 1);
+        assert!(!referral_count.completed);
+        assert!(message.contains("Referrals made: 1/3"));
+        assert_eq!(referral_count.referred_users.len(), 1);
+
+        // Duplicate referral - should fail
+        let (success, message) = update_referral_count(&mut referral_count, user1, now);
+        assert!(!success);
+        assert!(message.contains("already referred"));
+        // Counts should not change
+        assert_eq!(referral_count.referrals_made_total, 1);
+        assert_eq!(referral_count.referred_users.len(), 1);
+
+        // Second referral with different user - should succeed
+        let (success, _) = update_referral_count(&mut referral_count, user2, now);
+        assert!(success);
+        assert_eq!(referral_count.referrals_made_total, 2);
+        assert!(!referral_count.completed);
+        assert_eq!(referral_count.referred_users.len(), 2);
+
+        // Third referral - should succeed and complete mission
+        let (success, message) = update_referral_count(&mut referral_count, user3, now);
+        assert!(success);
+        assert_eq!(referral_count.referrals_made_total, 3);
+        assert!(referral_count.completed);
+        assert!(message.contains("Mission Complete!"));
+        assert_eq!(referral_count.referred_users.len(), 3);
+
+        // Try to refer after completion - should fail
+        let user4 = Principal::from_slice(&[4, 5, 6, 7]);
+        let (success, message) = update_referral_count(&mut referral_count, user4, now);
+        assert!(!success);
+        assert!(message.contains("already completed"));
+        assert!(message.contains("No more rewards available"));
+        // Counts should not change
+        assert_eq!(referral_count.referrals_made_total, 3);
+        assert_eq!(referral_count.referred_users.len(), 3);
+    }
+
+    #[test]
+    fn test_ai_video_count_tracks_total_correctly() {
+        let mut ai_video_count = GenerateAiVideoCount::default();
+        let now = create_test_time();
+
+        // Initially both counters should be 0
+        assert_eq!(ai_video_count.videos_generated_total, 0);
+        assert_eq!(ai_video_count.total_videos_generated, 0);
+
+        // After first update, both should increment
+        update_ai_video_count(&mut ai_video_count, now);
+        assert_eq!(ai_video_count.videos_generated_total, 1);
+        assert_eq!(ai_video_count.total_videos_generated, 1);
+
+        // After second update, both should increment
+        update_ai_video_count(&mut ai_video_count, now);
+        assert_eq!(ai_video_count.videos_generated_total, 2);
+        assert_eq!(ai_video_count.total_videos_generated, 2);
+
+        // After third update (completion), both should increment
+        update_ai_video_count(&mut ai_video_count, now);
+        assert_eq!(ai_video_count.videos_generated_total, 3);
+        assert_eq!(ai_video_count.total_videos_generated, 3);
+        assert!(ai_video_count.completed);
+    }
+
+    #[test]
+    fn test_referral_count_tracks_total_correctly() {
+        let mut referral_count = ReferralCount::default();
+        let now = create_test_time();
+        let user1 = Principal::from_slice(&[1, 2, 3, 4]);
+        let user2 = Principal::from_slice(&[2, 3, 4, 5]);
+        let user3 = Principal::from_slice(&[3, 4, 5, 6]);
+
+        // Initially both counters should be 0
+        assert_eq!(referral_count.referrals_made_total, 0);
+        assert_eq!(referral_count.total_referrals_made, 0);
+
+        // After first referral, both should increment
+        update_referral_count(&mut referral_count, user1, now);
+        assert_eq!(referral_count.referrals_made_total, 1);
+        assert_eq!(referral_count.total_referrals_made, 1);
+
+        // After second referral, both should increment
+        update_referral_count(&mut referral_count, user2, now);
+        assert_eq!(referral_count.referrals_made_total, 2);
+        assert_eq!(referral_count.total_referrals_made, 2);
+
+        // After third referral (completion), both should increment
+        update_referral_count(&mut referral_count, user3, now);
+        assert_eq!(referral_count.referrals_made_total, 3);
+        assert_eq!(referral_count.total_referrals_made, 3);
+        assert!(referral_count.completed);
+    }
+
+    #[test]
+    fn test_referral_users_list_management() {
+        let mut referral_count = ReferralCount::default();
+        let now = create_test_time();
+        let user1 = Principal::from_slice(&[1, 2, 3, 4]);
+        let user2 = Principal::from_slice(&[2, 3, 4, 5]);
+
+        // Initially no referred users
+        assert!(referral_count.referred_users.is_empty());
+
+        // After first referral, list should contain user1
+        update_referral_count(&mut referral_count, user1, now);
+        assert_eq!(referral_count.referred_users.len(), 1);
+        assert_eq!(referral_count.referred_users[0].principal_id, user1);
+        assert_eq!(referral_count.referred_users[0].referred_at, now);
+        assert!(referral_count.referred_users[0].is_active);
+
+        // After second referral, list should contain both users
+        update_referral_count(&mut referral_count, user2, now);
+        assert_eq!(referral_count.referred_users.len(), 2);
+        assert_eq!(referral_count.referred_users[1].principal_id, user2);
+        assert_eq!(referral_count.referred_users[1].referred_at, now);
+        assert!(referral_count.referred_users[1].is_active);
+
+        // Duplicate referral should not add to the list
+        let initial_len = referral_count.referred_users.len();
+        let (success, _) = update_referral_count(&mut referral_count, user1, now);
+        assert!(!success);
+        assert_eq!(referral_count.referred_users.len(), initial_len);
+    }
+
+    #[test]
+    fn test_mission_completion_states() {
+        let mut ai_video_count = GenerateAiVideoCount::default();
+        let mut referral_count = ReferralCount::default();
+        let now = create_test_time();
+
+        // Both missions start incomplete
+        assert!(!ai_video_count.completed);
+        assert!(!referral_count.completed);
+
+        // AI video mission - complete all 3 videos
+        for _ in 0..3 {
+            update_ai_video_count(&mut ai_video_count, now);
+        }
+        assert!(ai_video_count.completed);
+
+        // Referral mission - complete all 3 referrals
+        let users = [
+            Principal::from_slice(&[1, 2, 3, 4]),
+            Principal::from_slice(&[2, 3, 4, 5]),
+            Principal::from_slice(&[3, 4, 5, 6]),
+        ];
+        for user in users.iter() {
+            update_referral_count(&mut referral_count, *user, now);
+        }
+        assert!(referral_count.completed);
+
+        // Both missions should remain completed and reject further updates
+        let (success, _) = update_ai_video_count(&mut ai_video_count, now);
+        assert!(!success);
+
+        let user4 = Principal::from_slice(&[4, 5, 6, 7]);
+        let (success, _) = update_referral_count(&mut referral_count, user4, now);
+        assert!(!success);
+    }
+
+    #[test]
+    fn test_pending_rewards_generation() {
+        use crate::api::{add_pending_reward, generate_reward_id};
+        use crate::data_model::{
+            RewardType, UserDailyMissions, AI_VIDEO_GENERATION_REWARD, LOGIN_STREAK_REWARD,
+        };
+
+        let mut missions = UserDailyMissions::default();
+        let user = Principal::from_slice(&[1, 2, 3, 4]);
+        let now = create_test_time();
+
+        // Initially no pending rewards
+        assert!(missions.pending_rewards.is_empty());
+
+        // Add login streak reward
+        add_pending_reward(
+            &mut missions,
+            &user,
+            RewardType::LoginStreak,
+            LOGIN_STREAK_REWARD,
+            7,
+            now,
+        );
+
+        // Should have one pending reward
+        assert_eq!(missions.pending_rewards.len(), 1);
+        assert_eq!(
+            missions.pending_rewards[0].reward_type,
+            RewardType::LoginStreak
+        );
+        assert_eq!(missions.pending_rewards[0].amount, LOGIN_STREAK_REWARD);
+        assert_eq!(missions.pending_rewards[0].mission_day, 7);
+        assert_eq!(missions.pending_rewards[0].earned_at, now);
+
+        // Add AI video reward
+        add_pending_reward(
+            &mut missions,
+            &user,
+            RewardType::AiVideoGeneration,
+            AI_VIDEO_GENERATION_REWARD,
+            1,
+            now,
+        );
+
+        // Should have two pending rewards
+        assert_eq!(missions.pending_rewards.len(), 2);
+        assert_eq!(
+            missions.pending_rewards[1].reward_type,
+            RewardType::AiVideoGeneration
+        );
+        assert_eq!(
+            missions.pending_rewards[1].amount,
+            AI_VIDEO_GENERATION_REWARD
+        );
+    }
+
+    #[test]
+    fn test_reward_id_generation() {
+        use crate::api::generate_reward_id;
+        use crate::data_model::RewardType;
+
+        let user = Principal::from_slice(&[1, 2, 3, 4]);
+        let now = create_test_time();
+
+        let id1 = generate_reward_id(&user, &RewardType::LoginStreak, now);
+        let id2 = generate_reward_id(&user, &RewardType::GameCompletion, now);
+
+        // IDs should be different for different reward types
+        assert_ne!(id1, id2);
+
+        // IDs should contain expected components
+        assert!(id1.contains("LoginStreak"));
+        assert!(id2.contains("GameCompletion"));
+    }
+}

--- a/src/canister/daily_missions/src/tests/api_tests.rs
+++ b/src/canister/daily_missions/src/tests/api_tests.rs
@@ -1,8 +1,8 @@
 use candid::Principal;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
-use crate::api::{update_ai_video_count, update_referral_count};
 use crate::data_model::{GenerateAiVideoCount, ReferralCount};
+use crate::util::mission_utils::{update_ai_video_count, update_referral_count};
 
 fn create_test_time() -> SystemTime {
     UNIX_EPOCH + Duration::from_secs(1000000)
@@ -218,10 +218,10 @@ mod api_integration_tests {
 
     #[test]
     fn test_pending_rewards_generation() {
-        use crate::api::{add_pending_reward, generate_reward_id};
         use crate::data_model::{
-            RewardType, UserDailyMissions, AI_VIDEO_GENERATION_REWARD, LOGIN_STREAK_REWARD,
+            RewardType, UserDailyMissions, AI_VIDEO_GENERATION_REWARD, DAILY_LOGIN_REWARD,
         };
+        use crate::util::mission_utils::add_pending_reward;
 
         let mut missions = UserDailyMissions::default();
         let user = Principal::from_slice(&[1, 2, 3, 4]);
@@ -235,7 +235,7 @@ mod api_integration_tests {
             &mut missions,
             &user,
             RewardType::LoginStreak,
-            LOGIN_STREAK_REWARD,
+            DAILY_LOGIN_REWARD,
             7,
             now,
         );
@@ -246,7 +246,7 @@ mod api_integration_tests {
             missions.pending_rewards[0].reward_type,
             RewardType::LoginStreak
         );
-        assert_eq!(missions.pending_rewards[0].amount, LOGIN_STREAK_REWARD);
+        assert_eq!(missions.pending_rewards[0].amount, DAILY_LOGIN_REWARD);
         assert_eq!(missions.pending_rewards[0].mission_day, 7);
         assert_eq!(missions.pending_rewards[0].earned_at, now);
 
@@ -274,8 +274,8 @@ mod api_integration_tests {
 
     #[test]
     fn test_reward_id_generation() {
-        use crate::api::generate_reward_id;
         use crate::data_model::RewardType;
+        use crate::util::mission_utils::generate_reward_id;
 
         let user = Principal::from_slice(&[1, 2, 3, 4]);
         let now = create_test_time();

--- a/src/canister/daily_missions/src/tests/mod.rs
+++ b/src/canister/daily_missions/src/tests/mod.rs
@@ -1,0 +1,353 @@
+use candid::Principal;
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+use crate::data_model::{
+    ClaimedReward, GameStreak, GenerateAiVideoCount, LoginStreak, ReferralCount, ReferredUser,
+    RewardType, UserDailyMissions, AI_VIDEO_GENERATION_REWARD, AI_VIDEO_TARGET, REFERRAL_REWARD,
+    REFERRAL_TARGET,
+};
+
+// Helper function to create test principals
+fn create_test_principal() -> Principal {
+    Principal::anonymous()
+}
+
+fn create_test_time() -> SystemTime {
+    UNIX_EPOCH + Duration::from_secs(1000000)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_ai_video_mission_default_state() {
+        let ai_video_count = GenerateAiVideoCount::default();
+
+        assert_eq!(ai_video_count.videos_generated_total, 0);
+        assert_eq!(ai_video_count.target_videos, AI_VIDEO_TARGET);
+        assert_eq!(ai_video_count.completed, false);
+        assert_eq!(ai_video_count.reward_claimed, false);
+        assert_eq!(ai_video_count.total_videos_generated, 0);
+    }
+
+    #[test]
+    fn test_referral_mission_default_state() {
+        let referral_count = ReferralCount::default();
+
+        assert_eq!(referral_count.referrals_made_total, 0);
+        assert_eq!(referral_count.target_referrals, REFERRAL_TARGET);
+        assert_eq!(referral_count.completed, false);
+        assert_eq!(referral_count.reward_claimed, false);
+        assert_eq!(referral_count.total_referrals_made, 0);
+        assert!(referral_count.referred_users.is_empty());
+    }
+
+    #[test]
+    fn test_ai_video_mission_progress_tracking() {
+        let mut ai_video_count = GenerateAiVideoCount::default();
+        let now = create_test_time();
+
+        // Initially not completed
+        assert!(!ai_video_count.completed);
+
+        // Generate first video
+        ai_video_count.videos_generated_total += 1;
+        ai_video_count.total_videos_generated += 1;
+        assert!(!ai_video_count.completed);
+        assert_eq!(ai_video_count.videos_generated_total, 1);
+
+        // Generate second video
+        ai_video_count.videos_generated_total += 1;
+        ai_video_count.total_videos_generated += 1;
+        assert!(!ai_video_count.completed);
+        assert_eq!(ai_video_count.videos_generated_total, 2);
+
+        // Generate third video (target reached)
+        ai_video_count.videos_generated_total += 1;
+        ai_video_count.total_videos_generated += 1;
+        if ai_video_count.videos_generated_total >= ai_video_count.target_videos {
+            ai_video_count.completed = true;
+        }
+
+        assert!(ai_video_count.completed);
+        assert_eq!(ai_video_count.videos_generated_total, 3);
+        assert_eq!(ai_video_count.total_videos_generated, 3);
+    }
+
+    #[test]
+    fn test_referral_mission_progress_tracking() {
+        let mut referral_count = ReferralCount::default();
+        let now = create_test_time();
+        let user1 = Principal::from_slice(&[1, 2, 3, 4]);
+        let user2 = Principal::from_slice(&[2, 3, 4, 5]);
+        let user3 = Principal::from_slice(&[3, 4, 5, 6]);
+
+        // Initially not completed
+        assert!(!referral_count.completed);
+
+        // First referral
+        referral_count.referrals_made_total += 1;
+        referral_count.total_referrals_made += 1;
+        referral_count.referred_users.push(ReferredUser {
+            principal_id: user1,
+            referred_at: now,
+            is_active: true,
+        });
+        assert!(!referral_count.completed);
+        assert_eq!(referral_count.referrals_made_total, 1);
+
+        // Second referral
+        referral_count.referrals_made_total += 1;
+        referral_count.total_referrals_made += 1;
+        referral_count.referred_users.push(ReferredUser {
+            principal_id: user2,
+            referred_at: now,
+            is_active: true,
+        });
+        assert!(!referral_count.completed);
+        assert_eq!(referral_count.referrals_made_total, 2);
+
+        // Third referral (target reached)
+        referral_count.referrals_made_total += 1;
+        referral_count.total_referrals_made += 1;
+        referral_count.referred_users.push(ReferredUser {
+            principal_id: user3,
+            referred_at: now,
+            is_active: true,
+        });
+        if referral_count.referrals_made_total >= referral_count.target_referrals {
+            referral_count.completed = true;
+        }
+
+        assert!(referral_count.completed);
+        assert_eq!(referral_count.referrals_made_total, 3);
+        assert_eq!(referral_count.total_referrals_made, 3);
+        assert_eq!(referral_count.referred_users.len(), 3);
+    }
+
+    #[test]
+    fn test_ai_video_mission_reward_claiming() {
+        let mut ai_video_count = GenerateAiVideoCount::default();
+        let now = create_test_time();
+
+        // Complete the mission
+        ai_video_count.videos_generated_total = AI_VIDEO_TARGET;
+        ai_video_count.total_videos_generated = AI_VIDEO_TARGET;
+        ai_video_count.completed = true;
+
+        // Should be able to claim reward
+        assert!(ai_video_count.completed);
+        assert!(!ai_video_count.reward_claimed);
+
+        // Claim reward
+        ai_video_count.reward_claimed = true;
+
+        // Should not be able to claim again
+        assert!(ai_video_count.reward_claimed);
+    }
+
+    #[test]
+    fn test_referral_mission_reward_claiming() {
+        let mut referral_count = ReferralCount::default();
+        let now = create_test_time();
+
+        // Complete the mission
+        referral_count.referrals_made_total = REFERRAL_TARGET;
+        referral_count.total_referrals_made = REFERRAL_TARGET;
+        referral_count.completed = true;
+
+        // Should be able to claim reward
+        assert!(referral_count.completed);
+        assert!(!referral_count.reward_claimed);
+
+        // Claim reward
+        referral_count.reward_claimed = true;
+
+        // Should not be able to claim again
+        assert!(referral_count.reward_claimed);
+    }
+
+    #[test]
+    fn test_ai_video_mission_no_reset_after_completion() {
+        let mut ai_video_count = GenerateAiVideoCount::default();
+
+        // Complete the mission
+        ai_video_count.videos_generated_total = AI_VIDEO_TARGET;
+        ai_video_count.completed = true;
+        ai_video_count.reward_claimed = true;
+
+        // Simulate time passing (e.g., next day)
+        // In the old system, this would reset daily counters
+        // In the new system, completed missions stay completed
+
+        assert!(ai_video_count.completed);
+        assert!(ai_video_count.reward_claimed);
+        assert_eq!(ai_video_count.videos_generated_total, AI_VIDEO_TARGET);
+    }
+
+    #[test]
+    fn test_referral_mission_no_reset_after_completion() {
+        let mut referral_count = ReferralCount::default();
+        let now = create_test_time();
+        let user1 = Principal::from_slice(&[1, 2, 3, 4]);
+
+        // Complete the mission
+        referral_count.referrals_made_total = REFERRAL_TARGET;
+        referral_count.completed = true;
+        referral_count.reward_claimed = true;
+        referral_count.referred_users.push(ReferredUser {
+            principal_id: user1,
+            referred_at: now,
+            is_active: true,
+        });
+
+        // Simulate time passing (e.g., next day)
+        // In the old system, this would reset daily counters
+        // In the new system, completed missions stay completed
+
+        assert!(referral_count.completed);
+        assert!(referral_count.reward_claimed);
+        assert_eq!(referral_count.referrals_made_total, REFERRAL_TARGET);
+        assert_eq!(referral_count.referred_users.len(), 1);
+    }
+
+    #[test]
+    fn test_user_daily_missions_integration() {
+        let mut missions = UserDailyMissions::default();
+        let now = create_test_time();
+
+        // Initially, no missions are completed
+        assert!(!missions.ai_video_count.completed);
+        assert!(!missions.referral_count.completed);
+
+        // Complete AI video mission
+        missions.ai_video_count.videos_generated_total = AI_VIDEO_TARGET;
+        missions.ai_video_count.completed = true;
+        missions.ai_video_count.reward_claimed = true;
+        missions.last_updated = now;
+
+        // Referral mission should still be incomplete
+        assert!(missions.ai_video_count.completed);
+        assert!(!missions.referral_count.completed);
+
+        // Complete referral mission
+        missions.referral_count.referrals_made_total = REFERRAL_TARGET;
+        missions.referral_count.completed = true;
+        missions.referral_count.reward_claimed = true;
+
+        // Both missions should be completed
+        assert!(missions.ai_video_count.completed);
+        assert!(missions.referral_count.completed);
+    }
+
+    #[test]
+    fn test_duplicate_referral_prevention() {
+        let mut referral_count = ReferralCount::default();
+        let now = create_test_time();
+        let user1 = Principal::from_slice(&[1, 2, 3, 4]);
+
+        // Add first referral
+        referral_count.referred_users.push(ReferredUser {
+            principal_id: user1,
+            referred_at: now,
+            is_active: true,
+        });
+
+        // Check if user was already referred (simulating the check in update_referral_count)
+        let already_referred = referral_count
+            .referred_users
+            .iter()
+            .any(|u| u.principal_id == user1);
+
+        assert!(already_referred);
+    }
+
+    #[test]
+    fn test_mission_completion_thresholds() {
+        // Test AI Video mission threshold
+        let mut ai_video_count = GenerateAiVideoCount::default();
+
+        // Just below threshold
+        ai_video_count.videos_generated_total = AI_VIDEO_TARGET - 1;
+        assert!(!ai_video_count.completed);
+
+        // At threshold
+        ai_video_count.videos_generated_total = AI_VIDEO_TARGET;
+        if ai_video_count.videos_generated_total >= ai_video_count.target_videos {
+            ai_video_count.completed = true;
+        }
+        assert!(ai_video_count.completed);
+
+        // Test Referral mission threshold
+        let mut referral_count = ReferralCount::default();
+
+        // Just below threshold
+        referral_count.referrals_made_total = REFERRAL_TARGET - 1;
+        assert!(!referral_count.completed);
+
+        // At threshold
+        referral_count.referrals_made_total = REFERRAL_TARGET;
+        if referral_count.referrals_made_total >= referral_count.target_referrals {
+            referral_count.completed = true;
+        }
+        assert!(referral_count.completed);
+    }
+
+    #[test]
+    fn test_referred_user_structure() {
+        let now = create_test_time();
+        let user1 = Principal::from_slice(&[1, 2, 3, 4]);
+
+        let referred_user = ReferredUser {
+            principal_id: user1,
+            referred_at: now,
+            is_active: true,
+        };
+
+        assert_eq!(referred_user.principal_id, user1);
+        assert_eq!(referred_user.referred_at, now);
+        assert!(referred_user.is_active);
+    }
+
+    #[test]
+    fn test_mission_state_transitions() {
+        // AI Video Mission State Transitions
+        let mut ai_video_count = GenerateAiVideoCount::default();
+
+        // State 1: Initial (not completed, not claimed)
+        assert!(!ai_video_count.completed);
+        assert!(!ai_video_count.reward_claimed);
+
+        // State 2: Completed (completed, not claimed)
+        ai_video_count.videos_generated_total = AI_VIDEO_TARGET;
+        ai_video_count.completed = true;
+        assert!(ai_video_count.completed);
+        assert!(!ai_video_count.reward_claimed);
+
+        // State 3: Completed and Claimed (completed, claimed)
+        ai_video_count.reward_claimed = true;
+        assert!(ai_video_count.completed);
+        assert!(ai_video_count.reward_claimed);
+
+        // Referral Mission State Transitions
+        let mut referral_count = ReferralCount::default();
+
+        // State 1: Initial (not completed, not claimed)
+        assert!(!referral_count.completed);
+        assert!(!referral_count.reward_claimed);
+
+        // State 2: Completed (completed, not claimed)
+        referral_count.referrals_made_total = REFERRAL_TARGET;
+        referral_count.completed = true;
+        assert!(referral_count.completed);
+        assert!(!referral_count.reward_claimed);
+
+        // State 3: Completed and Claimed (completed, claimed)
+        referral_count.reward_claimed = true;
+        assert!(referral_count.completed);
+        assert!(referral_count.reward_claimed);
+    }
+}
+
+mod api_tests;

--- a/src/canister/daily_missions/src/util/mission_utils.rs
+++ b/src/canister/daily_missions/src/util/mission_utils.rs
@@ -1,0 +1,397 @@
+use crate::data_model::{
+    ClaimedReward, GameStreak, GenerateAiVideoCount, LoginStreak, PendingReward, ReferralCount,
+    ReferredUser, RewardType, UserDailyMissions,
+};
+use candid::Principal;
+use std::time::SystemTime;
+
+/// Updates login streak for a user based on current login
+pub fn update_login_streak(login_streak: &mut LoginStreak, now: SystemTime) -> (bool, String) {
+    let today = get_day_from_timestamp(now);
+
+    if let Some(last_login) = login_streak.last_login_date {
+        let last_login_day = get_day_from_timestamp(last_login);
+
+        if today == last_login_day {
+            return (true, "Already logged in today".to_string());
+        }
+
+        if today == last_login_day + 1 {
+            // Consecutive day
+            login_streak.current_streak += 1;
+            login_streak.can_claim_today = true;
+        } else {
+            // Streak broken
+            login_streak.current_streak = 1;
+            login_streak.streak_start_date = Some(now);
+            login_streak.can_claim_today = true;
+        }
+    } else {
+        // First login
+        login_streak.current_streak = 1;
+        login_streak.streak_start_date = Some(now);
+        login_streak.can_claim_today = true;
+    }
+
+    login_streak.last_login_date = Some(now);
+    login_streak.max_streak = login_streak.max_streak.max(login_streak.current_streak);
+
+    (
+        true,
+        format!(
+            "Login streak updated to {} days",
+            login_streak.current_streak
+        ),
+    )
+}
+
+/// Updates game streak for a user
+pub fn update_game_streak(game_streak: &mut GameStreak, now: SystemTime) -> (bool, String) {
+    if should_reset_daily_counter(&game_streak.last_reset_date, now) {
+        game_streak.games_played_today = 0;
+        game_streak.claimed_today = false;
+        game_streak.last_reset_date = Some(now);
+    }
+
+    game_streak.games_played_today += 1;
+
+    (
+        true,
+        format!(
+            "Games played today: {}/{}",
+            game_streak.games_played_today, game_streak.target_games
+        ),
+    )
+}
+
+/// Updates AI video generation count for a user
+pub fn update_ai_video_count(
+    ai_video_count: &mut GenerateAiVideoCount,
+    now: SystemTime,
+) -> (bool, String) {
+    // Check if mission is already completed
+    if ai_video_count.completed {
+        return (
+            false,
+            "AI video generation mission already completed. No more rewards available.".to_string(),
+        );
+    }
+
+    ai_video_count.videos_generated_total += 1;
+    ai_video_count.total_videos_generated += 1;
+
+    // Check if mission is now completed
+    if ai_video_count.videos_generated_total >= ai_video_count.target_videos {
+        ai_video_count.completed = true;
+    }
+
+    (
+        true,
+        format!(
+            "AI videos generated: {}/{}{}",
+            ai_video_count.videos_generated_total,
+            ai_video_count.target_videos,
+            if ai_video_count.completed {
+                " - Mission Complete!"
+            } else {
+                ""
+            }
+        ),
+    )
+}
+
+/// Updates referral count for a user
+pub fn update_referral_count(
+    referral_count: &mut ReferralCount,
+    referred_user: Principal,
+    now: SystemTime,
+) -> (bool, String) {
+    // Check if mission is already completed
+    if referral_count.completed {
+        return (
+            false,
+            "Referral mission already completed. No more rewards available.".to_string(),
+        );
+    }
+
+    // Check if user was already referred
+    if referral_count
+        .referred_users
+        .iter()
+        .any(|u| u.principal_id == referred_user)
+    {
+        return (false, "User already referred".to_string());
+    }
+
+    referral_count.referrals_made_total += 1;
+    referral_count.total_referrals_made += 1;
+    referral_count.referred_users.push(ReferredUser {
+        principal_id: referred_user,
+        referred_at: now,
+        is_active: true,
+    });
+
+    // Check if mission is now completed
+    if referral_count.referrals_made_total >= referral_count.target_referrals {
+        referral_count.completed = true;
+    }
+
+    (
+        true,
+        format!(
+            "Referrals made: {}/{}{}",
+            referral_count.referrals_made_total,
+            referral_count.target_referrals,
+            if referral_count.completed {
+                " - Mission Complete!"
+            } else {
+                ""
+            }
+        ),
+    )
+}
+
+/// Generates a unique reward ID
+pub fn generate_reward_id(
+    user: &Principal,
+    reward_type: &RewardType,
+    timestamp: SystemTime,
+) -> String {
+    format!(
+        "{:?}_{:?}_{:?}",
+        user.to_text(),
+        reward_type,
+        timestamp
+            .duration_since(SystemTime::UNIX_EPOCH)
+            .unwrap()
+            .as_secs()
+    )
+}
+
+/// Adds a pending reward to user's missions
+pub fn add_pending_reward(
+    missions: &mut UserDailyMissions,
+    user: &Principal,
+    reward_type: RewardType,
+    amount: u64,
+    mission_day: u32,
+    timestamp: SystemTime,
+) {
+    let reward_id = generate_reward_id(user, &reward_type, timestamp);
+    let pending_reward = PendingReward {
+        id: reward_id,
+        reward_type,
+        amount,
+        earned_at: timestamp,
+        mission_day,
+    };
+    missions.pending_rewards.push(pending_reward);
+}
+
+/// Checks if daily counter should be reset
+pub fn should_reset_daily_counter(last_reset: &Option<SystemTime>, now: SystemTime) -> bool {
+    match last_reset {
+        Some(last) => {
+            let last_day = get_day_from_timestamp(*last);
+            let current_day = get_day_from_timestamp(now);
+            current_day > last_day
+        }
+        None => true,
+    }
+}
+
+/// Converts timestamp to day number since Unix epoch
+pub fn get_day_from_timestamp(time: SystemTime) -> u64 {
+    time.duration_since(SystemTime::UNIX_EPOCH)
+        .unwrap()
+        .as_secs()
+        / (24 * 60 * 60)
+}
+
+/// Calculates hours until next day (UTC)
+pub fn calculate_hours_until_next_day(now: SystemTime) -> u32 {
+    let seconds_since_epoch = now
+        .duration_since(SystemTime::UNIX_EPOCH)
+        .unwrap()
+        .as_secs();
+    let seconds_in_day = 24 * 60 * 60;
+    let seconds_until_next_day = seconds_in_day - (seconds_since_epoch % seconds_in_day);
+    (seconds_until_next_day / 3600) as u32
+}
+
+/// Calculates hours until reset based on last reset time
+pub fn calculate_hours_until_reset(last_reset: &Option<SystemTime>, now: SystemTime) -> u32 {
+    match last_reset {
+        Some(last) => {
+            let hours_since_reset = now.duration_since(*last).unwrap().as_secs() / 3600;
+            if hours_since_reset >= 24 {
+                0
+            } else {
+                (24 - hours_since_reset) as u32
+            }
+        }
+        None => 0,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+    fn create_test_time(days: u64) -> SystemTime {
+        UNIX_EPOCH + Duration::from_secs(days * 24 * 60 * 60)
+    }
+
+    #[test]
+    fn test_update_login_streak_first_login() {
+        let mut streak = LoginStreak::default();
+        let now = create_test_time(1);
+
+        let (success, message) = update_login_streak(&mut streak, now);
+
+        assert!(success);
+        assert_eq!(streak.current_streak, 1);
+        assert_eq!(streak.max_streak, 1);
+        assert!(streak.can_claim_today);
+        assert!(message.contains("Login streak updated to 1 days"));
+    }
+
+    #[test]
+    fn test_update_login_streak_consecutive_days() {
+        let mut streak = LoginStreak {
+            current_streak: 1,
+            max_streak: 1,
+            last_login_date: Some(create_test_time(1)),
+            streak_start_date: Some(create_test_time(1)),
+            claimed_rewards: vec![],
+            can_claim_today: false,
+        };
+        let now = create_test_time(2);
+
+        let (success, message) = update_login_streak(&mut streak, now);
+
+        assert!(success);
+        assert_eq!(streak.current_streak, 2);
+        assert_eq!(streak.max_streak, 2);
+        assert!(streak.can_claim_today);
+        assert!(message.contains("Login streak updated to 2 days"));
+    }
+
+    #[test]
+    fn test_update_login_streak_same_day() {
+        let day1 = create_test_time(1);
+        let mut streak = LoginStreak {
+            current_streak: 1,
+            max_streak: 1,
+            last_login_date: Some(day1),
+            streak_start_date: Some(day1),
+            claimed_rewards: vec![],
+            can_claim_today: true,
+        };
+        // Same day, few hours later
+        let now = day1 + Duration::from_secs(3600);
+
+        let (success, message) = update_login_streak(&mut streak, now);
+
+        assert!(success);
+        assert_eq!(streak.current_streak, 1); // Should not increment
+        assert_eq!(message, "Already logged in today");
+    }
+
+    #[test]
+    fn test_update_login_streak_broken() {
+        let mut streak = LoginStreak {
+            current_streak: 5,
+            max_streak: 5,
+            last_login_date: Some(create_test_time(1)),
+            streak_start_date: Some(create_test_time(1)),
+            claimed_rewards: vec![],
+            can_claim_today: false,
+        };
+        let now = create_test_time(5); // 4 days gap
+
+        let (success, message) = update_login_streak(&mut streak, now);
+
+        assert!(success);
+        assert_eq!(streak.current_streak, 1); // Reset to 1
+        assert_eq!(streak.max_streak, 5); // Max should remain
+        assert!(streak.can_claim_today);
+        assert!(message.contains("Login streak updated to 1 days"));
+    }
+
+    #[test]
+    fn test_update_ai_video_count_completion() {
+        let mut count = GenerateAiVideoCount {
+            videos_generated_total: 2,
+            total_videos_generated: 2,
+            target_videos: 3,
+            completed: false,
+        };
+        let now = create_test_time(1);
+
+        let (success, message) = update_ai_video_count(&mut count, now);
+
+        assert!(success);
+        assert_eq!(count.videos_generated_total, 3);
+        assert_eq!(count.total_videos_generated, 3);
+        assert!(count.completed);
+        assert!(message.contains("Mission Complete!"));
+    }
+
+    #[test]
+    fn test_update_ai_video_count_already_completed() {
+        let mut count = GenerateAiVideoCount {
+            videos_generated_total: 3,
+            total_videos_generated: 3,
+            target_videos: 3,
+            completed: true,
+        };
+        let now = create_test_time(1);
+
+        let (success, message) = update_ai_video_count(&mut count, now);
+
+        assert!(!success);
+        assert!(message.contains("already completed"));
+        assert_eq!(count.videos_generated_total, 3); // Should not increment
+    }
+
+    #[test]
+    fn test_get_day_from_timestamp() {
+        let epoch = SystemTime::UNIX_EPOCH;
+        let day1 = epoch + Duration::from_secs(24 * 60 * 60);
+        let day2 = epoch + Duration::from_secs(2 * 24 * 60 * 60);
+
+        assert_eq!(get_day_from_timestamp(epoch), 0);
+        assert_eq!(get_day_from_timestamp(day1), 1);
+        assert_eq!(get_day_from_timestamp(day2), 2);
+    }
+
+    #[test]
+    fn test_should_reset_daily_counter() {
+        let day1 = create_test_time(1);
+        let day2 = create_test_time(2);
+
+        // No previous reset - should reset
+        assert!(should_reset_daily_counter(&None, day1));
+
+        // Same day - should not reset
+        assert!(!should_reset_daily_counter(&Some(day1), day1));
+
+        // Different day - should reset
+        assert!(should_reset_daily_counter(&Some(day1), day2));
+    }
+
+    #[test]
+    fn test_calculate_hours_until_next_day() {
+        // Test at the beginning of day 1 (should be 24 hours until next day)
+        let start_of_day = create_test_time(1);
+        let hours = calculate_hours_until_next_day(start_of_day);
+        assert_eq!(hours, 24);
+
+        // Test halfway through day 1 (should be 12 hours until next day)
+        let mid_day = start_of_day + Duration::from_secs(12 * 60 * 60);
+        let hours = calculate_hours_until_next_day(mid_day);
+        assert_eq!(hours, 12);
+    }
+}

--- a/src/canister/daily_missions/src/util/mission_utils.rs
+++ b/src/canister/daily_missions/src/util/mission_utils.rs
@@ -1,6 +1,6 @@
 use crate::data_model::{
-    ClaimedReward, GameStreak, GenerateAiVideoCount, LoginStreak, PendingReward, ReferralCount,
-    ReferredUser, RewardType, UserDailyMissions,
+    GameStreak, GenerateAiVideoCount, LoginStreak, PendingReward, ReferralCount, ReferredUser,
+    RewardType, UserDailyMissions,
 };
 use candid::Principal;
 use std::time::SystemTime;
@@ -13,24 +13,21 @@ pub fn update_login_streak(login_streak: &mut LoginStreak, now: SystemTime) -> (
         let last_login_day = get_day_from_timestamp(last_login);
 
         if today == last_login_day {
-            return (true, "Already logged in today".to_string());
+            return (false, "Already logged in today".to_string());
         }
 
         if today == last_login_day + 1 {
             // Consecutive day
             login_streak.current_streak += 1;
-            login_streak.can_claim_today = true;
         } else {
             // Streak broken
             login_streak.current_streak = 1;
             login_streak.streak_start_date = Some(now);
-            login_streak.can_claim_today = true;
         }
     } else {
         // First login
         login_streak.current_streak = 1;
         login_streak.streak_start_date = Some(now);
-        login_streak.can_claim_today = true;
     }
 
     login_streak.last_login_date = Some(now);
@@ -253,7 +250,6 @@ mod tests {
         assert!(success);
         assert_eq!(streak.current_streak, 1);
         assert_eq!(streak.max_streak, 1);
-        assert!(streak.can_claim_today);
         assert!(message.contains("Login streak updated to 1 days"));
     }
 
@@ -265,7 +261,6 @@ mod tests {
             last_login_date: Some(create_test_time(1)),
             streak_start_date: Some(create_test_time(1)),
             claimed_rewards: vec![],
-            can_claim_today: false,
         };
         let now = create_test_time(2);
 
@@ -274,7 +269,6 @@ mod tests {
         assert!(success);
         assert_eq!(streak.current_streak, 2);
         assert_eq!(streak.max_streak, 2);
-        assert!(streak.can_claim_today);
         assert!(message.contains("Login streak updated to 2 days"));
     }
 
@@ -287,14 +281,13 @@ mod tests {
             last_login_date: Some(day1),
             streak_start_date: Some(day1),
             claimed_rewards: vec![],
-            can_claim_today: true,
         };
         // Same day, few hours later
         let now = day1 + Duration::from_secs(3600);
 
         let (success, message) = update_login_streak(&mut streak, now);
 
-        assert!(success);
+        assert!(!success); // Should return false for same day login
         assert_eq!(streak.current_streak, 1); // Should not increment
         assert_eq!(message, "Already logged in today");
     }
@@ -307,7 +300,6 @@ mod tests {
             last_login_date: Some(create_test_time(1)),
             streak_start_date: Some(create_test_time(1)),
             claimed_rewards: vec![],
-            can_claim_today: false,
         };
         let now = create_test_time(5); // 4 days gap
 
@@ -316,7 +308,6 @@ mod tests {
         assert!(success);
         assert_eq!(streak.current_streak, 1); // Reset to 1
         assert_eq!(streak.max_streak, 5); // Max should remain
-        assert!(streak.can_claim_today);
         assert!(message.contains("Login streak updated to 1 days"));
     }
 
@@ -327,6 +318,7 @@ mod tests {
             total_videos_generated: 2,
             target_videos: 3,
             completed: false,
+            reward_claimed: false,
         };
         let now = create_test_time(1);
 
@@ -346,6 +338,7 @@ mod tests {
             total_videos_generated: 3,
             target_videos: 3,
             completed: true,
+            reward_claimed: false,
         };
         let now = create_test_time(1);
 

--- a/src/canister/daily_missions/src/util/mod.rs
+++ b/src/canister/daily_missions/src/util/mod.rs
@@ -1,5 +1,10 @@
 use std::time::{Duration, SystemTime};
 
+/// Mission-specific helper functions
+pub mod mission_utils;
+/// Progress calculation and building utilities
+pub mod progress_utils;
+
 /// Utility functions for daily missions canister
 
 /// Check if a given timestamp is from today

--- a/src/canister/daily_missions/src/util/mod.rs
+++ b/src/canister/daily_missions/src/util/mod.rs
@@ -1,0 +1,171 @@
+use std::time::{Duration, SystemTime};
+
+/// Utility functions for daily missions canister
+
+/// Check if a given timestamp is from today
+pub fn is_same_day(timestamp: SystemTime, reference: SystemTime) -> bool {
+    let ts_days = timestamp
+        .duration_since(SystemTime::UNIX_EPOCH)
+        .unwrap_or(Duration::ZERO)
+        .as_secs()
+        / (24 * 60 * 60);
+
+    let ref_days = reference
+        .duration_since(SystemTime::UNIX_EPOCH)
+        .unwrap_or(Duration::ZERO)
+        .as_secs()
+        / (24 * 60 * 60);
+
+    ts_days == ref_days
+}
+
+/// Check if a timestamp is from yesterday relative to reference
+pub fn is_yesterday(timestamp: SystemTime, reference: SystemTime) -> bool {
+    let ts_days = timestamp
+        .duration_since(SystemTime::UNIX_EPOCH)
+        .unwrap_or(Duration::ZERO)
+        .as_secs()
+        / (24 * 60 * 60);
+
+    let ref_days = reference
+        .duration_since(SystemTime::UNIX_EPOCH)
+        .unwrap_or(Duration::ZERO)
+        .as_secs()
+        / (24 * 60 * 60);
+
+    ts_days == ref_days - 1
+}
+
+/// Get the number of days between two timestamps
+pub fn days_between(start: SystemTime, end: SystemTime) -> u64 {
+    if end < start {
+        return 0;
+    }
+
+    let start_days = start
+        .duration_since(SystemTime::UNIX_EPOCH)
+        .unwrap_or(Duration::ZERO)
+        .as_secs()
+        / (24 * 60 * 60);
+
+    let end_days = end
+        .duration_since(SystemTime::UNIX_EPOCH)
+        .unwrap_or(Duration::ZERO)
+        .as_secs()
+        / (24 * 60 * 60);
+
+    end_days - start_days
+}
+
+/// Get the start of the day for a given timestamp
+pub fn get_day_start(timestamp: SystemTime) -> SystemTime {
+    let seconds_since_epoch = timestamp
+        .duration_since(SystemTime::UNIX_EPOCH)
+        .unwrap_or(Duration::ZERO)
+        .as_secs();
+
+    let seconds_in_day = 24 * 60 * 60;
+    let day_start_seconds = (seconds_since_epoch / seconds_in_day) * seconds_in_day;
+
+    SystemTime::UNIX_EPOCH + Duration::from_secs(day_start_seconds)
+}
+
+/// Get the end of the day for a given timestamp
+pub fn get_day_end(timestamp: SystemTime) -> SystemTime {
+    let day_start = get_day_start(timestamp);
+    day_start + Duration::from_secs(24 * 60 * 60 - 1)
+}
+
+/// Calculate hours remaining until next day (UTC)
+pub fn hours_until_next_day(timestamp: SystemTime) -> u32 {
+    let seconds_since_epoch = timestamp
+        .duration_since(SystemTime::UNIX_EPOCH)
+        .unwrap_or(Duration::ZERO)
+        .as_secs();
+
+    let seconds_in_day = 24 * 60 * 60;
+    let seconds_into_day = seconds_since_epoch % seconds_in_day;
+    let seconds_until_next_day = seconds_in_day - seconds_into_day;
+
+    (seconds_until_next_day / 3600) as u32
+}
+
+/// Validate if a reward can be claimed based on progress and requirements
+pub fn can_claim_reward(current_progress: u32, target: u32, already_claimed: bool) -> bool {
+    current_progress >= target && !already_claimed
+}
+
+/// Format duration in a human-readable way
+pub fn format_duration_hours(hours: u32) -> String {
+    if hours == 0 {
+        "Now".to_string()
+    } else if hours == 1 {
+        "1 hour".to_string()
+    } else if hours < 24 {
+        format!("{} hours", hours)
+    } else {
+        let days = hours / 24;
+        let remaining_hours = hours % 24;
+        if remaining_hours == 0 {
+            if days == 1 {
+                "1 day".to_string()
+            } else {
+                format!("{} days", days)
+            }
+        } else {
+            format!("{} days {} hours", days, remaining_hours)
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+    #[test]
+    fn test_is_same_day() {
+        let base_time = UNIX_EPOCH + Duration::from_secs(24 * 60 * 60); // Day 1
+        let same_day = base_time + Duration::from_secs(3600); // 1 hour later same day
+        let different_day = base_time + Duration::from_secs(24 * 60 * 60); // Next day
+
+        assert!(is_same_day(base_time, same_day));
+        assert!(!is_same_day(base_time, different_day));
+    }
+
+    #[test]
+    fn test_is_yesterday() {
+        let today = UNIX_EPOCH + Duration::from_secs(2 * 24 * 60 * 60); // Day 2
+        let yesterday = UNIX_EPOCH + Duration::from_secs(24 * 60 * 60); // Day 1
+        let two_days_ago = UNIX_EPOCH; // Day 0
+
+        assert!(is_yesterday(yesterday, today));
+        assert!(!is_yesterday(two_days_ago, today));
+    }
+
+    #[test]
+    fn test_days_between() {
+        let start = UNIX_EPOCH;
+        let end = UNIX_EPOCH + Duration::from_secs(3 * 24 * 60 * 60);
+
+        assert_eq!(days_between(start, end), 3);
+        assert_eq!(days_between(end, start), 0);
+    }
+
+    #[test]
+    fn test_can_claim_reward() {
+        assert!(can_claim_reward(10, 5, false));
+        assert!(!can_claim_reward(3, 5, false));
+        assert!(!can_claim_reward(10, 5, true));
+    }
+
+    #[test]
+    fn test_format_duration_hours() {
+        assert_eq!(format_duration_hours(0), "Now");
+        assert_eq!(format_duration_hours(1), "1 hour");
+        assert_eq!(format_duration_hours(5), "5 hours");
+        assert_eq!(format_duration_hours(24), "1 day");
+        assert_eq!(format_duration_hours(25), "1 days 1 hours");
+        assert_eq!(format_duration_hours(48), "2 days");
+    }
+}

--- a/src/canister/daily_missions/src/util/progress_utils.rs
+++ b/src/canister/daily_missions/src/util/progress_utils.rs
@@ -1,0 +1,411 @@
+use super::mission_utils::{calculate_hours_until_next_day, calculate_hours_until_reset};
+use crate::data_model::{
+    AiVideoProgress, GameProgress, LoginStreakProgress, MissionProgress, PendingReward,
+    ReferralProgress, RewardType, UserDailyMissions, AI_VIDEO_GENERATION_REWARD,
+    GAME_COMPLETION_REWARD, LOGIN_STREAK_REWARD, LOGIN_STREAK_TARGET, REFERRAL_REWARD,
+};
+use std::time::SystemTime;
+
+/// Builds comprehensive mission progress for a user
+pub fn build_mission_progress(missions: &UserDailyMissions, now: SystemTime) -> MissionProgress {
+    let has_pending_login_reward = missions
+        .pending_rewards
+        .iter()
+        .any(|r| r.reward_type == RewardType::LoginStreak);
+
+    let has_pending_game_reward = missions
+        .pending_rewards
+        .iter()
+        .any(|r| r.reward_type == RewardType::GameCompletion);
+
+    let has_pending_ai_reward = missions
+        .pending_rewards
+        .iter()
+        .any(|r| r.reward_type == RewardType::AiVideoGeneration);
+
+    let has_pending_referral_reward = missions
+        .pending_rewards
+        .iter()
+        .any(|r| r.reward_type == RewardType::Referral);
+
+    MissionProgress {
+        login_streak: LoginStreakProgress {
+            current_day: missions.login_streak.current_streak,
+            target_day: LOGIN_STREAK_TARGET,
+            can_claim: has_pending_login_reward
+                || (missions.login_streak.can_claim_today
+                    && missions.login_streak.current_streak >= LOGIN_STREAK_TARGET),
+            reward_amount: LOGIN_STREAK_REWARD,
+            next_reset_in_hours: calculate_hours_until_next_day(now),
+        },
+        game_progress: GameProgress {
+            current_count: missions.game_streak.games_played_today,
+            target_count: missions.game_streak.target_games,
+            can_claim: has_pending_game_reward
+                || (!missions.game_streak.claimed_today
+                    && missions.game_streak.games_played_today
+                        >= missions.game_streak.target_games),
+            reward_amount: GAME_COMPLETION_REWARD,
+            hours_remaining: calculate_hours_until_reset(
+                &missions.game_streak.last_reset_date,
+                now,
+            ),
+        },
+        ai_video_progress: AiVideoProgress {
+            current_count: missions.ai_video_count.videos_generated_total,
+            target_count: missions.ai_video_count.target_videos,
+            can_claim: has_pending_ai_reward
+                || (!missions.ai_video_count.reward_claimed && missions.ai_video_count.completed),
+            reward_amount: AI_VIDEO_GENERATION_REWARD,
+            completed: missions.ai_video_count.completed,
+        },
+        referral_progress: ReferralProgress {
+            current_count: missions.referral_count.referrals_made_total,
+            target_count: missions.referral_count.target_referrals,
+            can_claim: has_pending_referral_reward
+                || (!missions.referral_count.reward_claimed && missions.referral_count.completed),
+            reward_amount: REFERRAL_REWARD,
+            completed: missions.referral_count.completed,
+        },
+        pending_rewards: missions.pending_rewards.clone(),
+    }
+}
+
+/// Calculates total pending reward amount for a user
+pub fn calculate_total_pending_rewards(pending_rewards: &[PendingReward]) -> u64 {
+    pending_rewards.iter().map(|r| r.amount).sum()
+}
+
+/// Finds a pending reward by ID
+pub fn find_pending_reward_by_id<'a>(
+    pending_rewards: &'a [PendingReward],
+    reward_id: &str,
+) -> Option<&'a PendingReward> {
+    pending_rewards.iter().find(|r| r.id == reward_id)
+}
+
+/// Removes a pending reward by ID and returns it if found
+pub fn remove_pending_reward_by_id(
+    pending_rewards: &mut Vec<PendingReward>,
+    reward_id: &str,
+) -> Option<PendingReward> {
+    if let Some(index) = pending_rewards.iter().position(|r| r.id == reward_id) {
+        Some(pending_rewards.remove(index))
+    } else {
+        None
+    }
+}
+
+/// Checks if a user can claim any rewards
+pub fn has_claimable_rewards(missions: &UserDailyMissions, now: SystemTime) -> bool {
+    let progress = build_mission_progress(missions, now);
+
+    progress.login_streak.can_claim
+        || progress.game_progress.can_claim
+        || progress.ai_video_progress.can_claim
+        || progress.referral_progress.can_claim
+}
+
+/// Counts pending rewards by type
+pub fn count_pending_rewards_by_type(
+    pending_rewards: &[PendingReward],
+    reward_type: &RewardType,
+) -> usize {
+    pending_rewards
+        .iter()
+        .filter(|r| &r.reward_type == reward_type)
+        .count()
+}
+
+/// Gets the latest earned reward timestamp for a specific type
+pub fn get_latest_reward_timestamp(
+    pending_rewards: &[PendingReward],
+    reward_type: &RewardType,
+) -> Option<SystemTime> {
+    pending_rewards
+        .iter()
+        .filter(|r| &r.reward_type == reward_type)
+        .map(|r| r.earned_at)
+        .max()
+}
+
+/// Validates if a mission progress state is consistent
+pub fn validate_mission_progress(missions: &UserDailyMissions) -> Result<(), String> {
+    // Validate login streak
+    if missions.login_streak.current_streak > missions.login_streak.max_streak {
+        return Err("Current streak cannot exceed max streak".to_string());
+    }
+
+    // Validate AI video count
+    if missions.ai_video_count.videos_generated_total
+        > missions.ai_video_count.total_videos_generated
+    {
+        return Err("Daily videos cannot exceed total videos".to_string());
+    }
+
+    // Validate referral count
+    if missions.referral_count.referrals_made_total > missions.referral_count.total_referrals_made {
+        return Err("Daily referrals cannot exceed total referrals".to_string());
+    }
+
+    // Validate referrals list consistency
+    if missions.referral_count.referrals_made_total
+        != missions.referral_count.referred_users.len() as u32
+    {
+        return Err("Referral count mismatch with referred users list".to_string());
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::data_model::{
+        GameStreak, GenerateAiVideoCount, LoginStreak, ReferralCount, ReferredUser,
+    };
+    use candid::Principal;
+    use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+    fn create_test_time(days: u64) -> SystemTime {
+        UNIX_EPOCH + Duration::from_secs(days * 24 * 60 * 60)
+    }
+
+    fn create_test_missions() -> UserDailyMissions {
+        UserDailyMissions {
+            login_streak: LoginStreak {
+                current_streak: 5,
+                max_streak: 10,
+                last_login_date: Some(create_test_time(1)),
+                streak_start_date: Some(create_test_time(1)),
+                claimed_rewards: vec![],
+                can_claim_today: true,
+            },
+            game_streak: GameStreak {
+                games_played_today: 3,
+                target_games: 5,
+                claimed_today: false,
+                last_reset_date: Some(create_test_time(1)),
+            },
+            ai_video_count: GenerateAiVideoCount {
+                videos_generated_total: 2,
+                total_videos_generated: 2,
+                target_videos: 3,
+                completed: false,
+            },
+            referral_count: ReferralCount {
+                referrals_made_total: 1,
+                total_referrals_made: 1,
+                target_referrals: 3,
+                completed: false,
+                referred_users: vec![ReferredUser {
+                    principal_id: Principal::from_slice(&[1, 2, 3, 4]),
+                    referred_at: create_test_time(1),
+                    is_active: true,
+                }],
+            },
+            last_updated: create_test_time(1),
+            pending_rewards: vec![],
+        }
+    }
+
+    #[test]
+    fn test_build_mission_progress() {
+        let missions = create_test_missions();
+        let now = create_test_time(2);
+
+        let progress = build_mission_progress(&missions, now);
+
+        assert_eq!(progress.login_streak.current_day, 5);
+        assert_eq!(progress.login_streak.target_day, LOGIN_STREAK_TARGET);
+        assert_eq!(progress.game_progress.current_count, 3);
+        assert_eq!(progress.game_progress.target_count, 5);
+        assert_eq!(progress.ai_video_progress.current_count, 2);
+        assert_eq!(progress.ai_video_progress.target_count, 3);
+        assert_eq!(progress.referral_progress.current_count, 1);
+        assert_eq!(progress.referral_progress.target_count, 3);
+    }
+
+    #[test]
+    fn test_calculate_total_pending_rewards() {
+        let pending_rewards = vec![
+            PendingReward {
+                id: "test1".to_string(),
+                reward_type: RewardType::LoginStreak,
+                amount: 100,
+                earned_at: create_test_time(1),
+                mission_day: 1,
+            },
+            PendingReward {
+                id: "test2".to_string(),
+                reward_type: RewardType::GameCompletion,
+                amount: 200,
+                earned_at: create_test_time(1),
+                mission_day: 1,
+            },
+        ];
+
+        let total = calculate_total_pending_rewards(&pending_rewards);
+        assert_eq!(total, 300);
+    }
+
+    #[test]
+    fn test_find_pending_reward_by_id() {
+        let pending_rewards = vec![PendingReward {
+            id: "test1".to_string(),
+            reward_type: RewardType::LoginStreak,
+            amount: 100,
+            earned_at: create_test_time(1),
+            mission_day: 1,
+        }];
+
+        let found = find_pending_reward_by_id(&pending_rewards, "test1");
+        assert!(found.is_some());
+        assert_eq!(found.unwrap().amount, 100);
+
+        let not_found = find_pending_reward_by_id(&pending_rewards, "test2");
+        assert!(not_found.is_none());
+    }
+
+    #[test]
+    fn test_remove_pending_reward_by_id() {
+        let mut pending_rewards = vec![
+            PendingReward {
+                id: "test1".to_string(),
+                reward_type: RewardType::LoginStreak,
+                amount: 100,
+                earned_at: create_test_time(1),
+                mission_day: 1,
+            },
+            PendingReward {
+                id: "test2".to_string(),
+                reward_type: RewardType::GameCompletion,
+                amount: 200,
+                earned_at: create_test_time(1),
+                mission_day: 1,
+            },
+        ];
+
+        let removed = remove_pending_reward_by_id(&mut pending_rewards, "test1");
+        assert!(removed.is_some());
+        assert_eq!(removed.unwrap().amount, 100);
+        assert_eq!(pending_rewards.len(), 1);
+        assert_eq!(pending_rewards[0].id, "test2");
+
+        let not_found = remove_pending_reward_by_id(&mut pending_rewards, "test3");
+        assert!(not_found.is_none());
+        assert_eq!(pending_rewards.len(), 1);
+    }
+
+    #[test]
+    fn test_has_claimable_rewards() {
+        let mut missions = create_test_missions();
+        let now = create_test_time(2);
+
+        // Initially should have claimable login streak reward
+        missions.login_streak.can_claim_today = true;
+        missions.login_streak.current_streak = LOGIN_STREAK_TARGET;
+        assert!(has_claimable_rewards(&missions, now));
+
+        // Remove claimability
+        missions.login_streak.can_claim_today = false;
+        missions.login_streak.current_streak = 1;
+        assert!(!has_claimable_rewards(&missions, now));
+    }
+
+    #[test]
+    fn test_count_pending_rewards_by_type() {
+        let pending_rewards = vec![
+            PendingReward {
+                id: "test1".to_string(),
+                reward_type: RewardType::LoginStreak,
+                amount: 100,
+                earned_at: create_test_time(1),
+                mission_day: 1,
+            },
+            PendingReward {
+                id: "test2".to_string(),
+                reward_type: RewardType::LoginStreak,
+                amount: 100,
+                earned_at: create_test_time(2),
+                mission_day: 2,
+            },
+            PendingReward {
+                id: "test3".to_string(),
+                reward_type: RewardType::GameCompletion,
+                amount: 200,
+                earned_at: create_test_time(1),
+                mission_day: 1,
+            },
+        ];
+
+        let login_count = count_pending_rewards_by_type(&pending_rewards, &RewardType::LoginStreak);
+        assert_eq!(login_count, 2);
+
+        let game_count =
+            count_pending_rewards_by_type(&pending_rewards, &RewardType::GameCompletion);
+        assert_eq!(game_count, 1);
+
+        let ai_count =
+            count_pending_rewards_by_type(&pending_rewards, &RewardType::AiVideoGeneration);
+        assert_eq!(ai_count, 0);
+    }
+
+    #[test]
+    fn test_validate_mission_progress() {
+        let mut missions = create_test_missions();
+
+        // Valid state
+        assert!(validate_mission_progress(&missions).is_ok());
+
+        // Invalid: current streak > max streak
+        missions.login_streak.current_streak = 15;
+        missions.login_streak.max_streak = 10;
+        assert!(validate_mission_progress(&missions).is_err());
+
+        // Fix and test another invalid state
+        missions.login_streak.current_streak = 5;
+        missions.login_streak.max_streak = 10;
+        missions.ai_video_count.videos_generated_total = 5;
+        missions.ai_video_count.total_videos_generated = 3;
+        assert!(validate_mission_progress(&missions).is_err());
+    }
+
+    #[test]
+    fn test_get_latest_reward_timestamp() {
+        let pending_rewards = vec![
+            PendingReward {
+                id: "test1".to_string(),
+                reward_type: RewardType::LoginStreak,
+                amount: 100,
+                earned_at: create_test_time(1),
+                mission_day: 1,
+            },
+            PendingReward {
+                id: "test2".to_string(),
+                reward_type: RewardType::LoginStreak,
+                amount: 100,
+                earned_at: create_test_time(3),
+                mission_day: 3,
+            },
+            PendingReward {
+                id: "test3".to_string(),
+                reward_type: RewardType::GameCompletion,
+                amount: 200,
+                earned_at: create_test_time(2),
+                mission_day: 1,
+            },
+        ];
+
+        let latest_login = get_latest_reward_timestamp(&pending_rewards, &RewardType::LoginStreak);
+        assert_eq!(latest_login, Some(create_test_time(3)));
+
+        let latest_game =
+            get_latest_reward_timestamp(&pending_rewards, &RewardType::GameCompletion);
+        assert_eq!(latest_game, Some(create_test_time(2)));
+
+        let latest_ai =
+            get_latest_reward_timestamp(&pending_rewards, &RewardType::AiVideoGeneration);
+        assert_eq!(latest_ai, None);
+    }
+}

--- a/src/canister/daily_missions/src/util/progress_utils.rs
+++ b/src/canister/daily_missions/src/util/progress_utils.rs
@@ -2,16 +2,15 @@ use super::mission_utils::{calculate_hours_until_next_day, calculate_hours_until
 use crate::data_model::{
     AiVideoProgress, GameProgress, LoginStreakProgress, MissionProgress, PendingReward,
     ReferralProgress, RewardType, UserDailyMissions, AI_VIDEO_GENERATION_REWARD,
-    GAME_COMPLETION_REWARD, LOGIN_STREAK_REWARD, LOGIN_STREAK_TARGET, REFERRAL_REWARD,
+    DAILY_LOGIN_REWARD, GAME_COMPLETION_REWARD, LOGIN_STREAK_TARGET, REFERRAL_REWARD,
 };
 use std::time::SystemTime;
 
 /// Builds comprehensive mission progress for a user
 pub fn build_mission_progress(missions: &UserDailyMissions, now: SystemTime) -> MissionProgress {
-    let has_pending_login_reward = missions
-        .pending_rewards
-        .iter()
-        .any(|r| r.reward_type == RewardType::LoginStreak);
+    let has_pending_login_reward = missions.pending_rewards.iter().any(|r| {
+        r.reward_type == RewardType::LoginStreak || r.reward_type == RewardType::LoginStreakBonus
+    });
 
     let has_pending_game_reward = missions
         .pending_rewards
@@ -32,10 +31,8 @@ pub fn build_mission_progress(missions: &UserDailyMissions, now: SystemTime) -> 
         login_streak: LoginStreakProgress {
             current_day: missions.login_streak.current_streak,
             target_day: LOGIN_STREAK_TARGET,
-            can_claim: has_pending_login_reward
-                || (missions.login_streak.can_claim_today
-                    && missions.login_streak.current_streak >= LOGIN_STREAK_TARGET),
-            reward_amount: LOGIN_STREAK_REWARD,
+            can_claim: has_pending_login_reward,
+            reward_amount: DAILY_LOGIN_REWARD,
             next_reset_in_hours: calculate_hours_until_next_day(now),
         },
         game_progress: GameProgress {
@@ -179,25 +176,27 @@ mod tests {
                 last_login_date: Some(create_test_time(1)),
                 streak_start_date: Some(create_test_time(1)),
                 claimed_rewards: vec![],
-                can_claim_today: true,
             },
             game_streak: GameStreak {
                 games_played_today: 3,
                 target_games: 5,
                 claimed_today: false,
                 last_reset_date: Some(create_test_time(1)),
+                total_games_completed: 0,
             },
             ai_video_count: GenerateAiVideoCount {
                 videos_generated_total: 2,
                 total_videos_generated: 2,
                 target_videos: 3,
                 completed: false,
+                reward_claimed: false,
             },
             referral_count: ReferralCount {
                 referrals_made_total: 1,
                 total_referrals_made: 1,
                 target_referrals: 3,
                 completed: false,
+                reward_claimed: false,
                 referred_users: vec![ReferredUser {
                     principal_id: Principal::from_slice(&[1, 2, 3, 4]),
                     referred_at: create_test_time(1),
@@ -302,14 +301,18 @@ mod tests {
         let mut missions = create_test_missions();
         let now = create_test_time(2);
 
-        // Initially should have claimable login streak reward
-        missions.login_streak.can_claim_today = true;
-        missions.login_streak.current_streak = LOGIN_STREAK_TARGET;
+        // Add a pending reward to make it claimable
+        missions.pending_rewards.push(PendingReward {
+            id: "test1".to_string(),
+            reward_type: RewardType::LoginStreak,
+            amount: 100,
+            earned_at: create_test_time(1),
+            mission_day: 1,
+        });
         assert!(has_claimable_rewards(&missions, now));
 
-        // Remove claimability
-        missions.login_streak.can_claim_today = false;
-        missions.login_streak.current_streak = 1;
+        // Remove pending rewards to make it not claimable
+        missions.pending_rewards.clear();
         assert!(!has_claimable_rewards(&missions, now));
     }
 

--- a/src/lib/integration_tests/tests/daily_missions/main.rs
+++ b/src/lib/integration_tests/tests/daily_missions/main.rs
@@ -50,7 +50,7 @@ pub struct ClaimRewardResponse {
 pub struct MissionUpdateResult {
     pub success: bool,
     pub message: String,
-    pub new_progress: Option<MissionProgress>,
+    pub new_progress: Option<UserDailyMissions>,
     pub reward_earned: Option<ClaimedReward>,
 }
 
@@ -111,6 +111,7 @@ pub struct PendingReward {
 #[derive(candid::CandidType, serde::Deserialize, Clone, Debug, PartialEq)]
 pub enum RewardType {
     LoginStreak,
+    LoginStreakBonus,
     GameCompletion,
     AiVideoGeneration,
     Referral,
@@ -181,25 +182,78 @@ pub struct ReferredUser {
 
 mod helper {
     use super::*;
+    use shared_utils::common::utils::system_time::get_current_system_time_from_ic;
+
+    fn convert_user_missions_to_progress(missions: &UserDailyMissions) -> MissionProgress {
+        let has_pending_login_reward = missions.pending_rewards.iter().any(|r| {
+            matches!(
+                r.reward_type,
+                RewardType::LoginStreak | RewardType::LoginStreakBonus
+            )
+        });
+
+        let has_pending_game_reward = missions
+            .pending_rewards
+            .iter()
+            .any(|r| r.reward_type == RewardType::GameCompletion);
+
+        let has_pending_ai_reward = missions
+            .pending_rewards
+            .iter()
+            .any(|r| r.reward_type == RewardType::AiVideoGeneration);
+
+        let has_pending_referral_reward = missions
+            .pending_rewards
+            .iter()
+            .any(|r| r.reward_type == RewardType::Referral);
+
+        MissionProgress {
+            login_streak: LoginStreakProgress {
+                current_day: missions.login_streak.current_streak,
+                target_day: 7, // LOGIN_STREAK_TARGET
+                can_claim: has_pending_login_reward,
+                reward_amount: 5,        // DAILY_LOGIN_REWARD
+                next_reset_in_hours: 24, // Simplified for tests
+            },
+            game_progress: GameProgress {
+                current_count: missions.game_streak.games_played_today,
+                target_count: missions.game_streak.target_games,
+                can_claim: has_pending_game_reward
+                    || (!missions.game_streak.claimed_today
+                        && missions.game_streak.games_played_today
+                            >= missions.game_streak.target_games),
+                reward_amount: 10,   // GAME_COMPLETION_REWARD
+                hours_remaining: 24, // Simplified for tests
+            },
+            ai_video_progress: AiVideoProgress {
+                current_count: missions.ai_video_count.videos_generated_total,
+                target_count: missions.ai_video_count.target_videos,
+                can_claim: has_pending_ai_reward
+                    || (!missions.ai_video_count.reward_claimed
+                        && missions.ai_video_count.completed),
+                reward_amount: 30, // AI_VIDEO_GENERATION_REWARD
+                completed: missions.ai_video_count.completed,
+            },
+            referral_progress: ReferralProgress {
+                current_count: missions.referral_count.referrals_made_total,
+                target_count: missions.referral_count.target_referrals,
+                can_claim: has_pending_referral_reward
+                    || (!missions.referral_count.reward_claimed
+                        && missions.referral_count.completed),
+                reward_amount: 15, // REFERRAL_REWARD
+                completed: missions.referral_count.completed,
+            },
+            pending_rewards: missions.pending_rewards.clone(),
+        }
+    }
 
     pub fn get_mission_progress(
         pic: &PocketIc,
         canister_id: Principal,
         sender: Principal,
     ) -> MissionProgress {
-        let res = pic
-            .query_call(
-                canister_id,
-                sender,
-                "get_current_mission_progress",
-                encode_one(()).unwrap(),
-            )
-            .unwrap();
-
-        match res {
-            WasmResult::Reply(bytes) => decode_one(&bytes).unwrap(),
-            WasmResult::Reject(reason) => panic!("Query call rejected: {reason}"),
-        }
+        let missions = get_user_missions(pic, canister_id, sender);
+        convert_user_missions_to_progress(&missions)
     }
 
     pub fn get_user_missions(
@@ -211,13 +265,16 @@ mod helper {
             .query_call(
                 canister_id,
                 sender,
-                "get_current_missions",
-                encode_one(()).unwrap(),
+                "get_user_daily_missions",
+                encode_one(None::<Principal>).unwrap(),
             )
             .unwrap();
 
         match res {
-            WasmResult::Reply(bytes) => decode_one(&bytes).unwrap(),
+            WasmResult::Reply(bytes) => {
+                let result: Result<UserDailyMissions, String> = decode_one(&bytes).unwrap();
+                result.unwrap()
+            }
             WasmResult::Reject(reason) => panic!("Query call rejected: {reason}"),
         }
     }
@@ -285,13 +342,16 @@ mod helper {
             .query_call(
                 canister_id,
                 sender,
-                "get_user_missions_for_principal",
-                encode_one(target_principal).unwrap(),
+                "get_user_daily_missions",
+                encode_one(Some(target_principal)).unwrap(),
             )
             .unwrap();
 
         match res {
-            WasmResult::Reply(bytes) => decode_one(&bytes).unwrap(),
+            WasmResult::Reply(bytes) => {
+                let result: Result<UserDailyMissions, String> = decode_one(&bytes).unwrap();
+                result.unwrap()
+            }
             WasmResult::Reject(reason) => panic!("Query user missions call rejected: {reason}"),
         }
     }

--- a/src/lib/integration_tests/tests/daily_missions/main.rs
+++ b/src/lib/integration_tests/tests/daily_missions/main.rs
@@ -1,0 +1,957 @@
+use candid::{decode_one, encode_one, Principal};
+use pocket_ic::{PocketIc, WasmResult};
+use test_utils::setup::{
+    env::pocket_ic_env::{
+        get_new_pocket_ic_env_with_service_canisters_provisioned, ServiceCanisters,
+    },
+    test_constants::{
+        get_global_super_admin_principal_id, get_mock_user_alice_principal_id,
+        get_mock_user_bob_principal_id, get_mock_user_charlie_principal_id,
+    },
+};
+
+// Re-define types from the daily missions canister for testing
+#[derive(candid::CandidType, serde::Deserialize, Clone, Debug)]
+pub struct UpdateMissionRequest {
+    pub mission_type: MissionType,
+    pub data: MissionUpdateData,
+}
+
+#[derive(candid::CandidType, serde::Deserialize, Clone, Debug)]
+pub enum MissionType {
+    LoginStreak,
+    PlayGames,
+    GenerateAiVideos,
+    Referrals,
+}
+
+#[derive(candid::CandidType, serde::Deserialize, Clone, Debug)]
+pub enum MissionUpdateData {
+    LoginEvent,
+    GamePlayed { game_id: String },
+    AiVideoGenerated { video_id: String },
+    ReferralMade { referred_user: Principal },
+}
+
+#[derive(candid::CandidType, serde::Deserialize, Clone, Debug)]
+pub struct ClaimRewardRequest {
+    pub reward_id: String,
+}
+
+#[derive(candid::CandidType, serde::Deserialize, Clone, Debug)]
+pub struct ClaimRewardResponse {
+    pub success: bool,
+    pub message: String,
+    pub reward_amount: Option<u64>,
+    pub claimed_reward: Option<ClaimedReward>,
+}
+
+#[derive(candid::CandidType, serde::Deserialize, Clone, Debug)]
+pub struct MissionUpdateResult {
+    pub success: bool,
+    pub message: String,
+    pub new_progress: Option<MissionProgress>,
+    pub reward_earned: Option<ClaimedReward>,
+}
+
+#[derive(candid::CandidType, serde::Deserialize, Clone, Debug)]
+pub struct MissionProgress {
+    pub login_streak: LoginStreakProgress,
+    pub game_progress: GameProgress,
+    pub ai_video_progress: AiVideoProgress,
+    pub referral_progress: ReferralProgress,
+    pub pending_rewards: Vec<PendingReward>,
+}
+
+#[derive(candid::CandidType, serde::Deserialize, Clone, Debug)]
+pub struct LoginStreakProgress {
+    pub current_day: u32,
+    pub target_day: u32,
+    pub can_claim: bool,
+    pub reward_amount: u64,
+    pub next_reset_in_hours: u32,
+}
+
+#[derive(candid::CandidType, serde::Deserialize, Clone, Debug)]
+pub struct GameProgress {
+    pub current_count: u32,
+    pub target_count: u32,
+    pub can_claim: bool,
+    pub reward_amount: u64,
+    pub hours_remaining: u32,
+}
+
+#[derive(candid::CandidType, serde::Deserialize, Clone, Debug)]
+pub struct AiVideoProgress {
+    pub current_count: u32,
+    pub target_count: u32,
+    pub can_claim: bool,
+    pub reward_amount: u64,
+    pub completed: bool,
+}
+
+#[derive(candid::CandidType, serde::Deserialize, Clone, Debug)]
+pub struct ReferralProgress {
+    pub current_count: u32,
+    pub target_count: u32,
+    pub can_claim: bool,
+    pub reward_amount: u64,
+    pub completed: bool,
+}
+
+#[derive(candid::CandidType, serde::Deserialize, Clone, Debug)]
+pub struct PendingReward {
+    pub id: String,
+    pub reward_type: RewardType,
+    pub amount: u64,
+    pub earned_at: std::time::SystemTime,
+    pub mission_day: u32,
+}
+
+#[derive(candid::CandidType, serde::Deserialize, Clone, Debug, PartialEq)]
+pub enum RewardType {
+    LoginStreak,
+    GameCompletion,
+    AiVideoGeneration,
+    Referral,
+}
+
+#[derive(candid::CandidType, serde::Deserialize, Clone, Debug, PartialEq)]
+pub struct ClaimedReward {
+    pub reward_type: RewardType,
+    pub amount: u64,
+    pub claimed_at: std::time::SystemTime,
+    pub day: u32,
+}
+
+// Re-define UserDailyMissions for testing
+#[derive(candid::CandidType, serde::Deserialize, Clone, Debug)]
+pub struct UserDailyMissions {
+    pub login_streak: LoginStreak,
+    pub game_streak: GameStreak,
+    pub ai_video_count: GenerateAiVideoCount,
+    pub referral_count: ReferralCount,
+    pub last_updated: std::time::SystemTime,
+    pub pending_rewards: Vec<PendingReward>,
+}
+
+#[derive(candid::CandidType, serde::Deserialize, Clone, Debug)]
+pub struct LoginStreak {
+    pub current_streak: u32,
+    pub max_streak: u32,
+    pub last_login_date: Option<std::time::SystemTime>,
+    pub streak_start_date: Option<std::time::SystemTime>,
+    pub claimed_rewards: Vec<ClaimedReward>,
+    pub can_claim_today: bool,
+}
+
+#[derive(candid::CandidType, serde::Deserialize, Clone, Debug)]
+pub struct GameStreak {
+    pub games_played_today: u32,
+    pub target_games: u32,
+    pub last_reset_date: Option<std::time::SystemTime>,
+    pub claimed_today: bool,
+    pub total_games_completed: u32,
+}
+
+#[derive(candid::CandidType, serde::Deserialize, Clone, Debug)]
+pub struct GenerateAiVideoCount {
+    pub videos_generated_total: u32,
+    pub target_videos: u32,
+    pub completed: bool,
+    pub reward_claimed: bool,
+    pub total_videos_generated: u32,
+}
+
+#[derive(candid::CandidType, serde::Deserialize, Clone, Debug)]
+pub struct ReferralCount {
+    pub referrals_made_total: u32,
+    pub target_referrals: u32,
+    pub completed: bool,
+    pub reward_claimed: bool,
+    pub total_referrals_made: u32,
+    pub referred_users: Vec<ReferredUser>,
+}
+
+#[derive(candid::CandidType, serde::Deserialize, Clone, Debug)]
+pub struct ReferredUser {
+    pub principal_id: Principal,
+    pub referred_at: std::time::SystemTime,
+    pub is_active: bool,
+}
+
+mod helper {
+    use super::*;
+
+    pub fn get_mission_progress(
+        pic: &PocketIc,
+        canister_id: Principal,
+        sender: Principal,
+    ) -> MissionProgress {
+        let res = pic
+            .query_call(
+                canister_id,
+                sender,
+                "get_current_mission_progress",
+                encode_one(()).unwrap(),
+            )
+            .unwrap();
+
+        match res {
+            WasmResult::Reply(bytes) => decode_one(&bytes).unwrap(),
+            WasmResult::Reject(reason) => panic!("Query call rejected: {reason}"),
+        }
+    }
+
+    pub fn get_user_missions(
+        pic: &PocketIc,
+        canister_id: Principal,
+        sender: Principal,
+    ) -> UserDailyMissions {
+        let res = pic
+            .query_call(
+                canister_id,
+                sender,
+                "get_current_missions",
+                encode_one(()).unwrap(),
+            )
+            .unwrap();
+
+        match res {
+            WasmResult::Reply(bytes) => decode_one(&bytes).unwrap(),
+            WasmResult::Reject(reason) => panic!("Query call rejected: {reason}"),
+        }
+    }
+
+    pub fn update_mission(
+        pic: &PocketIc,
+        canister_id: Principal,
+        sender: Principal,
+        request: UpdateMissionRequest,
+    ) -> MissionUpdateResult {
+        let res = pic
+            .update_call(
+                canister_id,
+                sender,
+                "update_mission",
+                encode_one(request).unwrap(),
+            )
+            .unwrap();
+
+        match res {
+            WasmResult::Reply(bytes) => decode_one(&bytes).unwrap(),
+            WasmResult::Reject(reason) => panic!("Update call rejected: {reason}"),
+        }
+    }
+
+    pub fn claim_reward(
+        pic: &PocketIc,
+        canister_id: Principal,
+        sender: Principal,
+        reward_id: String,
+    ) -> ClaimRewardResponse {
+        let res = pic
+            .update_call(
+                canister_id,
+                sender,
+                "claim_reward",
+                encode_one(ClaimRewardRequest { reward_id }).unwrap(),
+            )
+            .unwrap();
+
+        match res {
+            WasmResult::Reply(bytes) => decode_one(&bytes).unwrap(),
+            WasmResult::Reject(reason) => panic!("Claim reward call rejected: {reason}"),
+        }
+    }
+
+    pub fn get_version(pic: &PocketIc, canister_id: Principal, sender: Principal) -> String {
+        let res = pic
+            .query_call(canister_id, sender, "get_version", encode_one(()).unwrap())
+            .unwrap();
+
+        match res {
+            WasmResult::Reply(bytes) => decode_one(&bytes).unwrap(),
+            WasmResult::Reject(reason) => panic!("Get version call rejected: {reason}"),
+        }
+    }
+
+    pub fn get_user_missions_for_principal(
+        pic: &PocketIc,
+        canister_id: Principal,
+        sender: Principal,
+        target_principal: Principal,
+    ) -> UserDailyMissions {
+        let res = pic
+            .query_call(
+                canister_id,
+                sender,
+                "get_user_missions_for_principal",
+                encode_one(target_principal).unwrap(),
+            )
+            .unwrap();
+
+        match res {
+            WasmResult::Reply(bytes) => decode_one(&bytes).unwrap(),
+            WasmResult::Reject(reason) => panic!("Query user missions call rejected: {reason}"),
+        }
+    }
+}
+
+#[test]
+fn test_daily_missions_canister_version() {
+    let (
+        pic,
+        ServiceCanisters {
+            daily_missions_canister_id: canister_id,
+            ..
+        },
+    ) = get_new_pocket_ic_env_with_service_canisters_provisioned();
+
+    let sender = get_global_super_admin_principal_id();
+    let version = helper::get_version(&pic, canister_id, sender);
+
+    assert_eq!(version, "v1.0.0");
+}
+
+#[test]
+fn test_initial_mission_progress() {
+    let (
+        pic,
+        ServiceCanisters {
+            daily_missions_canister_id: canister_id,
+            ..
+        },
+    ) = get_new_pocket_ic_env_with_service_canisters_provisioned();
+
+    let alice = get_mock_user_alice_principal_id();
+    let progress = helper::get_mission_progress(&pic, canister_id, alice);
+
+    // Initial progress should have default values
+    assert_eq!(progress.login_streak.current_day, 0);
+    assert_eq!(progress.game_progress.current_count, 0);
+    assert_eq!(progress.ai_video_progress.current_count, 0);
+    assert_eq!(progress.referral_progress.current_count, 0);
+    assert!(progress.pending_rewards.is_empty());
+}
+
+#[test]
+fn test_login_streak_mission_progression() {
+    let (
+        pic,
+        ServiceCanisters {
+            daily_missions_canister_id: canister_id,
+            ..
+        },
+    ) = get_new_pocket_ic_env_with_service_canisters_provisioned();
+
+    let alice = get_mock_user_alice_principal_id();
+
+    // Update login mission
+    let login_request = UpdateMissionRequest {
+        mission_type: MissionType::LoginStreak,
+        data: MissionUpdateData::LoginEvent,
+    };
+
+    let result = helper::update_mission(&pic, canister_id, alice, login_request);
+    assert!(result.success);
+    assert!(result.message.contains("Login streak updated"));
+
+    // Check progress after login
+    let progress = helper::get_mission_progress(&pic, canister_id, alice);
+    assert_eq!(progress.login_streak.current_day, 1);
+
+    // Login multiple times to reach target
+    for day in 2..=7 {
+        let login_request = UpdateMissionRequest {
+            mission_type: MissionType::LoginStreak,
+            data: MissionUpdateData::LoginEvent,
+        };
+
+        let result = helper::update_mission(&pic, canister_id, alice, login_request);
+        assert!(result.success);
+
+        let progress = helper::get_mission_progress(&pic, canister_id, alice);
+        assert_eq!(progress.login_streak.current_day, day);
+
+        if day >= progress.login_streak.target_day {
+            assert!(progress.login_streak.can_claim || !progress.pending_rewards.is_empty());
+        }
+    }
+}
+
+#[test]
+fn test_game_mission_progression() {
+    let (
+        pic,
+        ServiceCanisters {
+            daily_missions_canister_id: canister_id,
+            ..
+        },
+    ) = get_new_pocket_ic_env_with_service_canisters_provisioned();
+
+    let alice = get_mock_user_alice_principal_id();
+
+    // Play games to meet target
+    for game_num in 1..=5 {
+        let game_request = UpdateMissionRequest {
+            mission_type: MissionType::PlayGames,
+            data: MissionUpdateData::GamePlayed {
+                game_id: format!("game_{}", game_num),
+            },
+        };
+
+        let result = helper::update_mission(&pic, canister_id, alice, game_request);
+        assert!(result.success);
+
+        let progress = helper::get_mission_progress(&pic, canister_id, alice);
+        assert_eq!(progress.game_progress.current_count, game_num);
+    }
+
+    let final_progress = helper::get_mission_progress(&pic, canister_id, alice);
+
+    // Should have completed the target and have a pending reward or be able to claim
+    if final_progress.game_progress.current_count >= final_progress.game_progress.target_count {
+        assert!(
+            final_progress.game_progress.can_claim || !final_progress.pending_rewards.is_empty()
+        );
+    }
+}
+
+#[test]
+fn test_ai_video_generation_mission() {
+    let (
+        pic,
+        ServiceCanisters {
+            daily_missions_canister_id: canister_id,
+            ..
+        },
+    ) = get_new_pocket_ic_env_with_service_canisters_provisioned();
+
+    let alice = get_mock_user_alice_principal_id();
+    let initial_progress = helper::get_mission_progress(&pic, canister_id, alice);
+    let target_videos = initial_progress.ai_video_progress.target_count;
+
+    // Generate AI videos to meet target
+    for video_num in 1..=target_videos {
+        let video_request = UpdateMissionRequest {
+            mission_type: MissionType::GenerateAiVideos,
+            data: MissionUpdateData::AiVideoGenerated {
+                video_id: format!("video_{}", video_num),
+            },
+        };
+
+        let result = helper::update_mission(&pic, canister_id, alice, video_request);
+        assert!(result.success);
+
+        let progress = helper::get_mission_progress(&pic, canister_id, alice);
+        assert_eq!(progress.ai_video_progress.current_count, video_num);
+    }
+
+    let final_progress = helper::get_mission_progress(&pic, canister_id, alice);
+    assert!(final_progress.ai_video_progress.completed);
+    assert!(
+        final_progress.ai_video_progress.can_claim || !final_progress.pending_rewards.is_empty()
+    );
+}
+
+#[test]
+fn test_referral_mission_progression() {
+    let (
+        pic,
+        ServiceCanisters {
+            daily_missions_canister_id: canister_id,
+            ..
+        },
+    ) = get_new_pocket_ic_env_with_service_canisters_provisioned();
+
+    let alice = get_mock_user_alice_principal_id();
+    let bob = get_mock_user_bob_principal_id();
+    let charlie = get_mock_user_charlie_principal_id();
+
+    let initial_progress = helper::get_mission_progress(&pic, canister_id, alice);
+    let target_referrals = initial_progress.referral_progress.target_count;
+
+    let referred_users = vec![bob, charlie];
+
+    // Make referrals up to target
+    for (index, &referred_user) in referred_users.iter().enumerate() {
+        if (index + 1) as u32 > target_referrals {
+            break;
+        }
+
+        let referral_request = UpdateMissionRequest {
+            mission_type: MissionType::Referrals,
+            data: MissionUpdateData::ReferralMade { referred_user },
+        };
+
+        let result = helper::update_mission(&pic, canister_id, alice, referral_request);
+        assert!(result.success);
+
+        let progress = helper::get_mission_progress(&pic, canister_id, alice);
+        assert_eq!(progress.referral_progress.current_count, (index + 1) as u32);
+    }
+
+    let final_progress = helper::get_mission_progress(&pic, canister_id, alice);
+    if final_progress.referral_progress.current_count >= target_referrals {
+        assert!(final_progress.referral_progress.completed);
+        assert!(
+            final_progress.referral_progress.can_claim
+                || !final_progress.pending_rewards.is_empty()
+        );
+    }
+}
+
+#[test]
+fn test_reward_claiming_flow() {
+    let (
+        pic,
+        ServiceCanisters {
+            daily_missions_canister_id: canister_id,
+            ..
+        },
+    ) = get_new_pocket_ic_env_with_service_canisters_provisioned();
+
+    let alice = get_mock_user_alice_principal_id();
+
+    // Complete a mission to generate a reward
+    let initial_progress = helper::get_mission_progress(&pic, canister_id, alice);
+    let target_videos = initial_progress.ai_video_progress.target_count;
+
+    for video_num in 1..=target_videos {
+        let video_request = UpdateMissionRequest {
+            mission_type: MissionType::GenerateAiVideos,
+            data: MissionUpdateData::AiVideoGenerated {
+                video_id: format!("video_{}", video_num),
+            },
+        };
+        helper::update_mission(&pic, canister_id, alice, video_request);
+    }
+
+    let progress_after_completion = helper::get_mission_progress(&pic, canister_id, alice);
+
+    // Should have pending rewards
+    assert!(!progress_after_completion.pending_rewards.is_empty());
+
+    let pending_reward = &progress_after_completion.pending_rewards[0];
+    let reward_id = pending_reward.id.clone();
+    let expected_amount = pending_reward.amount;
+
+    // Claim the reward
+    let claim_response = helper::claim_reward(&pic, canister_id, alice, reward_id);
+
+    assert!(claim_response.success);
+    assert_eq!(claim_response.reward_amount, Some(expected_amount));
+    assert!(claim_response.claimed_reward.is_some());
+
+    // Verify reward is no longer pending
+    let progress_after_claim = helper::get_mission_progress(&pic, canister_id, alice);
+    assert!(progress_after_claim.pending_rewards.is_empty());
+}
+
+#[test]
+fn test_invalid_reward_claim() {
+    let (
+        pic,
+        ServiceCanisters {
+            daily_missions_canister_id: canister_id,
+            ..
+        },
+    ) = get_new_pocket_ic_env_with_service_canisters_provisioned();
+
+    let alice = get_mock_user_alice_principal_id();
+
+    // Try to claim a non-existent reward
+    let claim_response =
+        helper::claim_reward(&pic, canister_id, alice, "invalid_reward_id".to_string());
+
+    assert!(!claim_response.success);
+    assert!(
+        claim_response.message.contains("not found")
+            || claim_response.message.contains("already claimed")
+    );
+    assert_eq!(claim_response.reward_amount, None);
+    assert_eq!(claim_response.claimed_reward, None);
+}
+
+#[test]
+fn test_invalid_mission_update_data() {
+    let (
+        pic,
+        ServiceCanisters {
+            daily_missions_canister_id: canister_id,
+            ..
+        },
+    ) = get_new_pocket_ic_env_with_service_canisters_provisioned();
+
+    let alice = get_mock_user_alice_principal_id();
+
+    // Try to send game data for login streak mission (should fail)
+    let invalid_request = UpdateMissionRequest {
+        mission_type: MissionType::LoginStreak,
+        data: MissionUpdateData::GamePlayed {
+            game_id: "game_123".to_string(),
+        },
+    };
+
+    let result = helper::update_mission(&pic, canister_id, alice, invalid_request);
+    assert!(!result.success);
+    assert!(result.message.contains("Invalid data"));
+}
+
+#[test]
+fn test_multiple_users_independence() {
+    let (
+        pic,
+        ServiceCanisters {
+            daily_missions_canister_id: canister_id,
+            ..
+        },
+    ) = get_new_pocket_ic_env_with_service_canisters_provisioned();
+
+    let alice = get_mock_user_alice_principal_id();
+    let bob = get_mock_user_bob_principal_id();
+
+    // Alice completes some missions
+    let alice_login_request = UpdateMissionRequest {
+        mission_type: MissionType::LoginStreak,
+        data: MissionUpdateData::LoginEvent,
+    };
+    helper::update_mission(&pic, canister_id, alice, alice_login_request);
+
+    // Bob completes different missions
+    let bob_game_request = UpdateMissionRequest {
+        mission_type: MissionType::PlayGames,
+        data: MissionUpdateData::GamePlayed {
+            game_id: "bob_game_1".to_string(),
+        },
+    };
+    helper::update_mission(&pic, canister_id, bob, bob_game_request);
+
+    // Check that their progress is independent
+    let alice_progress = helper::get_mission_progress(&pic, canister_id, alice);
+    let bob_progress = helper::get_mission_progress(&pic, canister_id, bob);
+
+    assert_eq!(alice_progress.login_streak.current_day, 1);
+    assert_eq!(alice_progress.game_progress.current_count, 0);
+
+    assert_eq!(bob_progress.login_streak.current_day, 0);
+    assert_eq!(bob_progress.game_progress.current_count, 1);
+}
+
+#[test]
+fn test_mission_progress_persistence() {
+    let (
+        pic,
+        ServiceCanisters {
+            daily_missions_canister_id: canister_id,
+            ..
+        },
+    ) = get_new_pocket_ic_env_with_service_canisters_provisioned();
+
+    let alice = get_mock_user_alice_principal_id();
+
+    // Complete multiple missions
+    let login_request = UpdateMissionRequest {
+        mission_type: MissionType::LoginStreak,
+        data: MissionUpdateData::LoginEvent,
+    };
+    helper::update_mission(&pic, canister_id, alice, login_request);
+
+    let game_request = UpdateMissionRequest {
+        mission_type: MissionType::PlayGames,
+        data: MissionUpdateData::GamePlayed {
+            game_id: "persistent_game".to_string(),
+        },
+    };
+    helper::update_mission(&pic, canister_id, alice, game_request);
+
+    // Check progress persists across multiple queries
+    let progress1 = helper::get_mission_progress(&pic, canister_id, alice);
+    let progress2 = helper::get_mission_progress(&pic, canister_id, alice);
+
+    assert_eq!(
+        progress1.login_streak.current_day,
+        progress2.login_streak.current_day
+    );
+    assert_eq!(
+        progress1.game_progress.current_count,
+        progress2.game_progress.current_count
+    );
+    assert_eq!(progress1.login_streak.current_day, 1);
+    assert_eq!(progress1.game_progress.current_count, 1);
+}
+
+#[test]
+fn test_cross_mission_completion() {
+    let (
+        pic,
+        ServiceCanisters {
+            daily_missions_canister_id: canister_id,
+            ..
+        },
+    ) = get_new_pocket_ic_env_with_service_canisters_provisioned();
+
+    let alice = get_mock_user_alice_principal_id();
+    let bob = get_mock_user_bob_principal_id();
+
+    // Alice completes all mission types in sequence
+    let login_request = UpdateMissionRequest {
+        mission_type: MissionType::LoginStreak,
+        data: MissionUpdateData::LoginEvent,
+    };
+    let game_request = UpdateMissionRequest {
+        mission_type: MissionType::PlayGames,
+        data: MissionUpdateData::GamePlayed {
+            game_id: "cross_mission_game".to_string(),
+        },
+    };
+    let video_request = UpdateMissionRequest {
+        mission_type: MissionType::GenerateAiVideos,
+        data: MissionUpdateData::AiVideoGenerated {
+            video_id: "cross_mission_video".to_string(),
+        },
+    };
+    let referral_request = UpdateMissionRequest {
+        mission_type: MissionType::Referrals,
+        data: MissionUpdateData::ReferralMade { referred_user: bob },
+    };
+
+    // Execute all mission types
+    let login_result = helper::update_mission(&pic, canister_id, alice, login_request);
+    let game_result = helper::update_mission(&pic, canister_id, alice, game_request);
+    let video_result = helper::update_mission(&pic, canister_id, alice, video_request);
+    let referral_result = helper::update_mission(&pic, canister_id, alice, referral_request);
+
+    // All should succeed
+    assert!(login_result.success);
+    assert!(game_result.success);
+    assert!(video_result.success);
+    assert!(referral_result.success);
+
+    // Final progress should reflect all completions
+    let final_progress = helper::get_mission_progress(&pic, canister_id, alice);
+    assert_eq!(final_progress.login_streak.current_day, 1);
+    assert_eq!(final_progress.game_progress.current_count, 1);
+    assert_eq!(final_progress.ai_video_progress.current_count, 1);
+    assert_eq!(final_progress.referral_progress.current_count, 1);
+}
+
+#[test]
+fn test_admin_can_query_any_user_missions() {
+    let (
+        pic,
+        ServiceCanisters {
+            daily_missions_canister_id: canister_id,
+            ..
+        },
+    ) = get_new_pocket_ic_env_with_service_canisters_provisioned();
+
+    let admin = get_global_super_admin_principal_id();
+    let alice = get_mock_user_alice_principal_id();
+
+    // Alice completes some missions
+    let alice_login_request = UpdateMissionRequest {
+        mission_type: MissionType::LoginStreak,
+        data: MissionUpdateData::LoginEvent,
+    };
+    helper::update_mission(&pic, canister_id, alice, alice_login_request);
+
+    // Admin queries Alice's missions
+    let alice_missions = helper::get_user_missions_for_principal(&pic, canister_id, admin, alice);
+
+    assert_eq!(alice_missions.login_streak.current_streak, 1);
+    assert!(alice_missions.login_streak.last_login_date.is_some());
+}
+
+#[test]
+fn test_double_claim_prevention() {
+    let (
+        pic,
+        ServiceCanisters {
+            daily_missions_canister_id: canister_id,
+            ..
+        },
+    ) = get_new_pocket_ic_env_with_service_canisters_provisioned();
+
+    let alice = get_mock_user_alice_principal_id();
+
+    // Complete AI video mission to generate reward
+    let initial_progress = helper::get_mission_progress(&pic, canister_id, alice);
+    let target_videos = initial_progress.ai_video_progress.target_count;
+
+    for video_num in 1..=target_videos {
+        let video_request = UpdateMissionRequest {
+            mission_type: MissionType::GenerateAiVideos,
+            data: MissionUpdateData::AiVideoGenerated {
+                video_id: format!("video_{}", video_num),
+            },
+        };
+        helper::update_mission(&pic, canister_id, alice, video_request);
+    }
+
+    let progress_with_reward = helper::get_mission_progress(&pic, canister_id, alice);
+    assert!(!progress_with_reward.pending_rewards.is_empty());
+
+    let reward_id = progress_with_reward.pending_rewards[0].id.clone();
+
+    // Claim the reward successfully
+    let first_claim = helper::claim_reward(&pic, canister_id, alice, reward_id.clone());
+    assert!(first_claim.success);
+    assert!(first_claim.reward_amount.is_some());
+
+    // Try to claim the same reward again - should fail
+    let second_claim = helper::claim_reward(&pic, canister_id, alice, reward_id);
+    assert!(!second_claim.success);
+    assert!(
+        second_claim.message.contains("not found")
+            || second_claim.message.contains("already claimed")
+    );
+    assert_eq!(second_claim.reward_amount, None);
+}
+
+#[test]
+fn test_mission_reward_amounts() {
+    let (
+        pic,
+        ServiceCanisters {
+            daily_missions_canister_id: canister_id,
+            ..
+        },
+    ) = get_new_pocket_ic_env_with_service_canisters_provisioned();
+
+    let alice = get_mock_user_alice_principal_id();
+
+    // Test AI video generation reward
+    let initial_progress = helper::get_mission_progress(&pic, canister_id, alice);
+    let target_videos = initial_progress.ai_video_progress.target_count;
+    let expected_video_reward = initial_progress.ai_video_progress.reward_amount;
+
+    for video_num in 1..=target_videos {
+        let video_request = UpdateMissionRequest {
+            mission_type: MissionType::GenerateAiVideos,
+            data: MissionUpdateData::AiVideoGenerated {
+                video_id: format!("reward_test_video_{}", video_num),
+            },
+        };
+        helper::update_mission(&pic, canister_id, alice, video_request);
+    }
+
+    let progress_after_videos = helper::get_mission_progress(&pic, canister_id, alice);
+    assert!(!progress_after_videos.pending_rewards.is_empty());
+
+    let pending_reward = &progress_after_videos.pending_rewards[0];
+    assert_eq!(pending_reward.amount, expected_video_reward);
+
+    // Claim and verify the amount
+    let claim_response = helper::claim_reward(&pic, canister_id, alice, pending_reward.id.clone());
+    assert!(claim_response.success);
+    assert_eq!(claim_response.reward_amount, Some(expected_video_reward));
+}
+
+#[test]
+fn test_referral_with_multiple_users() {
+    let (
+        pic,
+        ServiceCanisters {
+            daily_missions_canister_id: canister_id,
+            ..
+        },
+    ) = get_new_pocket_ic_env_with_service_canisters_provisioned();
+
+    let alice = get_mock_user_alice_principal_id();
+    let bob = get_mock_user_bob_principal_id();
+    let charlie = get_mock_user_charlie_principal_id();
+
+    // Alice refers both Bob and Charlie
+    let referral_bob = UpdateMissionRequest {
+        mission_type: MissionType::Referrals,
+        data: MissionUpdateData::ReferralMade { referred_user: bob },
+    };
+
+    let referral_charlie = UpdateMissionRequest {
+        mission_type: MissionType::Referrals,
+        data: MissionUpdateData::ReferralMade {
+            referred_user: charlie,
+        },
+    };
+
+    helper::update_mission(&pic, canister_id, alice, referral_bob);
+    helper::update_mission(&pic, canister_id, alice, referral_charlie);
+
+    let alice_progress = helper::get_mission_progress(&pic, canister_id, alice);
+    assert_eq!(alice_progress.referral_progress.current_count, 2);
+
+    // Verify that Bob and Charlie still have clean states
+    let bob_progress = helper::get_mission_progress(&pic, canister_id, bob);
+    let charlie_progress = helper::get_mission_progress(&pic, canister_id, charlie);
+
+    assert_eq!(bob_progress.referral_progress.current_count, 0);
+    assert_eq!(charlie_progress.referral_progress.current_count, 0);
+}
+
+#[test]
+fn test_mission_target_values() {
+    let (
+        pic,
+        ServiceCanisters {
+            daily_missions_canister_id: canister_id,
+            ..
+        },
+    ) = get_new_pocket_ic_env_with_service_canisters_provisioned();
+
+    let alice = get_mock_user_alice_principal_id();
+    let progress = helper::get_mission_progress(&pic, canister_id, alice);
+
+    // Verify target values match expected defaults
+    assert_eq!(progress.login_streak.target_day, 7); // LOGIN_STREAK_TARGET
+    assert_eq!(progress.game_progress.target_count, 10); // GAME_TARGET
+    assert_eq!(progress.ai_video_progress.target_count, 3); // AI_VIDEO_TARGET
+    assert_eq!(progress.referral_progress.target_count, 3); // REFERRAL_TARGET
+
+    // Verify reward amounts are as expected (these should match constants from the canister)
+    assert!(progress.login_streak.reward_amount > 0);
+    assert!(progress.game_progress.reward_amount > 0);
+    assert!(progress.ai_video_progress.reward_amount > 0);
+    assert!(progress.referral_progress.reward_amount > 0);
+}
+
+#[test]
+fn test_mission_state_after_exceeding_targets() {
+    let (
+        pic,
+        ServiceCanisters {
+            daily_missions_canister_id: canister_id,
+            ..
+        },
+    ) = get_new_pocket_ic_env_with_service_canisters_provisioned();
+
+    let alice = get_mock_user_alice_principal_id();
+    let initial_progress = helper::get_mission_progress(&pic, canister_id, alice);
+    let target_videos = initial_progress.ai_video_progress.target_count;
+
+    // Generate more videos than the target
+    for video_num in 1..=(target_videos + 2) {
+        let video_request = UpdateMissionRequest {
+            mission_type: MissionType::GenerateAiVideos,
+            data: MissionUpdateData::AiVideoGenerated {
+                video_id: format!("exceed_target_video_{}", video_num),
+            },
+        };
+        helper::update_mission(&pic, canister_id, alice, video_request);
+    }
+
+    let final_progress = helper::get_mission_progress(&pic, canister_id, alice);
+
+    // Should be completed and have current count exceeding target
+    assert!(final_progress.ai_video_progress.completed);
+    assert_eq!(
+        final_progress.ai_video_progress.current_count,
+        target_videos + 2
+    );
+
+    // Should still be able to claim reward or have pending reward
+    assert!(
+        final_progress.ai_video_progress.can_claim || !final_progress.pending_rewards.is_empty()
+    );
+}

--- a/src/lib/integration_tests/tests/daily_missions/main.rs
+++ b/src/lib/integration_tests/tests/daily_missions/main.rs
@@ -142,7 +142,6 @@ pub struct LoginStreak {
     pub last_login_date: Option<std::time::SystemTime>,
     pub streak_start_date: Option<std::time::SystemTime>,
     pub claimed_rewards: Vec<ClaimedReward>,
-    pub can_claim_today: bool,
 }
 
 #[derive(candid::CandidType, serde::Deserialize, Clone, Debug)]

--- a/src/lib/test_utils/src/setup/env/pocket_ic_env.rs
+++ b/src/lib/test_utils/src/setup/env/pocket_ic_env.rs
@@ -54,6 +54,7 @@ pub struct ServiceCanisters {
     pub user_post_service_canister_id: Principal,
     pub dedup_index_canister_id: Principal,
     pub rate_limits_canister_id: Principal,
+    pub daily_missions_canister_id: Principal,
 }
 
 pub fn get_new_pocket_ic_env_with_service_canisters_provisioned() -> (PocketIc, ServiceCanisters) {
@@ -105,11 +106,20 @@ pub fn get_new_pocket_ic_env_with_service_canisters_provisioned() -> (PocketIc, 
         }),
     );
 
+    let daily_missions_canister = pocket_ic.create_canister_with_settings(
+        Some(super_admin),
+        Some(CanisterSettings {
+            controllers: Some(vec![super_admin]),
+            ..Default::default()
+        }),
+    );
+
     pocket_ic.add_cycles(user_service_canister, 10_000_000_000_000_000);
     pocket_ic.add_cycles(notification_store_canister, 10_000_000_000_000_000);
     pocket_ic.add_cycles(user_post_service_canister, 10_000_000_000_000_000);
     pocket_ic.add_cycles(dedup_index_canister, 10_000_000_000_000_000);
     pocket_ic.add_cycles(rate_limits_canister, 10_000_000_000_000_000);
+    pocket_ic.add_cycles(daily_missions_canister, 10_000_000_000_000_000);
 
     let user_info_service_canister_wasm = include_bytes!(
         "../../../../../../target/wasm32-unknown-unknown/release/user_info_service.wasm.gz"
@@ -129,6 +139,10 @@ pub fn get_new_pocket_ic_env_with_service_canisters_provisioned() -> (PocketIc, 
         "../../../../../../target/wasm32-unknown-unknown/release/user_post_service.wasm.gz"
     );
 
+    let daily_missions_canister_wasm = include_bytes!(
+        "../../../../../../target/wasm32-unknown-unknown/release/daily_missions.wasm.gz"
+    );
+
     let user_info_service_canister_init_args = UserInfoServiceInitArgs {
         version: "v1.0.0".into(),
     };
@@ -139,6 +153,17 @@ pub fn get_new_pocket_ic_env_with_service_canisters_provisioned() -> (PocketIc, 
 
     let user_post_service_canister_init_args = UserPostServiceInitArgs {
         version: "v1.0.0".into(),
+    };
+
+    #[derive(candid::CandidType)]
+    struct DailyMissionsInitArgs {
+        version: String,
+        known_principal_ids: Option<HashMap<String, Principal>>,
+    }
+
+    let daily_missions_canister_init_args = DailyMissionsInitArgs {
+        version: "v1.0.0".into(),
+        known_principal_ids: None,
     };
 
     pocket_ic.install_canister(
@@ -189,12 +214,20 @@ pub fn get_new_pocket_ic_env_with_service_canisters_provisioned() -> (PocketIc, 
         Some(super_admin),
     );
 
+    pocket_ic.install_canister(
+        daily_missions_canister,
+        daily_missions_canister_wasm.to_vec(),
+        candid::encode_one(daily_missions_canister_init_args).unwrap(),
+        Some(super_admin),
+    );
+
     let service_canisters = ServiceCanisters {
         user_info_service_canister_id: user_service_canister,
         notification_store_canister_id: notification_store_canister,
         user_post_service_canister_id: user_post_service_canister,
         dedup_index_canister_id: dedup_index_canister,
         rate_limits_canister_id: rate_limits_canister,
+        daily_missions_canister_id: daily_missions_canister,
     };
 
     (pocket_ic, service_canisters)


### PR DESCRIPTION
This PR adds support for Daily Missions Feature by adding a canister that will specifically track this for every user.

We are adding 3 query endpoints and 2 update endpoints, along with the canister data model.

The best explanation for this feature comes from the mweb designs, and while they have been depreciated, they show the functionality and expectation from this feature very well.

https://www.figma.com/design/Gpr4EKAaIchpiAIYfiJAec/YRAL-token---mweb?node-id=68-1339&m=dev .

The expectation is that apps will follow the same design and functionality as in these designs.

Mission Types & Reward Structure
- Login Streak: 5 YRAL tokens per 7-day streak completion
- Game Completion: 10 YRAL tokens for playing 10 games daily  
- AI Video Generation: 30 YRAL tokens for generating 3 AI videos (one-time)
- Referrals: 15 YRAL tokens for referring 3 users (one-time)

<img width="347" height="844" alt="Screenshot 2025-09-08 at 9 47 05 AM" src="https://github.com/user-attachments/assets/c8493f3f-8809-48cb-a8ce-1a1d5ac6ec9b" />

The canister data also creates and stores all the rewards that are meant to be dispersed. Clients will call a separate endpoint in off-chain (PR for that will be linked here soon) that will call the claim_reward endpoint to consume the reward from our state and commit the txn to users wallet. 
