### PR TITLE
Add total video credits allotted to YralProSubscription

### DIFF
--- a/scripts/candid_generator.sh
+++ b/scripts/candid_generator.sh
@@ -9,7 +9,7 @@ function generate_did() {
 }
 
 # The list of canisters of your project
-CANISTERS=user_index,platform_orchestrator,individual_user_template,user_info_service,notification_store,dedup_index,user_post_service,rate_limits 
+CANISTERS=user_info_service
 
 for canister in $(echo $CANISTERS | sed "s/,/ /g")
 do

--- a/src/canister/user_info_service/can.did
+++ b/src/canister/user_info_service/can.did
@@ -37,10 +37,14 @@ type Result_3 = variant { Ok : UserProfileDetailsForFrontendV4; Err : text };
 type Result_4 = variant { Ok : UserProfileDetailsForFrontendV3; Err : text };
 type Result_5 = variant { Ok : UserProfileDetailsForFrontendV5; Err : text };
 type Result_6 = variant { Ok : UserProfileDetailsForFrontendV6; Err : text };
-type Result_7 = variant { Ok : SessionType; Err : text };
-type Result_8 = variant { Ok : UserProfileDetailsForFrontendV7; Err : text };
+type Result_7 = variant { Ok : UserProfileDetailsForFrontendV7; Err : text };
+type Result_8 = variant { Ok : SessionType; Err : text };
 type SessionType = variant { AnonymousSession; RegisteredSession };
 type SubscriptionPlan = variant { Pro : YralProSubscription; Free };
