### PR TITLE
feat: added notification approved event in the notification store

### DIFF
--- a/src/canister/notification_store/can.did
+++ b/src/canister/notification_store/can.did
@@ -11,6 +11,8 @@ type NotificationStoreError = variant {
 type NotificationStoreInitArgs = record { version : text };
 type NotificationType = variant {
   Liked : LikedPayload;
+  VideoApproved : VideoApprovalPayload;
+  VideoDisapproved : VideoApprovalPayload;
   VideoUpload : VideoUploadPayload;
 };
 type RejectionCode = variant {
@@ -27,6 +29,7 @@ type SystemTime = record {
   nanos_since_epoch : nat32;
   secs_since_epoch : nat64;
 };
+type VideoApprovalPayload = record { post_id : text; video_id : text };
 type VideoUploadPayload = record { video_uid : text };
 service : (NotificationStoreInitArgs) -> {
   add_notification : (principal, NotificationType) -> (Result);

--- a/src/lib/shared_utils/src/canister_specific/notification_store/types/notification.rs
+++ b/src/lib/shared_utils/src/canister_specific/notification_store/types/notification.rs
@@ -32,9 +32,19 @@ pub struct VideoUploadPayload {
 }
 
 #[derive(Clone, Serialize, Deserialize, CandidType, PartialEq, Debug)]
+pub struct VideoApprovalPayload {
+    #[serde(deserialize_with = "string_or_number")]
+    pub video_id: String,
+    #[serde(deserialize_with = "string_or_number")]
+    pub post_id: String,
+}
+
+#[derive(Clone, Serialize, Deserialize, CandidType, PartialEq, Debug)]
 pub enum NotificationType {
     Liked(LikedPayload),
     VideoUpload(VideoUploadPayload),
+    VideoApproved(VideoApprovalPayload),
+    VideoDisapproved(VideoApprovalPayload),
 }
 
 fn string_or_number<'de, D>(deserializer: D) -> Result<String, D::Error>


### PR DESCRIPTION

#### To check the status of the deployment

- check if the platform orchestrator performed the step to upgrade subnet canister with appropriate version: [Platform Orchestrator function](https://dashboard.internetcomputer.org/canister/74zq4-iqaaa-aaaam-ab53a-cai#get_subnet_last_upgrade_status)
- check the status of upgrade for individual canisters in subnet orchestrators and verify the version. Example for one of the subnet orchesrator: [Subnet Orchestrator function](https://dashboard.internetcomputer.org/canister/rimrc-piaaa-aaaao-aaljq-cai#get_index_details_last_upgrade_status)

To test the platform orchestrator, you can use the following command:

`dfx canister call --query 74zq4-iqaaa-aaaam-ab53a-cai get_subnet_last_upgrade_status --network=ic`
 the canister id (74zq4-iqaaa-aaaam-ab53a-cai) is taken from the canister_ids.json file