### PR TITLE
feat: parent account subscriptions syncs to bot account

### DIFF
--- a/src/canister/user_info_service/src/data_model/mod.rs
+++ b/src/canister/user_info_service/src/data_model/mod.rs
@@ -234,6 +234,7 @@ impl CanisterData {
         caller_principal: Principal,
     ) -> Result<UserProfileDetailsForFrontendV5, String> {
         if let Some(user_info) = self.user_infos.get(&user_principal) {
+            let subscription_info = self.get_user_pro_subscription_plan(user_principal)?;
             Ok(UserProfileDetailsForFrontendV5 {
                 principal_id: user_principal,
                 bio: user_info.profile.bio.clone(),
@@ -262,7 +263,7 @@ impl CanisterData {
                             Some(false)
                         }
                     }),
-                subscription_plan: user_info.profile.subscription_plan.clone(),
+                subscription_plan: subscription_info,
                 profile_picture_url: user_info
                     .profile
                     .profile_picture
@@ -280,6 +281,7 @@ impl CanisterData {
         caller_principal: Principal,
     ) -> Result<UserProfileDetailsForFrontendV6, String> {
         if let Some(user_info) = self.user_infos.get(&user_principal) {
+            let subscription_info = self.get_user_pro_subscription_plan(user_principal)?;
             Ok(UserProfileDetailsForFrontendV6 {
                 principal_id: user_principal,
                 profile_picture: user_info.profile.profile_picture.clone(),
@@ -309,7 +311,7 @@ impl CanisterData {
                             Some(false)
                         }
                     }),
-                subscription_plan: user_info.profile.subscription_plan.clone(),
+                subscription_plan: subscription_info,
                 is_ai_influencer: user_info.profile.is_ai_influencer,
             })
         } else {
@@ -681,6 +683,7 @@ impl CanisterData {
         caller_principal: Principal,
     ) -> Result<UserProfileDetailsForFrontendV7, String> {
         if let Some(user_info) = self.user_infos.get(&user_principal) {
+            let subscription_info = self.get_user_pro_subscription_plan(user_principal)?;
             Ok(UserProfileDetailsForFrontendV7 {
                 principal_id: user_principal,
                 profile_picture: user_info.profile.profile_picture.clone(),
@@ -710,7 +713,7 @@ impl CanisterData {
                             Some(false)
                         }
                     }),
-                subscription_plan: user_info.profile.subscription_plan.clone(),
+                subscription_plan: subscription_info,
                 is_ai_influencer: user_info.profile.is_ai_influencer,
                 account_type: user_info.account_type.clone(),
             })
@@ -862,9 +865,23 @@ impl CanisterData {
             .get(&user_principal)
             .ok_or("User not found".to_string())?;
 
-        user_info.profile.subscription_plan = new_plan;
+        match user_info.account_type {
+            UserAccountType::BotAccount { owner } => {
+                let mut main_account_user_info = self
+                    .user_infos
+                    .get(&owner)
+                    .ok_or("Main account not found for bot".to_string())?;
 
-        self.user_infos.insert(user_principal, user_info);
+                main_account_user_info.profile.subscription_plan = new_plan;
+
+                self.user_infos.insert(owner, main_account_user_info);
+            }
+            _ => {
+                user_info.profile.subscription_plan = new_plan;
+                self.user_infos.insert(user_principal, user_info);
+            }
+        }
+
         Ok(())
     }
 
@@ -873,21 +890,39 @@ impl CanisterData {
         user_principal: Principal,
         credits_to_remove: u32,
     ) -> Result<(), String> {
-        let mut user_info = self
-            .user_infos
-            .get(&user_principal)
-            .ok_or("User not found".to_string())?;
+        let mut subscription_info = self.get_user_pro_subscription_plan(user_principal)?;
 
-        match &mut user_info.profile.subscription_plan {
+        match &mut subscription_info {
             SubscriptionPlan::Pro(pro_subscription) => {
                 if pro_subscription.free_video_credits_left < credits_to_remove {
                     return Err("Not enough free video credits".to_string());
                 }
                 pro_subscription.free_video_credits_left -= credits_to_remove;
-                self.user_infos.insert(user_principal, user_info);
+                self.change_subscription_plan(user_principal, subscription_info)?;
                 Ok(())
             }
             SubscriptionPlan::Free => Err("User is on Free plan".to_string()),
+        }
+    }
+
+    pub fn get_user_pro_subscription_plan(
+        &self,
+        user_principal: Principal,
+    ) -> Result<SubscriptionPlan, String> {
+        let user_info = self
+            .user_infos
+            .get(&user_principal)
+            .ok_or("User not found".to_string())?;
+
+        match user_info.account_type {
+            UserAccountType::BotAccount { owner } => {
+                // For bot accounts, return the owner's subscription plan if available
+                self.user_infos
+                    .get(&owner)
+                    .map(|owner_account_info| owner_account_info.profile.subscription_plan)
+                    .ok_or("Owner not found".to_string())
+            }
+            _ => Ok(user_info.profile.subscription_plan),
         }
     }
 
@@ -896,12 +931,9 @@ impl CanisterData {
         user_principal: Principal,
         credits_to_add: u32,
     ) -> Result<(), String> {
-        let mut user_info = self
-            .user_infos
-            .get(&user_principal)
-            .ok_or("User not found".to_string())?;
+        let mut subscription_info = self.get_user_pro_subscription_plan(user_principal)?;
 
-        match &mut user_info.profile.subscription_plan {
+        match &mut subscription_info {
             SubscriptionPlan::Pro(pro_subscription) => {
                 match pro_subscription
                     .free_video_credits_left
@@ -915,7 +947,7 @@ impl CanisterData {
                             ));
                         }
                         pro_subscription.free_video_credits_left = new_credits;
-                        self.user_infos.insert(user_principal, user_info);
+                        self.change_subscription_plan(user_principal, subscription_info)?;
                         Ok(())
                     }
                     None => Err("Overflow when adding free credits".to_string()),

--- a/src/canister/user_info_service/src/data_model/mod.rs
+++ b/src/canister/user_info_service/src/data_model/mod.rs
@@ -234,7 +234,7 @@ impl CanisterData {
         caller_principal: Principal,
     ) -> Result<UserProfileDetailsForFrontendV5, String> {
         if let Some(user_info) = self.user_infos.get(&user_principal) {
-            let subscription_info = self.get_user_pro_subscription_plan(user_principal)?;
+            let subscription_info = self.get_effective_subscription_plan(user_principal)?;
             Ok(UserProfileDetailsForFrontendV5 {
                 principal_id: user_principal,
                 bio: user_info.profile.bio.clone(),
@@ -281,7 +281,7 @@ impl CanisterData {
         caller_principal: Principal,
     ) -> Result<UserProfileDetailsForFrontendV6, String> {
         if let Some(user_info) = self.user_infos.get(&user_principal) {
-            let subscription_info = self.get_user_pro_subscription_plan(user_principal)?;
+            let subscription_info = self.get_effective_subscription_plan(user_principal)?;
             Ok(UserProfileDetailsForFrontendV6 {
                 principal_id: user_principal,
                 profile_picture: user_info.profile.profile_picture.clone(),
@@ -683,7 +683,7 @@ impl CanisterData {
         caller_principal: Principal,
     ) -> Result<UserProfileDetailsForFrontendV7, String> {
         if let Some(user_info) = self.user_infos.get(&user_principal) {
-            let subscription_info = self.get_user_pro_subscription_plan(user_principal)?;
+            let subscription_info = self.get_effective_subscription_plan(user_principal)?;
             Ok(UserProfileDetailsForFrontendV7 {
                 principal_id: user_principal,
                 profile_picture: user_info.profile.profile_picture.clone(),
@@ -865,7 +865,7 @@ impl CanisterData {
             .get(&user_principal)
             .ok_or("User not found".to_string())?;
 
-        match user_info.account_type {
+        match &user_info.account_type {
             UserAccountType::BotAccount { owner } => {
                 let mut main_account_user_info = self
                     .user_infos
@@ -874,7 +874,7 @@ impl CanisterData {
 
                 main_account_user_info.profile.subscription_plan = new_plan;
 
-                self.user_infos.insert(owner, main_account_user_info);
+                self.user_infos.insert(*owner, main_account_user_info);
             }
             _ => {
                 user_info.profile.subscription_plan = new_plan;
@@ -890,7 +890,7 @@ impl CanisterData {
         user_principal: Principal,
         credits_to_remove: u32,
     ) -> Result<(), String> {
-        let mut subscription_info = self.get_user_pro_subscription_plan(user_principal)?;
+        let mut subscription_info = self.get_effective_subscription_plan(user_principal)?;
 
         match &mut subscription_info {
             SubscriptionPlan::Pro(pro_subscription) => {
@@ -905,7 +905,7 @@ impl CanisterData {
         }
     }
 
-    pub fn get_user_pro_subscription_plan(
+    pub fn get_effective_subscription_plan(
         &self,
         user_principal: Principal,
     ) -> Result<SubscriptionPlan, String> {
@@ -914,11 +914,11 @@ impl CanisterData {
             .get(&user_principal)
             .ok_or("User not found".to_string())?;
 
-        match user_info.account_type {
+        match &user_info.account_type {
             UserAccountType::BotAccount { owner } => {
                 // For bot accounts, return the owner's subscription plan if available
                 self.user_infos
-                    .get(&owner)
+                    .get(owner)
                     .map(|owner_account_info| owner_account_info.profile.subscription_plan)
                     .ok_or("Owner not found".to_string())
             }
@@ -931,7 +931,7 @@ impl CanisterData {
         user_principal: Principal,
         credits_to_add: u32,
     ) -> Result<(), String> {
-        let mut subscription_info = self.get_user_pro_subscription_plan(user_principal)?;
+        let mut subscription_info = self.get_effective_subscription_plan(user_principal)?;
 
         match &mut subscription_info {
             SubscriptionPlan::Pro(pro_subscription) => {

--- a/src/lib/integration_tests/tests/user_info_service/test_subscription_plan_functionality.rs
+++ b/src/lib/integration_tests/tests/user_info_service/test_subscription_plan_functionality.rs
@@ -587,3 +587,549 @@ fn test_video_credits_never_exceed_allotted_limit() {
         _ => panic!("Expected Pro plan"),
     }
 }
+
+// ============================================================================
+// Bot Account Subscription Tests
+// ============================================================================
+
+/// Helper to setup a bot account with its parent
+fn setup_bot_with_parent(
+    pocket_ic: &PocketIc,
+    user_service_canister: candid::Principal,
+    parent_principal: candid::Principal,
+    bot_principal: candid::Principal,
+    admin_principal: candid::Principal,
+) {
+    // Register parent as main account
+    setup_test_user(pocket_ic, user_service_canister, parent_principal);
+
+    // Register bot linked to parent using accept_new_user_registration_v2
+    let result = update::<_, Result<(), String>>(
+        pocket_ic,
+        user_service_canister,
+        admin_principal,
+        "accept_new_user_registration_v2",
+        (bot_principal, true, Some(parent_principal)),
+    )
+    .expect("Failed to register bot");
+    assert!(result.is_ok(), "Bot registration failed: {:?}", result);
+}
+
+#[test]
+fn test_bot_inherits_parent_subscription_plan() {
+    let (pocket_ic, service_canisters) = get_new_pocket_ic_env_with_service_canisters_provisioned();
+    let user_service_canister = service_canisters.user_info_service_canister_id;
+    let admin_principal = get_global_super_admin_principal_id();
+    let parent_principal = get_mock_user_alice_principal_id();
+    let bot_principal = get_mock_user_bob_principal_id();
+
+    // Setup parent and bot accounts
+    setup_bot_with_parent(
+        &pocket_ic,
+        user_service_canister,
+        parent_principal,
+        bot_principal,
+        admin_principal,
+    );
+
+    // Verify both start with Free plan
+    let parent_plan = get_user_subscription_plan(
+        &pocket_ic,
+        user_service_canister,
+        parent_principal,
+        parent_principal,
+    );
+    assert!(matches!(parent_plan, SubscriptionPlan::Free));
+
+    let bot_plan = get_user_subscription_plan(
+        &pocket_ic,
+        user_service_canister,
+        bot_principal,
+        bot_principal,
+    );
+    assert!(matches!(bot_plan, SubscriptionPlan::Free));
+
+    // Upgrade parent to Pro plan
+    let pro_plan = SubscriptionPlan::Pro(YralProSubscription {
+        free_video_credits_left: 100,
+        total_video_credits_alloted: 100,
+    });
+
+    let _ = update::<_, Result<(), String>>(
+        &pocket_ic,
+        user_service_canister,
+        admin_principal,
+        "change_subscription_plan",
+        (parent_principal, pro_plan.clone()),
+    )
+    .expect("Failed to change parent subscription plan");
+
+    // Verify parent has Pro plan
+    let parent_updated = get_user_subscription_plan(
+        &pocket_ic,
+        user_service_canister,
+        parent_principal,
+        parent_principal,
+    );
+    match parent_updated {
+        SubscriptionPlan::Pro(pro_sub) => {
+            assert_eq!(pro_sub.free_video_credits_left, 100);
+            assert_eq!(pro_sub.total_video_credits_alloted, 100);
+        }
+        _ => panic!("Expected Pro plan for parent"),
+    }
+
+    // Verify bot also sees Pro plan (inherits from parent)
+    let bot_updated = get_user_subscription_plan(
+        &pocket_ic,
+        user_service_canister,
+        bot_principal,
+        bot_principal,
+    );
+    println!("Bot subscription plan: {:?}", bot_updated);
+    match bot_updated {
+        SubscriptionPlan::Pro(pro_sub) => {
+            assert_eq!(pro_sub.free_video_credits_left, 100);
+            assert_eq!(pro_sub.total_video_credits_alloted, 100);
+        }
+        _ => panic!(
+            "Expected Pro plan for bot (inherited from parent), got: {:?}",
+            bot_updated
+        ),
+    }
+}
+
+#[test]
+fn test_change_subscription_plan_for_bot_updates_parent() {
+    let (pocket_ic, service_canisters) = get_new_pocket_ic_env_with_service_canisters_provisioned();
+    let user_service_canister = service_canisters.user_info_service_canister_id;
+    let admin_principal = get_global_super_admin_principal_id();
+    let parent_principal = get_mock_user_alice_principal_id();
+    let bot_principal = get_mock_user_bob_principal_id();
+
+    // Setup parent and bot accounts
+    setup_bot_with_parent(
+        &pocket_ic,
+        user_service_canister,
+        parent_principal,
+        bot_principal,
+        admin_principal,
+    );
+
+    // Change subscription plan using bot principal (should update parent)
+    let pro_plan = SubscriptionPlan::Pro(YralProSubscription {
+        free_video_credits_left: 50,
+        total_video_credits_alloted: 50,
+    });
+
+    let result = update::<_, Result<(), String>>(
+        &pocket_ic,
+        user_service_canister,
+        admin_principal,
+        "change_subscription_plan",
+        (bot_principal, pro_plan.clone()),
+    )
+    .expect("Failed to change bot subscription plan");
+
+    assert!(
+        result.is_ok(),
+        "Changing bot subscription plan failed: {:?}",
+        result
+    );
+
+    // Verify parent's subscription was updated
+    let parent_plan = get_user_subscription_plan(
+        &pocket_ic,
+        user_service_canister,
+        parent_principal,
+        parent_principal,
+    );
+    match parent_plan {
+        SubscriptionPlan::Pro(pro_sub) => {
+            assert_eq!(pro_sub.free_video_credits_left, 50);
+            assert_eq!(pro_sub.total_video_credits_alloted, 50);
+        }
+        _ => panic!("Expected Pro plan for parent after bot subscription change"),
+    }
+
+    // Verify bot sees the same plan
+    let bot_plan = get_user_subscription_plan(
+        &pocket_ic,
+        user_service_canister,
+        bot_principal,
+        bot_principal,
+    );
+    match bot_plan {
+        SubscriptionPlan::Pro(pro_sub) => {
+            assert_eq!(pro_sub.free_video_credits_left, 50);
+            assert_eq!(pro_sub.total_video_credits_alloted, 50);
+        }
+        _ => panic!("Expected Pro plan for bot"),
+    }
+}
+
+#[test]
+fn test_add_credits_to_bot_updates_parent() {
+    let (pocket_ic, service_canisters) = get_new_pocket_ic_env_with_service_canisters_provisioned();
+    let user_service_canister = service_canisters.user_info_service_canister_id;
+    let admin_principal = get_global_super_admin_principal_id();
+    let parent_principal = get_mock_user_alice_principal_id();
+    let bot_principal = get_mock_user_bob_principal_id();
+
+    // Setup parent and bot accounts
+    setup_bot_with_parent(
+        &pocket_ic,
+        user_service_canister,
+        parent_principal,
+        bot_principal,
+        admin_principal,
+    );
+
+    // Set parent to Pro plan
+    let pro_plan = SubscriptionPlan::Pro(YralProSubscription {
+        free_video_credits_left: 10,
+        total_video_credits_alloted: 50,
+    });
+
+    let _ = update::<_, Result<(), String>>(
+        &pocket_ic,
+        user_service_canister,
+        admin_principal,
+        "change_subscription_plan",
+        (parent_principal, pro_plan),
+    )
+    .expect("Failed to set parent Pro plan");
+
+    // Add credits using bot principal
+    let result = update::<_, Result<(), String>>(
+        &pocket_ic,
+        user_service_canister,
+        admin_principal,
+        "add_pro_plan_free_video_credits",
+        (bot_principal, 20u32),
+    )
+    .expect("Failed to add credits to bot");
+
+    assert!(result.is_ok(), "Adding credits to bot failed: {:?}", result);
+
+    // Verify parent's credits were updated (10 + 20 = 30)
+    let parent_plan = get_user_subscription_plan(
+        &pocket_ic,
+        user_service_canister,
+        parent_principal,
+        parent_principal,
+    );
+    match parent_plan {
+        SubscriptionPlan::Pro(pro_sub) => {
+            assert_eq!(pro_sub.free_video_credits_left, 30);
+            assert_eq!(pro_sub.total_video_credits_alloted, 50);
+        }
+        _ => panic!("Expected Pro plan for parent"),
+    }
+
+    // Verify bot sees the updated credits
+    let bot_plan = get_user_subscription_plan(
+        &pocket_ic,
+        user_service_canister,
+        bot_principal,
+        bot_principal,
+    );
+    match bot_plan {
+        SubscriptionPlan::Pro(pro_sub) => {
+            assert_eq!(pro_sub.free_video_credits_left, 30);
+            assert_eq!(pro_sub.total_video_credits_alloted, 50);
+        }
+        _ => panic!("Expected Pro plan for bot"),
+    }
+}
+
+#[test]
+fn test_remove_credits_from_bot_updates_parent() {
+    let (pocket_ic, service_canisters) = get_new_pocket_ic_env_with_service_canisters_provisioned();
+    let user_service_canister = service_canisters.user_info_service_canister_id;
+    let admin_principal = get_global_super_admin_principal_id();
+    let parent_principal = get_mock_user_alice_principal_id();
+    let bot_principal = get_mock_user_bob_principal_id();
+
+    // Setup parent and bot accounts
+    setup_bot_with_parent(
+        &pocket_ic,
+        user_service_canister,
+        parent_principal,
+        bot_principal,
+        admin_principal,
+    );
+
+    // Set parent to Pro plan with credits
+    let pro_plan = SubscriptionPlan::Pro(YralProSubscription {
+        free_video_credits_left: 50,
+        total_video_credits_alloted: 50,
+    });
+
+    let _ = update::<_, Result<(), String>>(
+        &pocket_ic,
+        user_service_canister,
+        admin_principal,
+        "change_subscription_plan",
+        (parent_principal, pro_plan),
+    )
+    .expect("Failed to set parent Pro plan");
+
+    // Remove credits using bot principal
+    let result = update::<_, Result<(), String>>(
+        &pocket_ic,
+        user_service_canister,
+        admin_principal,
+        "remove_pro_plan_free_video_credits",
+        (bot_principal, 15u32),
+    )
+    .expect("Failed to remove credits from bot");
+
+    assert!(
+        result.is_ok(),
+        "Removing credits from bot failed: {:?}",
+        result
+    );
+
+    // Verify parent's credits were updated (50 - 15 = 35)
+    let parent_plan = get_user_subscription_plan(
+        &pocket_ic,
+        user_service_canister,
+        parent_principal,
+        parent_principal,
+    );
+    match parent_plan {
+        SubscriptionPlan::Pro(pro_sub) => {
+            assert_eq!(pro_sub.free_video_credits_left, 35);
+            assert_eq!(pro_sub.total_video_credits_alloted, 50);
+        }
+        _ => panic!("Expected Pro plan for parent"),
+    }
+
+    // Verify bot sees the updated credits
+    let bot_plan = get_user_subscription_plan(
+        &pocket_ic,
+        user_service_canister,
+        bot_principal,
+        bot_principal,
+    );
+    match bot_plan {
+        SubscriptionPlan::Pro(pro_sub) => {
+            assert_eq!(pro_sub.free_video_credits_left, 35);
+            assert_eq!(pro_sub.total_video_credits_alloted, 50);
+        }
+        _ => panic!("Expected Pro plan for bot"),
+    }
+}
+
+#[test]
+fn test_bot_credits_shared_with_parent() {
+    let (pocket_ic, service_canisters) = get_new_pocket_ic_env_with_service_canisters_provisioned();
+    let user_service_canister = service_canisters.user_info_service_canister_id;
+    let admin_principal = get_global_super_admin_principal_id();
+    let parent_principal = get_mock_user_alice_principal_id();
+    let bot1_principal = get_mock_user_bob_principal_id();
+    let bot2_principal = get_mock_user_charlie_principal_id();
+
+    // Setup parent with two bots
+    setup_test_user(&pocket_ic, user_service_canister, parent_principal);
+
+    let _ = update::<_, Result<(), String>>(
+        &pocket_ic,
+        user_service_canister,
+        admin_principal,
+        "accept_new_user_registration_v2",
+        (bot1_principal, true, Some(parent_principal)),
+    )
+    .expect("Failed to register bot1");
+
+    let _ = update::<_, Result<(), String>>(
+        &pocket_ic,
+        user_service_canister,
+        admin_principal,
+        "accept_new_user_registration_v2",
+        (bot2_principal, true, Some(parent_principal)),
+    )
+    .expect("Failed to register bot2");
+
+    // Set parent to Pro plan
+    let pro_plan = SubscriptionPlan::Pro(YralProSubscription {
+        free_video_credits_left: 100,
+        total_video_credits_alloted: 100,
+    });
+
+    let _ = update::<_, Result<(), String>>(
+        &pocket_ic,
+        user_service_canister,
+        admin_principal,
+        "change_subscription_plan",
+        (parent_principal, pro_plan),
+    )
+    .expect("Failed to set parent Pro plan");
+
+    // Remove credits via bot1
+    let _ = update::<_, Result<(), String>>(
+        &pocket_ic,
+        user_service_canister,
+        admin_principal,
+        "remove_pro_plan_free_video_credits",
+        (bot1_principal, 30u32),
+    )
+    .expect("Failed to remove credits via bot1");
+
+    // Verify all accounts see the same updated credits (100 - 30 = 70)
+    let parent_plan = get_user_subscription_plan(
+        &pocket_ic,
+        user_service_canister,
+        parent_principal,
+        parent_principal,
+    );
+    match parent_plan {
+        SubscriptionPlan::Pro(pro_sub) => {
+            assert_eq!(pro_sub.free_video_credits_left, 70);
+        }
+        _ => panic!("Expected Pro plan for parent"),
+    }
+
+    let bot1_plan = get_user_subscription_plan(
+        &pocket_ic,
+        user_service_canister,
+        bot1_principal,
+        bot1_principal,
+    );
+    match bot1_plan {
+        SubscriptionPlan::Pro(pro_sub) => {
+            assert_eq!(pro_sub.free_video_credits_left, 70);
+        }
+        _ => panic!("Expected Pro plan for bot1"),
+    }
+
+    let bot2_plan = get_user_subscription_plan(
+        &pocket_ic,
+        user_service_canister,
+        bot2_principal,
+        bot2_principal,
+    );
+    match bot2_plan {
+        SubscriptionPlan::Pro(pro_sub) => {
+            assert_eq!(pro_sub.free_video_credits_left, 70);
+        }
+        _ => panic!("Expected Pro plan for bot2"),
+    }
+
+    // Add credits via bot2
+    let _ = update::<_, Result<(), String>>(
+        &pocket_ic,
+        user_service_canister,
+        admin_principal,
+        "add_pro_plan_free_video_credits",
+        (bot2_principal, 20u32),
+    )
+    .expect("Failed to add credits via bot2");
+
+    // Verify all accounts see the new total (70 + 20 = 90)
+    let parent_plan = get_user_subscription_plan(
+        &pocket_ic,
+        user_service_canister,
+        parent_principal,
+        parent_principal,
+    );
+    match parent_plan {
+        SubscriptionPlan::Pro(pro_sub) => {
+            assert_eq!(pro_sub.free_video_credits_left, 90);
+        }
+        _ => panic!("Expected Pro plan for parent"),
+    }
+
+    let bot1_plan = get_user_subscription_plan(
+        &pocket_ic,
+        user_service_canister,
+        bot1_principal,
+        bot1_principal,
+    );
+    match bot1_plan {
+        SubscriptionPlan::Pro(pro_sub) => {
+            assert_eq!(pro_sub.free_video_credits_left, 90);
+        }
+        _ => panic!("Expected Pro plan for bot1"),
+    }
+
+    let bot2_plan = get_user_subscription_plan(
+        &pocket_ic,
+        user_service_canister,
+        bot2_principal,
+        bot2_principal,
+    );
+    match bot2_plan {
+        SubscriptionPlan::Pro(pro_sub) => {
+            assert_eq!(pro_sub.free_video_credits_left, 90);
+        }
+        _ => panic!("Expected Pro plan for bot2"),
+    }
+}
+
+#[test]
+fn test_bot_cannot_operate_with_free_plan() {
+    let (pocket_ic, service_canisters) = get_new_pocket_ic_env_with_service_canisters_provisioned();
+    let user_service_canister = service_canisters.user_info_service_canister_id;
+    let admin_principal = get_global_super_admin_principal_id();
+    let parent_principal = get_mock_user_alice_principal_id();
+    let bot_principal = get_mock_user_bob_principal_id();
+
+    // Setup parent and bot accounts (both start with Free plan)
+    setup_bot_with_parent(
+        &pocket_ic,
+        user_service_canister,
+        parent_principal,
+        bot_principal,
+        admin_principal,
+    );
+
+    // Try to add credits to bot with Free plan (should fail)
+    let result = update::<_, Result<(), String>>(
+        &pocket_ic,
+        user_service_canister,
+        admin_principal,
+        "add_pro_plan_free_video_credits",
+        (bot_principal, 10u32),
+    )
+    .expect("Failed to call add_pro_plan_free_video_credits");
+
+    assert!(result.is_err());
+    assert_eq!(result.unwrap_err(), "User is on Free plan");
+
+    // Try to remove credits from bot with Free plan (should fail)
+    let result = update::<_, Result<(), String>>(
+        &pocket_ic,
+        user_service_canister,
+        admin_principal,
+        "remove_pro_plan_free_video_credits",
+        (bot_principal, 5u32),
+    )
+    .expect("Failed to call remove_pro_plan_free_video_credits");
+
+    assert!(result.is_err());
+    assert_eq!(result.unwrap_err(), "User is on Free plan");
+}
+
+#[test]
+fn test_bot_subscription_operations_fail_when_owner_not_found() {
+    let (pocket_ic, service_canisters) = get_new_pocket_ic_env_with_service_canisters_provisioned();
+    let user_service_canister = service_canisters.user_info_service_canister_id;
+    let admin_principal = get_global_super_admin_principal_id();
+    let non_existent_parent = candid::Principal::from_text("aaaaa-aa").unwrap();
+    let bot_principal = get_mock_user_bob_principal_id();
+
+    // Try to register bot with non-existent parent (should fail)
+    let result = update::<_, Result<(), String>>(
+        &pocket_ic,
+        user_service_canister,
+        admin_principal,
+        "accept_new_user_registration_v2",
+        (bot_principal, true, Some(non_existent_parent)),
+    )
+    .expect("Failed to call accept_new_user_registration_v2");
+
+    assert!(result.is_err());
+    assert_eq!(result.unwrap_err(), "Owner not found");
+}

--- a/src/lib/integration_tests/tests/user_info_service/test_subscription_plan_functionality.rs
+++ b/src/lib/integration_tests/tests/user_info_service/test_subscription_plan_functionality.rs
@@ -3,6 +3,7 @@ use shared_utils::canister_specific::individual_user_template::types::profile::U
 use shared_utils::canister_specific::user_info_service::types::{
     SubscriptionPlan, YralProSubscription,
 };
+use shared_utils::service;
 use test_utils::canister_calls::{query, update};
 use test_utils::setup::env::pocket_ic_env::get_new_pocket_ic_env_with_service_canisters_provisioned;
 use test_utils::setup::test_constants::{
@@ -150,6 +151,60 @@ fn test_change_subscription_plan_from_pro_to_free() {
         user_principal,
     );
     assert!(matches!(updated_plan, SubscriptionPlan::Free));
+}
+
+#[test]
+fn test_change_subscripton_for_bot_account() {
+    let (pocket_ic, service_canisters) = get_new_pocket_ic_env_with_service_canisters_provisioned();
+
+    let user_service_canister = service_canisters.user_info_service_canister_id;
+
+    let admin_principal = get_global_super_admin_principal_id();
+    let parent_account = get_mock_user_charlie_principal_id(); // Don't register this user
+    let bot_account = get_mock_user_bob_principal_id();
+
+    setup_bot_with_parent(
+        &pocket_ic,
+        user_service_canister,
+        parent_account,
+        bot_account,
+        admin_principal,
+    );
+
+    let new_pro_plan = SubscriptionPlan::Pro(YralProSubscription {
+        free_video_credits_left: 50,
+        total_video_credits_alloted: 50,
+    });
+
+    let result = update::<_, Result<(), String>>(
+        &pocket_ic,
+        user_service_canister,
+        admin_principal,
+        "change_subscription_plan",
+        (bot_account, new_pro_plan),
+    )
+    .expect("Failed to call change_subscription_plan");
+
+    assert!(
+        result.is_ok(),
+        "Subscription plan change failed: {:?}",
+        result
+    );
+
+    // Verify credits were added (10 + 20 = 30)
+    let updated_plan = get_user_subscription_plan(
+        &pocket_ic,
+        user_service_canister,
+        parent_account,
+        parent_account,
+    );
+    match updated_plan {
+        SubscriptionPlan::Pro(pro_sub) => {
+            assert_eq!(pro_sub.free_video_credits_left, 50);
+            assert_eq!(pro_sub.total_video_credits_alloted, 50);
+        }
+        _ => panic!("Expected Pro plan, got: {:?}", updated_plan),
+    }
 }
 
 #[test]

--- a/src/lib/shared_utils/src/canister_specific/user_info_service/types.rs
+++ b/src/lib/shared_utils/src/canister_specific/user_info_service/types.rs
@@ -54,7 +54,7 @@ pub struct FollowingResponse {
     pub next_cursor: Option<Principal>,
 }
 
-#[derive(CandidType, Deserialize, Serialize, Debug, Clone, PartialEq, Eq)]
+#[derive(CandidType, Deserialize, Serialize, Debug, Clone, PartialEq, Eq, Copy)]
 pub struct YralProSubscription {
     pub free_video_credits_left: u32,
     #[serde(default = "default_value_for_total_video_credits_alloted")]
@@ -74,7 +74,7 @@ impl Default for YralProSubscription {
     }
 }
 
-#[derive(CandidType, Deserialize, Serialize, Debug, Default, Clone, PartialEq, Eq)]
+#[derive(CandidType, Deserialize, Serialize, Debug, Default, Clone, PartialEq, Eq, Copy)]
 pub enum SubscriptionPlan {
     #[default]
     Free,


### PR DESCRIPTION
## changes
- bot account recieves parent subscriptions
- parent account keeps account of all subscription and credits and syncs up with bot account.

## Impact
- fixes: https://github.com/dolr-ai/product-roadmap/issues/1634