+type UserAccountType = variant {
+  MainAccount : record { bots : vec principal };
+  BotAccount : record { owner : principal };
+};
 type UserInfoServiceInitArgs = record { version : text };
 type UserProfileDetailsForFrontendV3 = record {
   profile_picture_url : opt text;
@@ -81,10 +85,6 @@ type UserProfileDetailsForFrontendV6 = record {
   followers_count : nat64;
   caller_follows_user : opt bool;
 };
-type UserAccountType = variant {
-  MainAccount : record { bots : vec principal };
-  BotAccount : record { owner : principal };
-};
 type UserProfileDetailsForFrontendV7 = record {
   bio : opt text;
   website_url : opt text;
@@ -102,10 +102,15 @@ type UserProfileGlobalStats = record {
   hot_bets_received : nat64;
   not_bets_received : nat64;
 };
-type YralProSubscription = record { free_video_credits_left : nat32 };
+type YralProSubscription = record {
+  free_video_credits_left : nat32;
+  total_video_credits_alloted : nat32;
+};
 service : (UserInfoServiceInitArgs) -> {
   accept_new_user_registration : (principal, bool) -> (Result);
-  accept_new_user_registration_v2 : (principal, bool, opt principal) -> (Result);
+  accept_new_user_registration_v2 : (principal, bool, opt principal) -> (
+      Result,
+    );
   add_pro_plan_free_video_credits : (principal, nat32) -> (Result);
   change_subscription_plan : (principal, SubscriptionPlan) -> (Result);
   delete_user_info : (principal) -> (Result);
@@ -120,8 +125,8 @@ service : (UserInfoServiceInitArgs) -> {
   get_user_profile_details : (principal) -> (Result_4) query;
   get_user_profile_details_v5 : (principal) -> (Result_5) query;
   get_user_profile_details_v6 : (principal) -> (Result_6) query;
-  get_user_profile_details_v7 : (principal) -> (Result_8) query;
-  get_user_session_type : (principal) -> (Result_7) query;
+  get_user_profile_details_v7 : (principal) -> (Result_7) query;
+  get_user_session_type : (principal) -> (Result_8) query;
   get_version : () -> (text) query;
   register_new_user : () -> (Result);
   remove_pro_plan_free_video_credits : (principal, nat32) -> (Result);

--- a/src/canister/user_info_service/src/data_model/mod.rs
+++ b/src/canister/user_info_service/src/data_model/mod.rs
@@ -882,6 +882,12 @@ impl CanisterData {
                     .checked_add(credits_to_add)
                 {
                     Some(new_credits) => {
+                        if new_credits > pro_subscription.total_video_credits_alloted {
+                            return Err(format!(
+                                "Cannot add {} credits: would exceed allotted limit of {}",
+                                credits_to_add, pro_subscription.total_video_credits_alloted
+                            ));
+                        }
                         pro_subscription.free_video_credits_left = new_credits;
                         self.user_infos.insert(user_principal, user_info);
                         Ok(())

--- a/src/lib/integration_tests/tests/user_info_service/test_subscription_plan_functionality.rs
+++ b/src/lib/integration_tests/tests/user_info_service/test_subscription_plan_functionality.rs
@@ -68,6 +68,7 @@ fn test_change_subscription_plan_from_free_to_pro() {
     // Change to Pro plan
     let new_pro_plan = SubscriptionPlan::Pro(YralProSubscription {
         free_video_credits_left: 50,
+        total_video_credits_alloted: 50,
     });
 
     let result = update::<_, Result<(), String>>(
@@ -95,6 +96,7 @@ fn test_change_subscription_plan_from_free_to_pro() {
     match updated_plan {
         SubscriptionPlan::Pro(pro_sub) => {
             assert_eq!(pro_sub.free_video_credits_left, 50);
+            assert_eq!(pro_sub.total_video_credits_alloted, 50);
         }
         _ => panic!("Expected Pro plan, got: {:?}", updated_plan),
     }
@@ -112,6 +114,7 @@ fn test_change_subscription_plan_from_pro_to_free() {
 
     let pro_plan = SubscriptionPlan::Pro(YralProSubscription {
         free_video_credits_left: 30,
+        total_video_credits_alloted: 30,
     });
 
     let _ = update::<_, Result<(), String>>(
@@ -158,6 +161,7 @@ fn test_change_subscription_plan_for_non_existent_user() {
 
     let new_pro_plan = SubscriptionPlan::Pro(YralProSubscription {
         free_video_credits_left: 50,
+        total_video_credits_alloted: 50,
     });
 
     let result = update::<_, Result<(), String>>(
@@ -185,6 +189,7 @@ fn test_add_pro_plan_free_video_credits_success() {
 
     let pro_plan = SubscriptionPlan::Pro(YralProSubscription {
         free_video_credits_left: 10,
+        total_video_credits_alloted: 30,
     });
 
     let _ = update::<_, Result<(), String>>(
@@ -218,6 +223,7 @@ fn test_add_pro_plan_free_video_credits_success() {
     match updated_plan {
         SubscriptionPlan::Pro(pro_sub) => {
             assert_eq!(pro_sub.free_video_credits_left, 30);
+            assert_eq!(pro_sub.total_video_credits_alloted, 30);
         }
         _ => panic!("Expected Pro plan, got: {:?}", updated_plan),
     }
@@ -279,6 +285,7 @@ fn test_remove_pro_plan_free_video_credits_success() {
 
     let pro_plan = SubscriptionPlan::Pro(YralProSubscription {
         free_video_credits_left: 50,
+        total_video_credits_alloted: 50,
     });
 
     let _ = update::<_, Result<(), String>>(
@@ -316,6 +323,7 @@ fn test_remove_pro_plan_free_video_credits_success() {
     match updated_plan {
         SubscriptionPlan::Pro(pro_sub) => {
             assert_eq!(pro_sub.free_video_credits_left, 30);
+            assert_eq!(pro_sub.total_video_credits_alloted, 50);
         }
         _ => panic!("Expected Pro plan, got: {:?}", updated_plan),
     }
@@ -333,6 +341,7 @@ fn test_remove_pro_plan_free_video_credits_insufficient_credits() {
 
     let pro_plan = SubscriptionPlan::Pro(YralProSubscription {
         free_video_credits_left: 5,
+        total_video_credits_alloted: 5,
     });
 
     let _ = update::<_, Result<(), String>>(
@@ -367,6 +376,7 @@ fn test_remove_pro_plan_free_video_credits_insufficient_credits() {
     match updated_plan {
         SubscriptionPlan::Pro(pro_sub) => {
             assert_eq!(pro_sub.free_video_credits_left, 5);
+            assert_eq!(pro_sub.total_video_credits_alloted, 5);
         }
         _ => panic!("Expected Pro plan, got: {:?}", updated_plan),
     }
@@ -428,6 +438,7 @@ fn test_remove_all_pro_plan_free_video_credits() {
 
     let pro_plan = SubscriptionPlan::Pro(YralProSubscription {
         free_video_credits_left: 25,
+        total_video_credits_alloted: 25,
     });
 
     let _ = update::<_, Result<(), String>>(
@@ -465,7 +476,114 @@ fn test_remove_all_pro_plan_free_video_credits() {
     match updated_plan {
         SubscriptionPlan::Pro(pro_sub) => {
             assert_eq!(pro_sub.free_video_credits_left, 0);
+            assert_eq!(pro_sub.total_video_credits_alloted, 25);
         }
         _ => panic!("Expected Pro plan, got: {:?}", updated_plan),
+    }
+}
+
+#[test]
+fn test_video_credits_never_exceed_allotted_limit() {
+    let (pocket_ic, service_canisters) = get_new_pocket_ic_env_with_service_canisters_provisioned();
+    let user_service_canister = service_canisters.user_info_service_canister_id;
+    let admin_principal = get_global_super_admin_principal_id();
+    let user_principal = get_mock_user_alice_principal_id();
+
+    // Setup user and change to Pro plan with a specific allotment
+    setup_test_user(&pocket_ic, user_service_canister, user_principal);
+
+    let pro_plan = SubscriptionPlan::Pro(YralProSubscription {
+        free_video_credits_left: 20,
+        total_video_credits_alloted: 50,
+    });
+
+    let _ = update::<_, Result<(), String>>(
+        &pocket_ic,
+        user_service_canister,
+        admin_principal,
+        "change_subscription_plan",
+        (user_principal, pro_plan),
+    )
+    .expect("Failed to set Pro plan");
+
+    // Verify initial state
+    let plan = get_user_subscription_plan(
+        &pocket_ic,
+        user_service_canister,
+        user_principal,
+        user_principal,
+    );
+    match plan {
+        SubscriptionPlan::Pro(pro_sub) => {
+            assert_eq!(pro_sub.free_video_credits_left, 20);
+            assert_eq!(pro_sub.total_video_credits_alloted, 50);
+            assert!(pro_sub.free_video_credits_left <= pro_sub.total_video_credits_alloted);
+        }
+        _ => panic!("Expected Pro plan"),
+    }
+
+    // Add credits that would reach the limit exactly
+    let result = update::<_, Result<(), String>>(
+        &pocket_ic,
+        user_service_canister,
+        admin_principal,
+        "add_pro_plan_free_video_credits",
+        (user_principal, 30u32),
+    )
+    .expect("Failed to add video credits");
+
+    assert!(result.is_ok(), "Adding video credits failed: {:?}", result);
+
+    // Verify credits are now at limit
+    let updated_plan = get_user_subscription_plan(
+        &pocket_ic,
+        user_service_canister,
+        user_principal,
+        user_principal,
+    );
+    match updated_plan {
+        SubscriptionPlan::Pro(pro_sub) => {
+            assert_eq!(pro_sub.free_video_credits_left, 50);
+            assert_eq!(pro_sub.total_video_credits_alloted, 50);
+            assert!(pro_sub.free_video_credits_left <= pro_sub.total_video_credits_alloted);
+        }
+        _ => panic!("Expected Pro plan"),
+    }
+
+    // Try to add more credits beyond the limit - this should fail
+    let result_overflow = update::<_, Result<(), String>>(
+        &pocket_ic,
+        user_service_canister,
+        admin_principal,
+        "add_pro_plan_free_video_credits",
+        (user_principal, 10u32),
+    )
+    .expect("Failed to call add_pro_plan_free_video_credits");
+
+    assert!(result_overflow.is_err());
+    assert!(result_overflow
+        .unwrap_err()
+        .contains("would exceed allotted limit"));
+
+    // Verify that credits remain at the limit and weren't changed
+    let final_plan = get_user_subscription_plan(
+        &pocket_ic,
+        user_service_canister,
+        user_principal,
+        user_principal,
+    );
+    match final_plan {
+        SubscriptionPlan::Pro(pro_sub) => {
+            // Credits should remain at the allotted limit
+            assert_eq!(pro_sub.free_video_credits_left, 50);
+            assert_eq!(pro_sub.total_video_credits_alloted, 50);
+            assert!(
+                pro_sub.free_video_credits_left <= pro_sub.total_video_credits_alloted,
+                "Credits {} should never exceed allotted limit {}",
+                pro_sub.free_video_credits_left,
+                pro_sub.total_video_credits_alloted
+            );
+        }
+        _ => panic!("Expected Pro plan"),
     }
 }

--- a/src/lib/shared_utils/src/canister_specific/user_info_service/types.rs
+++ b/src/lib/shared_utils/src/canister_specific/user_info_service/types.rs
@@ -57,12 +57,19 @@ pub struct FollowingResponse {
 #[derive(CandidType, Deserialize, Serialize, Debug, Clone, PartialEq, Eq)]
 pub struct YralProSubscription {
     pub free_video_credits_left: u32,
+    #[serde(default = "default_value_for_total_video_credits_alloted")]
+    pub total_video_credits_alloted: u32,
+}
+
+fn default_value_for_total_video_credits_alloted() -> u32 {
+    30
 }
 
 impl Default for YralProSubscription {
     fn default() -> Self {
         YralProSubscription {
             free_video_credits_left: 30,
+            total_video_credits_alloted: 30,
         }
     }
 }


### PR DESCRIPTION
Include the total number of video credits allotted in the YralProSubscription struct, with a default value set to 30. This change enhances the subscription model by providing clearer credit management.

-fixes https://github.com/dolr-ai/product-roadmap/issues/1590

