### PR TITLE
avoid throwing errors on already registered session

### DIFF
--- a/src/canister/user_info_service/src/data_model/mod.rs
+++ b/src/canister/user_info_service/src/data_model/mod.rs
@@ -175,7 +175,12 @@ impl CanisterData {
                     self.user_infos.insert(user_principal, user_info);
                     Ok(())
                 }
-                _ => Err("Session type can only be updated from AnonymousSession".to_string()),
+                _ => {
+                    ic_cdk::println!(
+                        "Session type of user {user_principal} can only be updated from AnonymousSession"
+                    );
+                    Ok(())
+                }
             }
         } else {
             Err("User not found".to_string())

--- a/src/lib/integration_tests/tests/user_info_service/test_update_session_type_for_user_info_service.rs
+++ b/src/lib/integration_tests/tests/user_info_service/test_update_session_type_for_user_info_service.rs
@@ -112,11 +112,6 @@ fn test_update_session_type_for_user_info_service() {
     )
     .expect("Failed to call update_session_type for downgrade");
 
-    assert!(downgrade_result.is_err());
-    assert!(downgrade_result
-        .unwrap_err()
-        .contains("Session type can only be updated from AnonymousSession"));
-
     // Final verification - session type should still be RegisteredSession
     let final_session_type = query::<_, Result<SessionType, String>>(
         &pocket_ic,


### PR DESCRIPTION
## Changes
- avoid throwing errors on update registered session

## Impact 
- fixes https://github.com/dolr-ai/product-roadmap/issues/1332