### PR TITLE
feat: add convert_to_bot_account method to user_info_service

### DIFF
--- a/src/canister/user_info_service/can.did
+++ b/src/canister/user_info_service/can.did
@@ -115,6 +115,7 @@ service : (UserInfoServiceInitArgs) -> {
   accept_new_user_registration_v2 : (principal, bool, opt principal) -> (
       Result,
     );
+  convert_to_bot_account : (principal, principal) -> (Result);
   add_pro_plan_free_video_credits : (principal, nat32) -> (Result);
   change_subscription_plan : (principal, SubscriptionPlan) -> (Result);
   delete_user_info : (principal) -> (Result);

--- a/src/canister/user_info_service/src/api/convert_to_bot_account.rs
+++ b/src/canister/user_info_service/src/api/convert_to_bot_account.rs
@@ -1,0 +1,12 @@
+use candid::Principal;
+use ic_cdk::update;
+use shared_utils::common::utils::permissions::is_caller_controller_or_global_admin;
+
+use crate::CANISTER_DATA;
+
+#[update(guard = "is_caller_controller_or_global_admin")]
+fn convert_to_bot_account(bot_principal: Principal, owner: Principal) -> Result<(), String> {
+    CANISTER_DATA.with_borrow_mut(|canister_data| {
+        canister_data.convert_to_bot_account(bot_principal, owner)
+    })
+}

--- a/src/canister/user_info_service/src/api/mod.rs
+++ b/src/canister/user_info_service/src/api/mod.rs
@@ -1,5 +1,6 @@
 mod accept_new_user_registration;
 mod canister_lifecycle;
+mod convert_to_bot_account;
 mod delete_user_info;
 mod follow_user;
 pub mod get_followers;

--- a/src/canister/user_info_service/src/data_model/mod.rs
+++ b/src/canister/user_info_service/src/data_model/mod.rs
@@ -660,6 +660,46 @@ impl CanisterData {
         Ok(())
     }
 
+    /// Admin-only method to convert an existing MainAccount into a BotAccount under an owner
+    pub fn convert_to_bot_account(
+        &mut self,
+        bot_principal: Principal,
+        owner: Principal,
+    ) -> Result<(), String> {
+        if bot_principal == owner {
+            return Err("Cannot convert owner to its own bot".to_string());
+        }
+
+        let mut bot_info = self
+            .user_infos
+            .get(&bot_principal)
+            .ok_or("Bot principal not found")?;
+
+        let mut owner_info = self
+            .user_infos
+            .get(&owner)
+            .ok_or("Owner not found")?;
+
+        match &mut owner_info.account_type {
+            UserAccountType::MainAccount { bots } => {
+                if bots.contains(&bot_principal) {
+                    return Err("Already a bot of this owner".to_string());
+                }
+                bots.push(bot_principal);
+            }
+            UserAccountType::BotAccount { .. } => {
+                return Err("Owner is a bot account, cannot own other bots".to_string());
+            }
+        }
+
+        bot_info.account_type = UserAccountType::BotAccount { owner };
+
+        self.user_infos.insert(owner, owner_info);
+        self.user_infos.insert(bot_principal, bot_info);
+
+        Ok(())
+    }
+
     /// Admin-only method to update AI influencer status for a user's profile
     pub fn update_profile_ai_influencer_status(
         &mut self,

--- a/src/canister/user_info_service/src/data_model/mod.rs
+++ b/src/canister/user_info_service/src/data_model/mod.rs
@@ -660,7 +660,9 @@ impl CanisterData {
         Ok(())
     }
 
-    /// Admin-only method to convert an existing MainAccount into a BotAccount under an owner
+    /// Admin-only method to convert an existing MainAccount into a BotAccount under an owner.
+    /// If the bot account has a Pro subscription, it is transferred to the owner and the bot's
+    /// subscription is reset to Free.
     pub fn convert_to_bot_account(
         &mut self,
         bot_principal: Principal,
@@ -690,6 +692,15 @@ impl CanisterData {
             UserAccountType::BotAccount { .. } => {
                 return Err("Owner is a bot account, cannot own other bots".to_string());
             }
+        }
+
+        // Transfer Pro subscription from bot to owner if bot has one
+        if let SubscriptionPlan::Pro(_) = bot_info.profile.subscription_plan {
+            // Only transfer if owner is on Free plan
+            if matches!(owner_info.profile.subscription_plan, SubscriptionPlan::Free) {
+                owner_info.profile.subscription_plan = bot_info.profile.subscription_plan;
+            }
+            bot_info.profile.subscription_plan = SubscriptionPlan::Free;
         }
 
         bot_info.account_type = UserAccountType::BotAccount { owner };

--- a/src/lib/integration_tests/tests/user_info_service/main.rs
+++ b/src/lib/integration_tests/tests/user_info_service/main.rs
@@ -1,5 +1,6 @@
 pub mod test_accept_new_user_registration_for_user_info_service;
 pub mod test_check_session_type_for_user_info_service;
+pub mod test_convert_to_bot_account;
 pub mod test_delete_user_for_user_info_service;
 pub mod test_follower_following_functionality;
 pub mod test_get_users_profile_details;

--- a/src/lib/integration_tests/tests/user_info_service/test_convert_to_bot_account.rs
+++ b/src/lib/integration_tests/tests/user_info_service/test_convert_to_bot_account.rs
@@ -1,0 +1,627 @@
+use pocket_ic::PocketIc;
+use shared_utils::canister_specific::individual_user_template::types::profile::{
+    UserAccountType, UserProfileDetailsForFrontendV5, UserProfileDetailsForFrontendV7,
+};
+use shared_utils::canister_specific::user_info_service::types::{
+    SubscriptionPlan, YralProSubscription,
+};
+use test_utils::canister_calls::{query, update};
+use test_utils::setup::env::pocket_ic_env::get_new_pocket_ic_env_with_service_canisters_provisioned;
+use test_utils::setup::test_constants::{
+    get_global_super_admin_principal_id, get_mock_user_alice_principal_id,
+    get_mock_user_bob_principal_id, get_mock_user_charlie_principal_id,
+    get_mock_user_dan_principal_id,
+};
+
+fn setup_test_user(
+    pocket_ic: &PocketIc,
+    user_service_canister: candid::Principal,
+    user_principal: candid::Principal,
+) {
+    let result = update::<_, Result<(), String>>(
+        pocket_ic,
+        user_service_canister,
+        user_principal,
+        "register_new_user",
+        (),
+    )
+    .expect("Failed to register new user");
+    assert!(result.is_ok(), "User registration failed: {:?}", result);
+}
+
+fn get_user_profile_v7(
+    pocket_ic: &PocketIc,
+    user_service_canister: candid::Principal,
+    caller: candid::Principal,
+    user_principal: candid::Principal,
+) -> UserProfileDetailsForFrontendV7 {
+    query::<_, Result<UserProfileDetailsForFrontendV7, String>>(
+        pocket_ic,
+        user_service_canister,
+        caller,
+        "get_user_profile_details_v7",
+        (user_principal,),
+    )
+    .unwrap()
+    .unwrap()
+}
+
+fn get_user_subscription_plan(
+    pocket_ic: &PocketIc,
+    user_service_canister: candid::Principal,
+    caller: candid::Principal,
+    user_principal: candid::Principal,
+) -> SubscriptionPlan {
+    let profile_details = query::<_, Result<UserProfileDetailsForFrontendV5, String>>(
+        pocket_ic,
+        user_service_canister,
+        caller,
+        "get_user_profile_details_v5",
+        (user_principal,),
+    )
+    .unwrap()
+    .unwrap();
+
+    profile_details.subscription_plan
+}
+
+// ============================================================================
+// Basic convert_to_bot_account tests
+// ============================================================================
+
+#[test]
+fn test_convert_main_account_to_bot_account() {
+    let (pocket_ic, service_canisters) =
+        get_new_pocket_ic_env_with_service_canisters_provisioned();
+    let user_service_canister = service_canisters.user_info_service_canister_id;
+    let admin_principal = get_global_super_admin_principal_id();
+    let owner_principal = get_mock_user_alice_principal_id();
+    let bot_principal = get_mock_user_bob_principal_id();
+
+    // Register both as regular users (MainAccount)
+    setup_test_user(&pocket_ic, user_service_canister, owner_principal);
+    setup_test_user(&pocket_ic, user_service_canister, bot_principal);
+
+    // Verify both are MainAccount before conversion
+    let owner_profile = get_user_profile_v7(
+        &pocket_ic,
+        user_service_canister,
+        admin_principal,
+        owner_principal,
+    );
+    assert!(
+        matches!(owner_profile.account_type, UserAccountType::MainAccount { bots } if bots.is_empty())
+    );
+
+    let bot_profile_before = get_user_profile_v7(
+        &pocket_ic,
+        user_service_canister,
+        admin_principal,
+        bot_principal,
+    );
+    assert!(
+        matches!(bot_profile_before.account_type, UserAccountType::MainAccount { bots } if bots.is_empty())
+    );
+
+    // Convert bot to bot account under owner
+    let result = update::<_, Result<(), String>>(
+        &pocket_ic,
+        user_service_canister,
+        admin_principal,
+        "convert_to_bot_account",
+        (bot_principal, owner_principal),
+    )
+    .expect("Failed to call convert_to_bot_account");
+    assert!(result.is_ok(), "Conversion failed: {:?}", result);
+
+    // Verify bot is now BotAccount
+    let bot_profile_after = get_user_profile_v7(
+        &pocket_ic,
+        user_service_canister,
+        admin_principal,
+        bot_principal,
+    );
+    match bot_profile_after.account_type {
+        UserAccountType::BotAccount { owner } => {
+            assert_eq!(owner, owner_principal);
+        }
+        _ => panic!(
+            "Expected BotAccount, got: {:?}",
+            bot_profile_after.account_type
+        ),
+    }
+
+    // Verify owner's bots list contains the bot
+    let owner_profile_after = get_user_profile_v7(
+        &pocket_ic,
+        user_service_canister,
+        admin_principal,
+        owner_principal,
+    );
+    match owner_profile_after.account_type {
+        UserAccountType::MainAccount { bots } => {
+            assert_eq!(bots.len(), 1);
+            assert!(bots.contains(&bot_principal));
+        }
+        _ => panic!(
+            "Expected MainAccount, got: {:?}",
+            owner_profile_after.account_type
+        ),
+    }
+}
+
+#[test]
+fn test_convert_to_bot_account_fails_for_self() {
+    let (pocket_ic, service_canisters) =
+        get_new_pocket_ic_env_with_service_canisters_provisioned();
+    let user_service_canister = service_canisters.user_info_service_canister_id;
+    let admin_principal = get_global_super_admin_principal_id();
+    let user_principal = get_mock_user_alice_principal_id();
+
+    setup_test_user(&pocket_ic, user_service_canister, user_principal);
+
+    let result = update::<_, Result<(), String>>(
+        &pocket_ic,
+        user_service_canister,
+        admin_principal,
+        "convert_to_bot_account",
+        (user_principal, user_principal),
+    )
+    .expect("Failed to call convert_to_bot_account");
+
+    assert!(result.is_err());
+    assert_eq!(result.unwrap_err(), "Cannot convert owner to its own bot");
+}
+
+#[test]
+fn test_convert_to_bot_account_fails_when_owner_is_bot() {
+    let (pocket_ic, service_canisters) =
+        get_new_pocket_ic_env_with_service_canisters_provisioned();
+    let user_service_canister = service_canisters.user_info_service_canister_id;
+    let admin_principal = get_global_super_admin_principal_id();
+    let owner_principal = get_mock_user_alice_principal_id();
+    let bot1_principal = get_mock_user_bob_principal_id();
+    let bot2_principal = get_mock_user_charlie_principal_id();
+
+    setup_test_user(&pocket_ic, user_service_canister, owner_principal);
+    setup_test_user(&pocket_ic, user_service_canister, bot1_principal);
+    setup_test_user(&pocket_ic, user_service_canister, bot2_principal);
+
+    // Convert bot1 to bot under owner
+    let _ = update::<_, Result<(), String>>(
+        &pocket_ic,
+        user_service_canister,
+        admin_principal,
+        "convert_to_bot_account",
+        (bot1_principal, owner_principal),
+    )
+    .expect("Failed to convert bot1");
+
+    // Try to convert bot2 under bot1 (should fail)
+    let result = update::<_, Result<(), String>>(
+        &pocket_ic,
+        user_service_canister,
+        admin_principal,
+        "convert_to_bot_account",
+        (bot2_principal, bot1_principal),
+    )
+    .expect("Failed to call convert_to_bot_account");
+
+    assert!(result.is_err());
+    assert_eq!(
+        result.unwrap_err(),
+        "Owner is a bot account, cannot own other bots"
+    );
+}
+
+#[test]
+fn test_convert_to_bot_account_fails_when_already_bot_of_owner() {
+    let (pocket_ic, service_canisters) =
+        get_new_pocket_ic_env_with_service_canisters_provisioned();
+    let user_service_canister = service_canisters.user_info_service_canister_id;
+    let admin_principal = get_global_super_admin_principal_id();
+    let owner_principal = get_mock_user_alice_principal_id();
+    let bot_principal = get_mock_user_bob_principal_id();
+
+    setup_test_user(&pocket_ic, user_service_canister, owner_principal);
+    setup_test_user(&pocket_ic, user_service_canister, bot_principal);
+
+    // Convert once
+    let _ = update::<_, Result<(), String>>(
+        &pocket_ic,
+        user_service_canister,
+        admin_principal,
+        "convert_to_bot_account",
+        (bot_principal, owner_principal),
+    )
+    .expect("Failed to convert bot");
+
+    // Try to convert again (should fail)
+    let result = update::<_, Result<(), String>>(
+        &pocket_ic,
+        user_service_canister,
+        admin_principal,
+        "convert_to_bot_account",
+        (bot_principal, owner_principal),
+    )
+    .expect("Failed to call convert_to_bot_account");
+
+    assert!(result.is_err());
+    assert_eq!(result.unwrap_err(), "Already a bot of this owner");
+}
+
+#[test]
+fn test_convert_to_bot_account_fails_for_non_existent_bot() {
+    let (pocket_ic, service_canisters) =
+        get_new_pocket_ic_env_with_service_canisters_provisioned();
+    let user_service_canister = service_canisters.user_info_service_canister_id;
+    let admin_principal = get_global_super_admin_principal_id();
+    let owner_principal = get_mock_user_alice_principal_id();
+    let non_existent = get_mock_user_dan_principal_id();
+
+    setup_test_user(&pocket_ic, user_service_canister, owner_principal);
+
+    let result = update::<_, Result<(), String>>(
+        &pocket_ic,
+        user_service_canister,
+        admin_principal,
+        "convert_to_bot_account",
+        (non_existent, owner_principal),
+    )
+    .expect("Failed to call convert_to_bot_account");
+
+    assert!(result.is_err());
+    assert_eq!(result.unwrap_err(), "Bot principal not found");
+}
+
+#[test]
+fn test_convert_to_bot_account_fails_for_non_existent_owner() {
+    let (pocket_ic, service_canisters) =
+        get_new_pocket_ic_env_with_service_canisters_provisioned();
+    let user_service_canister = service_canisters.user_info_service_canister_id;
+    let admin_principal = get_global_super_admin_principal_id();
+    let bot_principal = get_mock_user_alice_principal_id();
+    let non_existent = get_mock_user_dan_principal_id();
+
+    setup_test_user(&pocket_ic, user_service_canister, bot_principal);
+
+    let result = update::<_, Result<(), String>>(
+        &pocket_ic,
+        user_service_canister,
+        admin_principal,
+        "convert_to_bot_account",
+        (bot_principal, non_existent),
+    )
+    .expect("Failed to call convert_to_bot_account");
+
+    assert!(result.is_err());
+    assert_eq!(result.unwrap_err(), "Owner not found");
+}
+
+#[test]
+fn test_convert_multiple_bots_to_same_owner() {
+    let (pocket_ic, service_canisters) =
+        get_new_pocket_ic_env_with_service_canisters_provisioned();
+    let user_service_canister = service_canisters.user_info_service_canister_id;
+    let admin_principal = get_global_super_admin_principal_id();
+    let owner_principal = get_mock_user_alice_principal_id();
+    let bot1_principal = get_mock_user_bob_principal_id();
+    let bot2_principal = get_mock_user_charlie_principal_id();
+
+    setup_test_user(&pocket_ic, user_service_canister, owner_principal);
+    setup_test_user(&pocket_ic, user_service_canister, bot1_principal);
+    setup_test_user(&pocket_ic, user_service_canister, bot2_principal);
+
+    // Convert both bots
+    let result1 = update::<_, Result<(), String>>(
+        &pocket_ic,
+        user_service_canister,
+        admin_principal,
+        "convert_to_bot_account",
+        (bot1_principal, owner_principal),
+    )
+    .expect("Failed to convert bot1");
+    assert!(result1.is_ok());
+
+    let result2 = update::<_, Result<(), String>>(
+        &pocket_ic,
+        user_service_canister,
+        admin_principal,
+        "convert_to_bot_account",
+        (bot2_principal, owner_principal),
+    )
+    .expect("Failed to convert bot2");
+    assert!(result2.is_ok());
+
+    // Verify owner has both bots
+    let owner_profile = get_user_profile_v7(
+        &pocket_ic,
+        user_service_canister,
+        admin_principal,
+        owner_principal,
+    );
+    match owner_profile.account_type {
+        UserAccountType::MainAccount { bots } => {
+            assert_eq!(bots.len(), 2);
+            assert!(bots.contains(&bot1_principal));
+            assert!(bots.contains(&bot2_principal));
+        }
+        _ => panic!("Expected MainAccount"),
+    }
+}
+
+#[test]
+fn test_convert_to_bot_account_rejects_non_admin_caller() {
+    let (pocket_ic, service_canisters) =
+        get_new_pocket_ic_env_with_service_canisters_provisioned();
+    let user_service_canister = service_canisters.user_info_service_canister_id;
+    let owner_principal = get_mock_user_alice_principal_id();
+    let bot_principal = get_mock_user_bob_principal_id();
+    let non_admin = get_mock_user_charlie_principal_id();
+
+    setup_test_user(&pocket_ic, user_service_canister, owner_principal);
+    setup_test_user(&pocket_ic, user_service_canister, bot_principal);
+
+    // Non-admin caller should be rejected (canister will trap)
+    let result = update::<_, Result<(), String>>(
+        &pocket_ic,
+        user_service_canister,
+        non_admin,
+        "convert_to_bot_account",
+        (bot_principal, owner_principal),
+    );
+
+    assert!(result.is_err(), "Non-admin should not be able to call convert_to_bot_account");
+}
+
+// ============================================================================
+// Pro subscription transfer tests
+// ============================================================================
+
+#[test]
+fn test_convert_bot_with_pro_subscription_transfers_to_owner() {
+    let (pocket_ic, service_canisters) =
+        get_new_pocket_ic_env_with_service_canisters_provisioned();
+    let user_service_canister = service_canisters.user_info_service_canister_id;
+    let admin_principal = get_global_super_admin_principal_id();
+    let owner_principal = get_mock_user_alice_principal_id();
+    let bot_principal = get_mock_user_bob_principal_id();
+
+    setup_test_user(&pocket_ic, user_service_canister, owner_principal);
+    setup_test_user(&pocket_ic, user_service_canister, bot_principal);
+
+    // Give bot a Pro subscription before conversion
+    let pro_plan = SubscriptionPlan::Pro(YralProSubscription {
+        free_video_credits_left: 50,
+        total_video_credits_alloted: 50,
+    });
+
+    let _ = update::<_, Result<(), String>>(
+        &pocket_ic,
+        user_service_canister,
+        admin_principal,
+        "change_subscription_plan",
+        (bot_principal, pro_plan),
+    )
+    .expect("Failed to set bot Pro plan");
+
+    // Verify bot has Pro and owner has Free before conversion
+    let bot_plan_before = get_user_subscription_plan(
+        &pocket_ic,
+        user_service_canister,
+        bot_principal,
+        bot_principal,
+    );
+    assert!(matches!(bot_plan_before, SubscriptionPlan::Pro(_)));
+
+    let owner_plan_before = get_user_subscription_plan(
+        &pocket_ic,
+        user_service_canister,
+        owner_principal,
+        owner_principal,
+    );
+    assert!(matches!(owner_plan_before, SubscriptionPlan::Free));
+
+    // Convert bot to bot account
+    let result = update::<_, Result<(), String>>(
+        &pocket_ic,
+        user_service_canister,
+        admin_principal,
+        "convert_to_bot_account",
+        (bot_principal, owner_principal),
+    )
+    .expect("Failed to convert bot");
+    assert!(result.is_ok(), "Conversion failed: {:?}", result);
+
+    // Verify Pro subscription was transferred to owner
+    let owner_plan_after = get_user_subscription_plan(
+        &pocket_ic,
+        user_service_canister,
+        owner_principal,
+        owner_principal,
+    );
+    match owner_plan_after {
+        SubscriptionPlan::Pro(pro_sub) => {
+            assert_eq!(pro_sub.free_video_credits_left, 50);
+            assert_eq!(pro_sub.total_video_credits_alloted, 50);
+        }
+        _ => panic!("Expected owner to have Pro plan after conversion"),
+    }
+
+    // Verify bot's own subscription was reset to Free
+    // (bot now inherits from owner via get_effective_subscription_plan)
+    let bot_plan_after = get_user_subscription_plan(
+        &pocket_ic,
+        user_service_canister,
+        bot_principal,
+        bot_principal,
+    );
+    // Bot should see the owner's Pro plan through inheritance
+    match bot_plan_after {
+        SubscriptionPlan::Pro(pro_sub) => {
+            assert_eq!(pro_sub.free_video_credits_left, 50);
+            assert_eq!(pro_sub.total_video_credits_alloted, 50);
+        }
+        _ => panic!("Expected bot to inherit Pro plan from owner"),
+    }
+}
+
+#[test]
+fn test_convert_bot_with_pro_does_not_overwrite_owner_pro() {
+    let (pocket_ic, service_canisters) =
+        get_new_pocket_ic_env_with_service_canisters_provisioned();
+    let user_service_canister = service_canisters.user_info_service_canister_id;
+    let admin_principal = get_global_super_admin_principal_id();
+    let owner_principal = get_mock_user_alice_principal_id();
+    let bot_principal = get_mock_user_bob_principal_id();
+
+    setup_test_user(&pocket_ic, user_service_canister, owner_principal);
+    setup_test_user(&pocket_ic, user_service_canister, bot_principal);
+
+    // Give owner a Pro subscription
+    let owner_pro_plan = SubscriptionPlan::Pro(YralProSubscription {
+        free_video_credits_left: 100,
+        total_video_credits_alloted: 100,
+    });
+    let _ = update::<_, Result<(), String>>(
+        &pocket_ic,
+        user_service_canister,
+        admin_principal,
+        "change_subscription_plan",
+        (owner_principal, owner_pro_plan),
+    )
+    .expect("Failed to set owner Pro plan");
+
+    // Give bot a different Pro subscription
+    let bot_pro_plan = SubscriptionPlan::Pro(YralProSubscription {
+        free_video_credits_left: 30,
+        total_video_credits_alloted: 30,
+    });
+    let _ = update::<_, Result<(), String>>(
+        &pocket_ic,
+        user_service_canister,
+        admin_principal,
+        "change_subscription_plan",
+        (bot_principal, bot_pro_plan),
+    )
+    .expect("Failed to set bot Pro plan");
+
+    // Convert bot to bot account
+    let result = update::<_, Result<(), String>>(
+        &pocket_ic,
+        user_service_canister,
+        admin_principal,
+        "convert_to_bot_account",
+        (bot_principal, owner_principal),
+    )
+    .expect("Failed to convert bot");
+    assert!(result.is_ok());
+
+    // Verify owner's Pro plan was NOT overwritten (kept the original 100 credits)
+    let owner_plan_after = get_user_subscription_plan(
+        &pocket_ic,
+        user_service_canister,
+        owner_principal,
+        owner_principal,
+    );
+    match owner_plan_after {
+        SubscriptionPlan::Pro(pro_sub) => {
+            assert_eq!(pro_sub.free_video_credits_left, 100);
+            assert_eq!(pro_sub.total_video_credits_alloted, 100);
+        }
+        _ => panic!("Expected owner to keep original Pro plan"),
+    }
+}
+
+#[test]
+fn test_convert_bot_with_free_plan_no_subscription_change() {
+    let (pocket_ic, service_canisters) =
+        get_new_pocket_ic_env_with_service_canisters_provisioned();
+    let user_service_canister = service_canisters.user_info_service_canister_id;
+    let admin_principal = get_global_super_admin_principal_id();
+    let owner_principal = get_mock_user_alice_principal_id();
+    let bot_principal = get_mock_user_bob_principal_id();
+
+    setup_test_user(&pocket_ic, user_service_canister, owner_principal);
+    setup_test_user(&pocket_ic, user_service_canister, bot_principal);
+
+    // Both start with Free plan (default)
+    let result = update::<_, Result<(), String>>(
+        &pocket_ic,
+        user_service_canister,
+        admin_principal,
+        "convert_to_bot_account",
+        (bot_principal, owner_principal),
+    )
+    .expect("Failed to convert bot");
+    assert!(result.is_ok());
+
+    // Verify both remain on Free plan
+    let owner_plan = get_user_subscription_plan(
+        &pocket_ic,
+        user_service_canister,
+        owner_principal,
+        owner_principal,
+    );
+    assert!(matches!(owner_plan, SubscriptionPlan::Free));
+
+    let bot_plan = get_user_subscription_plan(
+        &pocket_ic,
+        user_service_canister,
+        bot_principal,
+        bot_principal,
+    );
+    assert!(matches!(bot_plan, SubscriptionPlan::Free));
+}
+
+#[test]
+fn test_converted_bot_inherits_owner_subscription_after_conversion() {
+    let (pocket_ic, service_canisters) =
+        get_new_pocket_ic_env_with_service_canisters_provisioned();
+    let user_service_canister = service_canisters.user_info_service_canister_id;
+    let admin_principal = get_global_super_admin_principal_id();
+    let owner_principal = get_mock_user_alice_principal_id();
+    let bot_principal = get_mock_user_bob_principal_id();
+
+    setup_test_user(&pocket_ic, user_service_canister, owner_principal);
+    setup_test_user(&pocket_ic, user_service_canister, bot_principal);
+
+    // Convert bot first (both on Free plan)
+    let _ = update::<_, Result<(), String>>(
+        &pocket_ic,
+        user_service_canister,
+        admin_principal,
+        "convert_to_bot_account",
+        (bot_principal, owner_principal),
+    )
+    .expect("Failed to convert bot");
+
+    // Now upgrade owner to Pro
+    let pro_plan = SubscriptionPlan::Pro(YralProSubscription {
+        free_video_credits_left: 75,
+        total_video_credits_alloted: 75,
+    });
+    let _ = update::<_, Result<(), String>>(
+        &pocket_ic,
+        user_service_canister,
+        admin_principal,
+        "change_subscription_plan",
+        (owner_principal, pro_plan),
+    )
+    .expect("Failed to upgrade owner");
+
+    // Verify bot inherits owner's Pro plan
+    let bot_plan = get_user_subscription_plan(
+        &pocket_ic,
+        user_service_canister,
+        bot_principal,
+        bot_principal,
+    );
+    match bot_plan {
+        SubscriptionPlan::Pro(pro_sub) => {
+            assert_eq!(pro_sub.free_video_credits_left, 75);
+            assert_eq!(pro_sub.total_video_credits_alloted, 75);
+        }
+        _ => panic!("Expected bot to inherit owner's Pro plan"),
+    }
+}


### PR DESCRIPTION
Add admin-only method to convert an existing MainAccount into a BotAccount under a specified owner. This is needed for linking company-created AI influencer bots to their parent accounts.



#### To check the status of the deployment

- check if the platform orchestrator performed the step to upgrade subnet canister with appropriate version: [Platform Orchestrator function](https://dashboard.internetcomputer.org/canister/74zq4-iqaaa-aaaam-ab53a-cai#get_subnet_last_upgrade_status)
- check the status of upgrade for individual canisters in subnet orchestrators and verify the version. Example for one of the subnet orchesrator: [Subnet Orchestrator function](https://dashboard.internetcomputer.org/canister/rimrc-piaaa-aaaao-aaljq-cai#get_index_details_last_upgrade_status)

To test the platform orchestrator, you can use the following command:

`dfx canister call --query 74zq4-iqaaa-aaaam-ab53a-cai get_subnet_last_upgrade_status --network=ic`
 the canister id (74zq4-iqaaa-aaaam-ab53a-cai) is taken from the canister_ids.json file